### PR TITLE
feat: archive excel reports for variance auditing

### DIFF
--- a/AUDIT_README.md
+++ b/AUDIT_README.md
@@ -9,6 +9,7 @@ The Billing Report Audit System tracks changes to critical billing columns (`Qua
 - **Change Tracking**: Monitors `Quantity` and `Redlined Total Price` columns for any modifications
 - **Who, What, When**: Records the user, timestamp, and exact values for each change
 - **Delta Calculation**: Shows the difference between old and new values
+- **Variance Auditing**: Archives each generated Excel report and logs column-level differences
 - **Automated Integration**: Runs as part of your existing Excel generation process
 - **Deduplication**: Efficiently handles multiple references to the same source row
 - **First Run Support**: On initial run, compares the last two revisions if available


### PR DESCRIPTION
## Summary
- create an archive folder for generated Excel reports
- add `archive_and_compare_excel` to log column deltas to the Smartsheet audit sheet
- hook the weekly Excel workflow to archive each workbook for comparison
- document variance auditing in `AUDIT_README.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a51b9508dc8326b6ad808a2a4e298f