### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/weekly-excel-generation.yml
+++ b/.github/workflows/weekly-excel-generation.yml
@@ -1,5 +1,8 @@
 name: Comprehensive Excel Generation with Enhanced Sentry Monitoring (Every 2 Hours + Weekly)
 
+permissions:
+  contents: read
+
 on:
   schedule:
     # Production billing system - Run every 2 hours during business hours (Monday-Friday)


### PR DESCRIPTION
Potential fix for [https://github.com/JFlo21/Generate-Weekly-PDFs-DSR-Resiliency/security/code-scanning/8](https://github.com/JFlo21/Generate-Weekly-PDFs-DSR-Resiliency/security/code-scanning/8)

To fix the problem, add a `permissions` block to the root of the workflow YAML file (above `jobs:`) specifying the minimum necessary permissions. For most CI/CD workflows that only need read access to repository contents (e.g., code checkout, artifact upload but no modifications to the repository itself), the minimal required permission is `contents: read`. If the workflow later needs to write to pull requests (e.g., comments), those should be enabled, but based on the current steps, only read access to contents appears necessary.

Specifically:
- Edit `.github/workflows/weekly-excel-generation.yml`.
- After the workflow `name:` and before or after `on:`, add this block:
  ```yaml
  permissions:
    contents: read
  ```
- No imports or extra definitions are needed.
- If finer-grained access becomes necessary in future (e.g., issues, pull-requests), add those types as needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
