### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/weekly-excel-generation.yml
+++ b/.github/workflows/weekly-excel-generation.yml
@@ -1,5 +1,8 @@
 name: AI-Powered Excel Generation & Advanced Billing Audit System
 
+permissions:
+  contents: read
+
 on:
   schedule:
     # Run every 2 hours, every day to check for data updates and audit changes


### PR DESCRIPTION
Potential fix for [https://github.com/JFlo21/Generate-Weekly-PDFs-DSR-Resiliency/security/code-scanning/1](https://github.com/JFlo21/Generate-Weekly-PDFs-DSR-Resiliency/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly limit the permissions of the GITHUB_TOKEN. The best way is to add the block at the root level of the workflow (above `jobs:`), so it applies to all jobs unless overridden. For this workflow, the minimal required permission is likely `contents: read`, since the workflow checks out code and uploads artifacts but does not push changes or interact with issues or pull requests. If any job needs additional permissions (e.g., to create issues or pull requests), those can be added at the job level, but for now, `contents: read` is the safest default.

Edit the file `.github/workflows/weekly-excel-generation.yml` by inserting the following block after the workflow name and before `on:`:

```yaml
permissions:
  contents: read
```

No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
