### PR TITLE
Add date-based rate contract versioning for 2026 pricing

### DIFF
--- a/.github/instructions/subcontractor-pricing-folder-discovery.instructions.md
+++ b/.github/instructions/subcontractor-pricing-folder-discovery.instructions.md
@@ -22,11 +22,11 @@ Excel generated with subcontractor's reduced 10% pricing as-is
 
 ## Critical Constraints
 
-### No Price Reversion
-- Subcontractor sheets keep their reduced 10% pricing as-is
+### Subcontractor Pricing Behavior
+- **When `RATE_CUTOFF_DATE` is NOT set (default):** Subcontractor sheets keep their reduced 10% pricing as-is — no price changes are performed. SmartSheet `Units Total Price` flows through unchanged.
+- **When `RATE_CUTOFF_DATE` IS set:** Post-cutoff rows on subcontractor sheets get prices recalculated using new contract rates × 0.90 (Arrowhead discount). Pre-cutoff rows still keep SmartSheet pricing as-is.
 - `revert_subcontractor_price()` exists in the codebase but is **not called** during row processing
-- The CSV rate files (`CU List - Corpus North & South.csv`, `CU List Contract - Arrowhead Contract.csv`) are reference documentation only
-- `load_contract_rates()` still loads on startup but the rates are not used for price modification
+- The `__is_subcontractor` flag on each row determines whether primary or Arrowhead (discounted) rate tables are used for recalculation
 
 ### Folder-Based Discovery Over Individual Sheet IDs
 - Subcontractor sheets live in stable Smartsheet folders that never change location

--- a/.github/instructions/subcontractor-pricing-folder-discovery.instructions.md
+++ b/.github/instructions/subcontractor-pricing-folder-discovery.instructions.md
@@ -23,10 +23,11 @@ Excel generated with subcontractor's reduced 10% pricing as-is
 ## Critical Constraints
 
 ### Subcontractor Pricing Behavior
-- **When `RATE_CUTOFF_DATE` is NOT set (default):** Subcontractor sheets keep their reduced 10% pricing as-is — no price changes are performed. SmartSheet `Units Total Price` flows through unchanged.
-- **When `RATE_CUTOFF_DATE` IS set:** Post-cutoff rows on subcontractor sheets get prices recalculated using new contract rates × 0.90 (Arrowhead discount). Pre-cutoff rows still keep SmartSheet pricing as-is.
+- Subcontractor (Arrowhead) sheets **always keep their SmartSheet pricing as-is** — no rate recalculation is performed, regardless of whether `RATE_CUTOFF_DATE` is set
+- Rate recalculation only applies to primary (non-subcontractor) sheets
+- Subcontractor new rates will be enabled separately in a future update when a subcontractor cutoff date is provided
+- The Arrowhead rate tables (`_rate_new_arrowhead`) are precomputed and ready for when subcontractor recalculation is enabled
 - `revert_subcontractor_price()` exists in the codebase but is **not called** during row processing
-- The `__is_subcontractor` flag on each row determines whether primary or Arrowhead (discounted) rate tables are used for recalculation
 
 ### Folder-Based Discovery Over Individual Sheet IDs
 - Subcontractor sheets live in stable Smartsheet folders that never change location

--- a/.github/workflows/weekly-excel-generation.yml
+++ b/.github/workflows/weekly-excel-generation.yml
@@ -220,6 +220,12 @@ jobs:
           # Helper/Resiliency Grouping Mode
           RES_GROUPING_MODE: ${{ github.event.inputs.res_grouping_mode || 'both' }}
           
+          # Rate Contract Versioning (set via repo Variables in Settings > Secrets and variables > Actions)
+          # RATE_CUTOFF_DATE: YYYY-MM-DD date when new rates take effect (empty = disabled)
+          RATE_CUTOFF_DATE: ${{ vars.RATE_CUTOFF_DATE || '' }}
+          NEW_RATES_CSV: ${{ vars.NEW_RATES_CSV || '' }}
+          OLD_RATES_CSV: ${{ vars.OLD_RATES_CSV || '' }}
+
           # Advanced Filters
           WR_FILTER: ${{ github.event.inputs.wr_filter || '' }}
           # EXCLUDE_WRS: Manual input overrides repo variable; repo variable is persistent default

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -645,12 +645,16 @@ def recalculate_row_price(row_data, cu_to_group, rates_dict):
     elif 'tran' in work_type_raw or 'xfr' in work_type_raw:
         wt_key = 'transfer'
 
-    # Parse quantity
-    qty_str = str(row_data.get('Quantity', '') or '0')
+    # Parse quantity — if missing or unparseable, keep SmartSheet price
+    qty_str = str(row_data.get('Quantity', '') or '')
     try:
         qty = float(_RE_EXTRACT_NUMBERS.sub('', qty_str) or 0)
     except ValueError:
         qty = 0.0
+
+    if qty <= 0:
+        logging.debug(f"Rate recalculation: quantity '{qty_str}' is zero/missing for CU '{cu_code}', keeping SmartSheet price")
+        return price_val
 
     rate = rates_dict[group_code].get(wt_key, 0.0)
     new_price = round(rate * qty, 2)

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -220,9 +220,19 @@ except ValueError:
     logging.error(f"Invalid RATE_CUTOFF_DATE format: '{_cutoff_str}', expected YYYY-MM-DD. Rate versioning disabled.")
     RATE_CUTOFF_DATE = None
 ARROWHEAD_DISCOUNT = 0.90  # 10% reduction for subcontractors (Arrowhead)
-# Sanitize CSV paths: only allow basenames (no directory traversal)
-NEW_RATES_CSV = os.path.basename(os.getenv('NEW_RATES_CSV', 'New Contract Rates copy regenerated again.csv'))
-OLD_RATES_CSV = os.path.basename(os.getenv('OLD_RATES_CSV', 'CU List - Corpus North & South.csv'))
+
+def _sanitize_csv_path(env_var, default, label):
+    """Validate a CSV path from env var, preventing directory traversal."""
+    raw = os.getenv(env_var, default)
+    resolved = os.path.normpath(os.path.abspath(raw))
+    cwd = os.path.normpath(os.path.abspath('.'))
+    if not resolved.startswith(cwd + os.sep) and resolved != cwd:
+        logging.warning(f"⚠️ {env_var} resolves outside working directory: '{raw}'. Using default: '{default}'")
+        return default
+    return raw
+
+NEW_RATES_CSV = _sanitize_csv_path('NEW_RATES_CSV', 'New Contract Rates copy regenerated again.csv', 'new rates')
+OLD_RATES_CSV = _sanitize_csv_path('OLD_RATES_CSV', 'CU List - Corpus North & South.csv', 'old rates')
 
 _RATES_FINGERPRINT = ''  # Populated at runtime by load_rate_versions()
 

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -222,10 +222,10 @@ except ValueError:
 ARROWHEAD_DISCOUNT = 0.90  # 10% reduction for subcontractors (Arrowhead)
 
 def _sanitize_csv_path(env_var, default):
-    """Validate a CSV path from env var, preventing directory traversal."""
+    """Validate a CSV path from env var, preventing directory traversal and symlink escapes."""
     raw = os.getenv(env_var, default)
-    resolved = os.path.normpath(os.path.abspath(raw))
-    cwd = os.path.normpath(os.path.abspath('.'))
+    resolved = os.path.normpath(os.path.realpath(raw))
+    cwd = os.path.normpath(os.path.realpath('.'))
     if not resolved.startswith(cwd + os.sep) and resolved != cwd:
         logging.warning(f"⚠️ {env_var} resolves outside working directory: '{raw}'. Using default: '{default}'")
         return default
@@ -1728,7 +1728,7 @@ def get_all_source_rows(client, source_sheets):
     """
     merged_rows = []
     global_row_counter = 0
-    original_rates = load_contract_rates('CU List - Corpus North & South.csv')
+    original_rates = load_contract_rates(OLD_RATES_CSV)
     # Load new rate versions if rate cutoff is configured
     global _RATES_FINGERPRINT
     _rate_cu_to_group = {}

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -1880,30 +1880,32 @@ def get_all_source_rows(client, source_sheets):
                         price_val = parse_price(price_raw)
 
                         # --- SUBCONTRACTOR PRICING ---
-                        # When RATE_CUTOFF_DATE is NOT set: subcontractor sheets keep
-                        # their SmartSheet pricing as-is (reduced 10% rates from upstream).
-                        # When RATE_CUTOFF_DATE IS set: post-cutoff rows get prices
-                        # recalculated from new rate tables (subcontractors at new_rate × 0.90).
+                        # Subcontractor (Arrowhead) sheets always keep their SmartSheet
+                        # pricing as-is. Rate recalculation only applies to primary
+                        # (non-subcontractor) sheets. Subcontractor new rates will be
+                        # enabled separately when a subcontractor cutoff date is provided.
                         # --- END SUBCONTRACTOR PRICING ---
 
                         # Pre-acceptance rate recalculation: for cutoff-eligible rows,
                         # recalculate price BEFORE the has_price check so rows with
                         # zero/blank SmartSheet prices can still be accepted if the
                         # new rate produces a valid non-zero amount.
-                        if RATE_CUTOFF_DATE and _rate_new_primary:
+                        # NOTE: Subcontractor (Arrowhead) sheets are EXCLUDED from
+                        # recalculation until a separate subcontractor cutoff date is
+                        # provided. They keep SmartSheet pricing as-is for now.
+                        if RATE_CUTOFF_DATE and _rate_new_primary and not is_subcontractor_sheet:
                             snapshot_raw_pre = row_data.get('Snapshot Date')
                             if snapshot_raw_pre:
                                 snap_dt_pre = excel_serial_to_date(snapshot_raw_pre)
                                 if snap_dt_pre:
                                     snap_date_pre = snap_dt_pre.date() if hasattr(snap_dt_pre, 'date') else snap_dt_pre
                                     if snap_date_pre >= RATE_CUTOFF_DATE:
-                                        target_rates = _rate_new_arrowhead if is_subcontractor_sheet else _rate_new_primary
                                         old_price = price_val
-                                        price_val = recalculate_row_price(row_data, _rate_cu_to_group, target_rates)
+                                        price_val = recalculate_row_price(row_data, _rate_cu_to_group, _rate_new_primary)
                                         if price_val != old_price:
                                             logging.debug(f"Rate recalc: CU={row_data.get('CU')}, "
                                                           f"old=${old_price:.2f} -> new=${price_val:.2f}, "
-                                                          f"sub={is_subcontractor_sheet}, date={snap_date_pre}")
+                                                          f"date={snap_date_pre}")
 
                         price_raw = row_data.get('Units Total Price')
                         has_price = (price_raw not in (None, "", "$0", "$0.00", "0", "0.0")) and price_val > 0

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -596,12 +596,16 @@ def load_rate_versions():
             'transfer': round(rates['transfer'] * ARROWHEAD_DISCOUNT, 2),
         }
 
-    rates_fingerprint = _compute_rates_fingerprint(new_rates_primary)
+    # Only compute fingerprint if rates were successfully loaded
+    rates_fingerprint = _compute_rates_fingerprint(new_rates_primary) if new_rates_primary else ''
 
-    logging.info(f"Rate versions loaded: {len(new_rates_primary)} primary groups, "
-                 f"{len(new_rates_arrowhead)} Arrowhead groups, "
-                 f"{len(cu_to_group)} CU-to-group mappings, "
-                 f"fingerprint={rates_fingerprint}")
+    if not new_rates_primary:
+        logging.warning("⚠️ New rate table is empty — rate recalculation will be skipped even though RATE_CUTOFF_DATE is set")
+    else:
+        logging.info(f"Rate versions loaded: {len(new_rates_primary)} primary groups, "
+                     f"{len(new_rates_arrowhead)} Arrowhead groups (precomputed, not yet active), "
+                     f"{len(cu_to_group)} CU-to-group mappings, "
+                     f"fingerprint={rates_fingerprint}")
     return cu_to_group, new_rates_primary, new_rates_arrowhead, rates_fingerprint
 
 

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -206,6 +206,24 @@ ORIGINAL_CONTRACT_FOLDER_IDS = _parse_sheet_ids(os.getenv('ORIGINAL_CONTRACT_FOL
 _FOLDER_DISCOVERED_SUB_IDS: set[int] = set()
 _FOLDER_DISCOVERED_ORIG_IDS: set[int] = set()
 
+# --- RATE CONTRACT VERSIONING ---
+# Set RATE_CUTOFF_DATE (YYYY-MM-DD) to activate new rate recalculation.
+# When set, rows with Snapshot Date >= cutoff get prices recalculated from new rate tables.
+# When unset (empty string), all rows keep their SmartSheet Units Total Price (current behavior).
+_cutoff_str = os.getenv('RATE_CUTOFF_DATE', '')
+RATE_CUTOFF_DATE = (
+    datetime.datetime.strptime(_cutoff_str, '%Y-%m-%d').date()
+    if _cutoff_str else None
+)
+ARROWHEAD_DISCOUNT = 0.90  # 10% reduction for subcontractors (Arrowhead)
+NEW_RATES_CSV = 'New Contract Rates copy regenerated again.csv'
+OLD_RATES_CSV = 'CU List - Corpus North & South.csv'
+
+if RATE_CUTOFF_DATE:
+    logging.info(f"📊 Rate contract versioning ENABLED: cutoff date = {RATE_CUTOFF_DATE.isoformat()}")
+else:
+    logging.info("📊 Rate contract versioning DISABLED (RATE_CUTOFF_DATE not set)")
+
 RESET_HASH_HISTORY = os.getenv('RESET_HASH_HISTORY','0').lower() in ('1','true','yes')  # When true, delete ALL existing WR_*.xlsx attachments & local files first
 RESET_WR_LIST = {w.strip() for w in os.getenv('RESET_WR_LIST','').split(',') if w.strip()}  # When provided, only purge these WR numbers (overrides full reset)
 _env_hist_path = os.getenv('HASH_HISTORY_PATH')
@@ -463,6 +481,152 @@ def load_contract_rates(filepath):
     except Exception as e:
         logging.error(f"Failed to load rates from {filepath}: {e}")
     return rates
+
+
+def load_new_contract_rates(filepath):
+    """Load new contract rates from the 2026 format CSV (group-level codes).
+
+    The new CSV has 3 metadata rows before data, with columns by position:
+    [0]=Group Code, [1]=Description, [2]=UOM, [3]=Category, [4]=Region,
+    [5]=Date, [6]=Install Price, [7]=Removal Price, [8]=Transfer Price.
+
+    Returns:
+        dict: {GROUP_CODE: {install: float, removal: float, transfer: float}}
+    """
+    rates = {}
+    try:
+        with open(filepath, mode='r', encoding='utf-8-sig') as f:
+            reader = csv.reader(f)
+            # Skip 3 metadata/header rows
+            for _ in range(3):
+                next(reader, None)
+            for row in reader:
+                if len(row) < 9:
+                    continue
+                group_code = row[0].strip().upper()
+                if not group_code:
+                    continue
+                rates[group_code] = {
+                    'install': parse_price(row[6]),
+                    'removal': parse_price(row[7]),
+                    'transfer': parse_price(row[8]),
+                }
+        logging.info(f"Loaded {len(rates)} group-level rates from {filepath}")
+    except Exception as e:
+        logging.error(f"Failed to load new contract rates from {filepath}: {e}")
+    return rates
+
+
+def build_cu_to_group_mapping(old_csv_path):
+    """Build a mapping from detailed CU codes to Compatible Unit Group codes.
+
+    Reads the old-format CSV which has both 'CU' (detailed code) and
+    'Compatible Unit Group' columns.
+
+    Returns:
+        dict: {DETAILED_CU_CODE: GROUP_CODE} e.g. {'ANC-DHM-10-84-D1': 'ANC-M'}
+    """
+    mapping = {}
+    try:
+        with open(old_csv_path, mode='r', encoding='utf-8-sig') as f:
+            reader = csv.DictReader(f)
+            if not reader.fieldnames or 'CU' not in reader.fieldnames or 'Compatible Unit Group' not in reader.fieldnames:
+                logging.error(f"CSV {old_csv_path} missing 'CU' or 'Compatible Unit Group' columns for mapping")
+                return mapping
+            for row in reader:
+                cu = str(row.get('CU', '')).strip().upper()
+                group = str(row.get('Compatible Unit Group', '')).strip().upper()
+                if cu and group:
+                    mapping[cu] = group
+        logging.info(f"Built CU-to-group mapping: {len(mapping)} CU codes -> groups")
+    except Exception as e:
+        logging.error(f"Failed to build CU-to-group mapping from {old_csv_path}: {e}")
+    return mapping
+
+
+def load_rate_versions():
+    """Load new rate versions and build all necessary lookup structures.
+
+    Returns:
+        tuple: (cu_to_group, new_rates_primary, new_rates_arrowhead)
+            - cu_to_group: {DETAILED_CU: GROUP_CODE}
+            - new_rates_primary: {GROUP_CODE: {install, removal, transfer}}
+            - new_rates_arrowhead: {GROUP_CODE: {install, removal, transfer}} (rates * 0.90)
+    """
+    cu_to_group = build_cu_to_group_mapping(OLD_RATES_CSV)
+    new_rates_primary = load_new_contract_rates(NEW_RATES_CSV)
+
+    # Precompute Arrowhead (subcontractor) rates: primary rate * ARROWHEAD_DISCOUNT
+    new_rates_arrowhead = {}
+    for group_code, rates in new_rates_primary.items():
+        new_rates_arrowhead[group_code] = {
+            'install': round(rates['install'] * ARROWHEAD_DISCOUNT, 2),
+            'removal': round(rates['removal'] * ARROWHEAD_DISCOUNT, 2),
+            'transfer': round(rates['transfer'] * ARROWHEAD_DISCOUNT, 2),
+        }
+
+    logging.info(f"Rate versions loaded: {len(new_rates_primary)} primary groups, "
+                 f"{len(new_rates_arrowhead)} Arrowhead groups, "
+                 f"{len(cu_to_group)} CU-to-group mappings")
+    return cu_to_group, new_rates_primary, new_rates_arrowhead
+
+
+def recalculate_row_price(row_data, cu_to_group, rates_dict):
+    """Recalculate a row's price using new contract rates.
+
+    Looks up the CU code, maps it to its Compatible Unit Group, then
+    calculates price as rate × quantity using the provided rates dict.
+    Modifies row_data['Units Total Price'] in-place if a matching rate is found.
+
+    Args:
+        row_data: Dict of row field values (modified in-place).
+        cu_to_group: Dict mapping detailed CU codes to group codes.
+        rates_dict: Dict mapping group codes to {install, removal, transfer} rates.
+
+    Returns:
+        float: The (possibly recalculated) price value.
+    """
+    price_val = parse_price(row_data.get('Units Total Price'))
+
+    # Resolve CU code (same chain as revert_subcontractor_price)
+    cu_code = str(row_data.get('CU Helper') or row_data.get('CU') or row_data.get('Billable Unit Code') or '').strip().upper()
+    if cu_code == 'NAN':
+        cu_code = str(row_data.get('CU') or '').strip().upper()
+
+    # Map detailed CU code to group code
+    group_code = cu_to_group.get(cu_code)
+    if not group_code:
+        # CU code not found in mapping — try direct group lookup (in case SmartSheet uses group codes)
+        if cu_code in rates_dict:
+            group_code = cu_code
+        else:
+            logging.debug(f"Rate recalculation: CU '{cu_code}' not found in CU-to-group mapping or rates, keeping SmartSheet price")
+            return price_val
+
+    if group_code not in rates_dict:
+        logging.debug(f"Rate recalculation: group '{group_code}' (from CU '{cu_code}') not found in new rates, keeping SmartSheet price")
+        return price_val
+
+    # Determine work type
+    work_type_raw = str(row_data.get('Work Type') or '').strip().lower()
+    wt_key = 'install'
+    if 'rem' in work_type_raw:
+        wt_key = 'removal'
+    elif 'tran' in work_type_raw or 'xfr' in work_type_raw:
+        wt_key = 'transfer'
+
+    # Parse quantity
+    qty_str = str(row_data.get('Quantity', '') or '0')
+    try:
+        qty = float(_RE_EXTRACT_NUMBERS.sub('', qty_str) or 0)
+    except ValueError:
+        qty = 0.0
+
+    rate = rates_dict[group_code].get(wt_key, 0.0)
+    new_price = round(rate * qty, 2)
+    row_data['Units Total Price'] = new_price
+    return new_price
+
 
 def revert_subcontractor_price(row_data, original_rates):
     """Revert a subcontractor row's price to the 100% original contract rate.
@@ -736,6 +900,8 @@ def calculate_data_hash(group_rows: list[dict]) -> str:
     meta_parts.append(f"DEPTS={','.join(unique_depts)}")
     meta_parts.append(f"TOTAL={total_price:.2f}")
     meta_parts.append(f"ROWCOUNT={len(sorted_rows)}")
+    if RATE_CUTOFF_DATE:
+        meta_parts.append(f"RATE_CUTOFF={RATE_CUTOFF_DATE.isoformat()}")
 
     # Update hash with metadata
     if meta_parts:
@@ -1527,6 +1693,12 @@ def get_all_source_rows(client, source_sheets):
     merged_rows = []
     global_row_counter = 0
     original_rates = load_contract_rates('CU List - Corpus North & South.csv')
+    # Load new rate versions if rate cutoff is configured
+    _rate_cu_to_group = {}
+    _rate_new_primary = {}
+    _rate_new_arrowhead = {}
+    if RATE_CUTOFF_DATE:
+        _rate_cu_to_group, _rate_new_primary, _rate_new_arrowhead = load_rate_versions()
     exclusion_counts = {
         'missing_work_request': 0,
         'missing_weekly_reference_logged_date': 0,
@@ -1789,7 +1961,30 @@ def get_all_source_rows(client, source_sheets):
                                         logging.info(f"🚐 VAC CREW ROW DETECTED [Row {sheet_row_counter+1}]: WR={wr_key_for_diag}, Name={vac_crew_name}, Dept={row_data['__vac_crew_dept']}, Job={row_data['__vac_crew_job']}")
                             
                             row_data['__is_vac_crew'] = is_vac_crew_row
-                            
+                            row_data['__is_subcontractor'] = is_subcontractor_sheet
+
+                            # --- DATE-BASED RATE RECALCULATION ---
+                            # When RATE_CUTOFF_DATE is set, rows with Snapshot Date on/after
+                            # the cutoff get prices recalculated from new contract rates.
+                            # Pre-cutoff rows keep their SmartSheet Units Total Price.
+                            if RATE_CUTOFF_DATE and _rate_new_primary:
+                                snapshot_raw = row_data.get('Snapshot Date')
+                                if snapshot_raw:
+                                    snap_dt = excel_serial_to_date(snapshot_raw)
+                                    if snap_dt:
+                                        snap_date = snap_dt.date() if hasattr(snap_dt, 'date') else snap_dt
+                                        if snap_date >= RATE_CUTOFF_DATE:
+                                            target_rates = _rate_new_arrowhead if is_subcontractor_sheet else _rate_new_primary
+                                            old_price = parse_price(row_data.get('Units Total Price'))
+                                            new_price = recalculate_row_price(row_data, _rate_cu_to_group, target_rates)
+                                            if new_price != old_price:
+                                                logging.debug(f"Rate recalc: CU={row_data.get('CU')}, "
+                                                              f"old=${old_price:.2f} -> new=${new_price:.2f}, "
+                                                              f"sub={is_subcontractor_sheet}, date={snap_date}")
+                                                # Update price_val and has_price after recalculation
+                                                price_val = new_price
+                                                has_price = price_val > 0
+
                             sheet_rows.append(row_data)
                             sheet_exclusion_counts['accepted'] += 1
                         else:

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -661,6 +661,10 @@ def recalculate_row_price(row_data, cu_to_group, rates_dict):
         return price_val
 
     rate = rates_dict[group_code].get(wt_key, 0.0)
+    if rate <= 0:
+        logging.debug(f"Rate recalculation: rate is zero for group '{group_code}' work type '{wt_key}', keeping SmartSheet price")
+        return price_val
+
     new_price = round(rate * qty, 2)
     row_data['Units Total Price'] = new_price
     return new_price

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -221,7 +221,7 @@ except ValueError:
     RATE_CUTOFF_DATE = None
 ARROWHEAD_DISCOUNT = 0.90  # 10% reduction for subcontractors (Arrowhead)
 
-def _sanitize_csv_path(env_var, default, label):
+def _sanitize_csv_path(env_var, default):
     """Validate a CSV path from env var, preventing directory traversal."""
     raw = os.getenv(env_var, default)
     resolved = os.path.normpath(os.path.abspath(raw))
@@ -231,8 +231,8 @@ def _sanitize_csv_path(env_var, default, label):
         return default
     return raw
 
-NEW_RATES_CSV = _sanitize_csv_path('NEW_RATES_CSV', 'New Contract Rates copy regenerated again.csv', 'new rates')
-OLD_RATES_CSV = _sanitize_csv_path('OLD_RATES_CSV', 'CU List - Corpus North & South.csv', 'old rates')
+NEW_RATES_CSV = _sanitize_csv_path('NEW_RATES_CSV', 'New Contract Rates copy regenerated again.csv')
+OLD_RATES_CSV = _sanitize_csv_path('OLD_RATES_CSV', 'CU List - Corpus North & South.csv')
 
 _RATES_FINGERPRINT = ''  # Populated at runtime by load_rate_versions()
 

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -222,14 +222,18 @@ except ValueError:
 ARROWHEAD_DISCOUNT = 0.90  # 10% reduction for subcontractors (Arrowhead)
 
 def _sanitize_csv_path(env_var, default):
-    """Validate a CSV path from env var, preventing directory traversal and symlink escapes."""
+    """Validate a CSV path from env var, preventing directory traversal and symlink escapes.
+
+    Returns the fully resolved path so that the value passed to open() is
+    the same value that was validated (satisfies CodeQL taint analysis).
+    """
     raw = (os.getenv(env_var, '') or '').strip() or default
     resolved = os.path.normpath(os.path.realpath(raw))
     cwd = os.path.normpath(os.path.realpath('.'))
     if not resolved.startswith(cwd + os.sep) and resolved != cwd:
         logging.warning(f"⚠️ {env_var} resolves outside working directory: '{raw}'. Using default: '{default}'")
-        return default
-    return raw
+        return os.path.normpath(os.path.realpath(default))
+    return resolved
 
 NEW_RATES_CSV = _sanitize_csv_path('NEW_RATES_CSV', 'New Contract Rates copy regenerated again.csv')
 OLD_RATES_CSV = _sanitize_csv_path('OLD_RATES_CSV', 'CU List - Corpus North & South.csv')

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -211,13 +211,19 @@ _FOLDER_DISCOVERED_ORIG_IDS: set[int] = set()
 # When set, rows with Snapshot Date >= cutoff get prices recalculated from new rate tables.
 # When unset (empty string), all rows keep their SmartSheet Units Total Price (current behavior).
 _cutoff_str = os.getenv('RATE_CUTOFF_DATE', '')
-RATE_CUTOFF_DATE = (
-    datetime.datetime.strptime(_cutoff_str, '%Y-%m-%d').date()
-    if _cutoff_str else None
-)
+try:
+    RATE_CUTOFF_DATE = (
+        datetime.datetime.strptime(_cutoff_str, '%Y-%m-%d').date()
+        if _cutoff_str else None
+    )
+except ValueError:
+    logging.error(f"Invalid RATE_CUTOFF_DATE format: '{_cutoff_str}', expected YYYY-MM-DD. Rate versioning disabled.")
+    RATE_CUTOFF_DATE = None
 ARROWHEAD_DISCOUNT = 0.90  # 10% reduction for subcontractors (Arrowhead)
-NEW_RATES_CSV = 'New Contract Rates copy regenerated again.csv'
-OLD_RATES_CSV = 'CU List - Corpus North & South.csv'
+NEW_RATES_CSV = os.getenv('NEW_RATES_CSV', 'New Contract Rates copy regenerated again.csv')
+OLD_RATES_CSV = os.getenv('OLD_RATES_CSV', 'CU List - Corpus North & South.csv')
+
+_RATES_FINGERPRINT = ''  # Populated at runtime by load_rate_versions()
 
 if RATE_CUTOFF_DATE:
     logging.info(f"📊 Rate contract versioning ENABLED: cutoff date = {RATE_CUTOFF_DATE.isoformat()}")
@@ -544,14 +550,24 @@ def build_cu_to_group_mapping(old_csv_path):
     return mapping
 
 
+def _compute_rates_fingerprint(rates_dict):
+    """Compute a short SHA256 fingerprint of a rates dictionary for hash invalidation."""
+    h = hashlib.sha256()
+    for code in sorted(rates_dict.keys()):
+        r = rates_dict[code]
+        h.update(f"{code}:{r['install']:.2f},{r['removal']:.2f},{r['transfer']:.2f}\n".encode())
+    return h.hexdigest()[:12]
+
+
 def load_rate_versions():
     """Load new rate versions and build all necessary lookup structures.
 
     Returns:
-        tuple: (cu_to_group, new_rates_primary, new_rates_arrowhead)
+        tuple: (cu_to_group, new_rates_primary, new_rates_arrowhead, rates_fingerprint)
             - cu_to_group: {DETAILED_CU: GROUP_CODE}
             - new_rates_primary: {GROUP_CODE: {install, removal, transfer}}
             - new_rates_arrowhead: {GROUP_CODE: {install, removal, transfer}} (rates * 0.90)
+            - rates_fingerprint: short hash of rate table contents for cache invalidation
     """
     cu_to_group = build_cu_to_group_mapping(OLD_RATES_CSV)
     new_rates_primary = load_new_contract_rates(NEW_RATES_CSV)
@@ -565,10 +581,13 @@ def load_rate_versions():
             'transfer': round(rates['transfer'] * ARROWHEAD_DISCOUNT, 2),
         }
 
+    rates_fingerprint = _compute_rates_fingerprint(new_rates_primary)
+
     logging.info(f"Rate versions loaded: {len(new_rates_primary)} primary groups, "
                  f"{len(new_rates_arrowhead)} Arrowhead groups, "
-                 f"{len(cu_to_group)} CU-to-group mappings")
-    return cu_to_group, new_rates_primary, new_rates_arrowhead
+                 f"{len(cu_to_group)} CU-to-group mappings, "
+                 f"fingerprint={rates_fingerprint}")
+    return cu_to_group, new_rates_primary, new_rates_arrowhead, rates_fingerprint
 
 
 def recalculate_row_price(row_data, cu_to_group, rates_dict):
@@ -902,6 +921,8 @@ def calculate_data_hash(group_rows: list[dict]) -> str:
     meta_parts.append(f"ROWCOUNT={len(sorted_rows)}")
     if RATE_CUTOFF_DATE:
         meta_parts.append(f"RATE_CUTOFF={RATE_CUTOFF_DATE.isoformat()}")
+        if _RATES_FINGERPRINT:
+            meta_parts.append(f"RATES_FP={_RATES_FINGERPRINT}")
 
     # Update hash with metadata
     if meta_parts:
@@ -1694,11 +1715,12 @@ def get_all_source_rows(client, source_sheets):
     global_row_counter = 0
     original_rates = load_contract_rates('CU List - Corpus North & South.csv')
     # Load new rate versions if rate cutoff is configured
+    global _RATES_FINGERPRINT
     _rate_cu_to_group = {}
     _rate_new_primary = {}
     _rate_new_arrowhead = {}
     if RATE_CUTOFF_DATE:
-        _rate_cu_to_group, _rate_new_primary, _rate_new_arrowhead = load_rate_versions()
+        _rate_cu_to_group, _rate_new_primary, _rate_new_arrowhead, _RATES_FINGERPRINT = load_rate_versions()
     exclusion_counts = {
         'missing_work_request': 0,
         'missing_weekly_reference_logged_date': 0,
@@ -1835,10 +1857,30 @@ def get_all_source_rows(client, source_sheets):
                         price_val = parse_price(price_raw)
 
                         # --- SUBCONTRACTOR PRICING ---
-                        # Subcontractor sheets keep their reduced 10% pricing as-is.
-                        # The Excel files will reflect the actual subcontractor rates
-                        # captured from Smartsheet without reversion to original contract rates.
+                        # When RATE_CUTOFF_DATE is NOT set: subcontractor sheets keep
+                        # their SmartSheet pricing as-is (reduced 10% rates from upstream).
+                        # When RATE_CUTOFF_DATE IS set: post-cutoff rows get prices
+                        # recalculated from new rate tables (subcontractors at new_rate × 0.90).
                         # --- END SUBCONTRACTOR PRICING ---
+
+                        # Pre-acceptance rate recalculation: for cutoff-eligible rows,
+                        # recalculate price BEFORE the has_price check so rows with
+                        # zero/blank SmartSheet prices can still be accepted if the
+                        # new rate produces a valid non-zero amount.
+                        if RATE_CUTOFF_DATE and _rate_new_primary:
+                            snapshot_raw_pre = row_data.get('Snapshot Date')
+                            if snapshot_raw_pre:
+                                snap_dt_pre = excel_serial_to_date(snapshot_raw_pre)
+                                if snap_dt_pre:
+                                    snap_date_pre = snap_dt_pre.date() if hasattr(snap_dt_pre, 'date') else snap_dt_pre
+                                    if snap_date_pre >= RATE_CUTOFF_DATE:
+                                        target_rates = _rate_new_arrowhead if is_subcontractor_sheet else _rate_new_primary
+                                        old_price = price_val
+                                        price_val = recalculate_row_price(row_data, _rate_cu_to_group, target_rates)
+                                        if price_val != old_price:
+                                            logging.debug(f"Rate recalc: CU={row_data.get('CU')}, "
+                                                          f"old=${old_price:.2f} -> new=${price_val:.2f}, "
+                                                          f"sub={is_subcontractor_sheet}, date={snap_date_pre}")
 
                         price_raw = row_data.get('Units Total Price')
                         has_price = (price_raw not in (None, "", "$0", "$0.00", "0", "0.0")) and price_val > 0
@@ -1962,28 +2004,6 @@ def get_all_source_rows(client, source_sheets):
                             
                             row_data['__is_vac_crew'] = is_vac_crew_row
                             row_data['__is_subcontractor'] = is_subcontractor_sheet
-
-                            # --- DATE-BASED RATE RECALCULATION ---
-                            # When RATE_CUTOFF_DATE is set, rows with Snapshot Date on/after
-                            # the cutoff get prices recalculated from new contract rates.
-                            # Pre-cutoff rows keep their SmartSheet Units Total Price.
-                            if RATE_CUTOFF_DATE and _rate_new_primary:
-                                snapshot_raw = row_data.get('Snapshot Date')
-                                if snapshot_raw:
-                                    snap_dt = excel_serial_to_date(snapshot_raw)
-                                    if snap_dt:
-                                        snap_date = snap_dt.date() if hasattr(snap_dt, 'date') else snap_dt
-                                        if snap_date >= RATE_CUTOFF_DATE:
-                                            target_rates = _rate_new_arrowhead if is_subcontractor_sheet else _rate_new_primary
-                                            old_price = parse_price(row_data.get('Units Total Price'))
-                                            new_price = recalculate_row_price(row_data, _rate_cu_to_group, target_rates)
-                                            if new_price != old_price:
-                                                logging.debug(f"Rate recalc: CU={row_data.get('CU')}, "
-                                                              f"old=${old_price:.2f} -> new=${new_price:.2f}, "
-                                                              f"sub={is_subcontractor_sheet}, date={snap_date}")
-                                                # Update price_val and has_price after recalculation
-                                                price_val = new_price
-                                                has_price = price_val > 0
 
                             sheet_rows.append(row_data)
                             sheet_exclusion_counts['accepted'] += 1

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -220,8 +220,9 @@ except ValueError:
     logging.error(f"Invalid RATE_CUTOFF_DATE format: '{_cutoff_str}', expected YYYY-MM-DD. Rate versioning disabled.")
     RATE_CUTOFF_DATE = None
 ARROWHEAD_DISCOUNT = 0.90  # 10% reduction for subcontractors (Arrowhead)
-NEW_RATES_CSV = os.getenv('NEW_RATES_CSV', 'New Contract Rates copy regenerated again.csv')
-OLD_RATES_CSV = os.getenv('OLD_RATES_CSV', 'CU List - Corpus North & South.csv')
+# Sanitize CSV paths: only allow basenames (no directory traversal)
+NEW_RATES_CSV = os.path.basename(os.getenv('NEW_RATES_CSV', 'New Contract Rates copy regenerated again.csv'))
+OLD_RATES_CSV = os.path.basename(os.getenv('OLD_RATES_CSV', 'CU List - Corpus North & South.csv'))
 
 _RATES_FINGERPRINT = ''  # Populated at runtime by load_rate_versions()
 

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -223,7 +223,7 @@ ARROWHEAD_DISCOUNT = 0.90  # 10% reduction for subcontractors (Arrowhead)
 
 def _sanitize_csv_path(env_var, default):
     """Validate a CSV path from env var, preventing directory traversal and symlink escapes."""
-    raw = os.getenv(env_var, default)
+    raw = (os.getenv(env_var, '') or '').strip() or default
     resolved = os.path.normpath(os.path.realpath(raw))
     cwd = os.path.normpath(os.path.realpath('.'))
     if not resolved.startswith(cwd + os.sep) and resolved != cwd:

--- a/tests/test_subcontractor_pricing.py
+++ b/tests/test_subcontractor_pricing.py
@@ -613,8 +613,8 @@ class TestCutoffDateRecalculationIntegration(unittest.TestCase):
             row, self.cu_to_group, self.rates_primary)
         self.assertAlmostEqual(new_price, 448.12)  # 224.06 * 2
 
-    def test_subcontractor_row_gets_discounted_rates(self):
-        """Verify subcontractor rows use 90% of primary rates."""
+    def test_discounted_rate_table_math(self):
+        """Verify recalculate_row_price correctly applies a 90% discounted rate table (for future Arrowhead use)."""
         arrowhead_rates = {
             'ANC-M': {
                 'install': round(224.06 * 0.90, 2),

--- a/tests/test_subcontractor_pricing.py
+++ b/tests/test_subcontractor_pricing.py
@@ -514,6 +514,14 @@ class TestRecalculateRowPrice(unittest.TestCase):
         self.assertAlmostEqual(result, 100.0)
         self.assertEqual(row['Units Total Price'], '$100.00')
 
+    def test_zero_rate_keeps_smartsheet_price(self):
+        """Test that a zero rate for a work type keeps the original SmartSheet price."""
+        # ANC-M has transfer rate of 0.0 in the test data
+        row = {'CU': 'ANC-DHM-10-84-D1', 'Work Type': 'Transfer', 'Quantity': '2', 'Units Total Price': '$75.00'}
+        result = generate_weekly_pdfs.recalculate_row_price(row, self.cu_to_group, self.rates_primary)
+        self.assertAlmostEqual(result, 75.0)
+        self.assertEqual(row['Units Total Price'], '$75.00')
+
 
 class TestRateCutoffConfig(unittest.TestCase):
     """Tests for rate cutoff configuration."""
@@ -527,9 +535,9 @@ class TestRateCutoffConfig(unittest.TestCase):
         self.assertAlmostEqual(generate_weekly_pdfs.ARROWHEAD_DISCOUNT, 0.90)
 
     def test_new_rates_csv_attribute(self):
-        """Test that NEW_RATES_CSV attribute exists and points to the new file."""
+        """Test that NEW_RATES_CSV attribute exists and is a non-empty path."""
         self.assertTrue(hasattr(generate_weekly_pdfs, 'NEW_RATES_CSV'))
-        self.assertIn('New Contract Rates', generate_weekly_pdfs.NEW_RATES_CSV)
+        self.assertTrue(len(generate_weekly_pdfs.NEW_RATES_CSV) > 0)
 
     def test_rates_fingerprint_attribute_exists(self):
         """Test that _RATES_FINGERPRINT attribute exists on the module."""

--- a/tests/test_subcontractor_pricing.py
+++ b/tests/test_subcontractor_pricing.py
@@ -299,6 +299,230 @@ class TestIdentityNormalization(unittest.TestCase):
         self.assertNotEqual((ident_identifier or ''), (identifier or ''))
 
 
+class TestLoadNewContractRates(unittest.TestCase):
+    """Tests for loading the 2026-format new contract rates CSV."""
+
+    def test_loads_new_format_csv(self):
+        """Test loading a CSV with 3 metadata rows and positional columns."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.csv', delete=False, newline='') as f:
+            writer = csv.writer(f)
+            # 3 metadata rows
+            writer.writerow(['', '', '', '', '', '', '2026 Update', '', '0.03'])
+            writer.writerow(['', '', '', '', '', '', 'Revised Pricing', '', ''])
+            writer.writerow(['', '', '', '', '', '', 'Install', 'Remove ', 'Transfer'])
+            # Data rows
+            writer.writerow(['ANC-H', 'Anchor Assembly (Hand)', 'EA', 'Overhead', 'AEP TX', '01-18-26', '814.28', '29.45', '0'])
+            writer.writerow(['ANC-M', 'Anchor Assembly (Machine)', 'EA', 'Overhead', 'AEP TX', '01-18-26', '224.06', '29.46', '0'])
+            writer.writerow(['ARM-DW', 'Double Wood Crossarm', 'EA', 'Overhead', 'AEP TX', '01-18-26', '330.24', '75.94', '183.98'])
+            tmp_path = f.name
+
+        try:
+            rates = generate_weekly_pdfs.load_new_contract_rates(tmp_path)
+            self.assertEqual(len(rates), 3)
+            self.assertIn('ANC-H', rates)
+            self.assertIn('ANC-M', rates)
+            self.assertIn('ARM-DW', rates)
+            self.assertAlmostEqual(rates['ANC-H']['install'], 814.28)
+            self.assertAlmostEqual(rates['ANC-H']['removal'], 29.45)
+            self.assertAlmostEqual(rates['ANC-H']['transfer'], 0.0)
+            self.assertAlmostEqual(rates['ANC-M']['install'], 224.06)
+            self.assertAlmostEqual(rates['ARM-DW']['transfer'], 183.98)
+        finally:
+            os.unlink(tmp_path)
+
+    def test_missing_file_returns_empty(self):
+        """Test that a missing file returns empty dict."""
+        rates = generate_weekly_pdfs.load_new_contract_rates('/nonexistent/new_rates.csv')
+        self.assertEqual(rates, {})
+
+    def test_skips_short_rows(self):
+        """Test that rows with fewer than 9 columns are skipped."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.csv', delete=False, newline='') as f:
+            writer = csv.writer(f)
+            writer.writerow(['', '', '', '', '', '', 'Header', '', ''])
+            writer.writerow(['', '', '', '', '', '', '', '', ''])
+            writer.writerow(['', '', '', '', '', '', '', '', ''])
+            writer.writerow(['SHORT', 'Only 5 cols', 'EA', 'Cat', 'Region'])  # Too short
+            writer.writerow(['VALID', 'Full row', 'EA', 'Cat', 'Region', '01-18-26', '100', '50', '25'])
+            tmp_path = f.name
+
+        try:
+            rates = generate_weekly_pdfs.load_new_contract_rates(tmp_path)
+            self.assertEqual(len(rates), 1)
+            self.assertIn('VALID', rates)
+        finally:
+            os.unlink(tmp_path)
+
+    def test_group_code_uppercased(self):
+        """Test that group codes are normalized to uppercase."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.csv', delete=False, newline='') as f:
+            writer = csv.writer(f)
+            for _ in range(3):
+                writer.writerow([''] * 9)
+            writer.writerow(['anc-h', 'Anchor', 'EA', 'OH', 'AEP', '01-18-26', '100', '50', '25'])
+            tmp_path = f.name
+
+        try:
+            rates = generate_weekly_pdfs.load_new_contract_rates(tmp_path)
+            self.assertIn('ANC-H', rates)
+            self.assertNotIn('anc-h', rates)
+        finally:
+            os.unlink(tmp_path)
+
+
+class TestBuildCuToGroupMapping(unittest.TestCase):
+    """Tests for building the CU-to-group code mapping."""
+
+    def test_builds_mapping_from_old_csv(self):
+        """Test building CU -> Compatible Unit Group mapping."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.csv', delete=False, newline='') as f:
+            writer = csv.writer(f)
+            writer.writerow([
+                'CU WBS #', 'CU', 'Unit Of Measure', 'Description',
+                'Compatible Unit Group', 'Install Hours', 'Removal Hours',
+                'Transfer Hours', 'Install Price', 'Removal Price', 'Transfer Price'
+            ])
+            writer.writerow(['100', 'ANC-DHM-10-84-D1', 'EA', 'Anchor', 'ANC-M', '0.24', '0.14', '0', '217.53', '28.60', '0'])
+            writer.writerow(['101', 'ANC-DSC-16-96-D1', 'EA', 'Anchor Disc', 'ANC-H', '0.90', '0.14', '0', '790.56', '28.59', '0'])
+            writer.writerow(['102', 'ARM-10D-60HS', 'EA', 'Crossarm', 'ARM-DW', '0.66', '0.38', '0.93', '320.62', '73.73', '178.62'])
+            tmp_path = f.name
+
+        try:
+            mapping = generate_weekly_pdfs.build_cu_to_group_mapping(tmp_path)
+            self.assertEqual(len(mapping), 3)
+            self.assertEqual(mapping['ANC-DHM-10-84-D1'], 'ANC-M')
+            self.assertEqual(mapping['ANC-DSC-16-96-D1'], 'ANC-H')
+            self.assertEqual(mapping['ARM-10D-60HS'], 'ARM-DW')
+        finally:
+            os.unlink(tmp_path)
+
+    def test_missing_file_returns_empty(self):
+        """Test that missing file returns empty mapping."""
+        mapping = generate_weekly_pdfs.build_cu_to_group_mapping('/nonexistent/old.csv')
+        self.assertEqual(mapping, {})
+
+    def test_cu_codes_uppercased(self):
+        """Test that CU codes and group codes are uppercased."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.csv', delete=False, newline='') as f:
+            writer = csv.writer(f)
+            writer.writerow([
+                'CU WBS #', 'CU', 'Unit Of Measure', 'Description',
+                'Compatible Unit Group', 'Install Hours', 'Removal Hours',
+                'Transfer Hours', 'Install Price', 'Removal Price', 'Transfer Price'
+            ])
+            writer.writerow(['100', 'lower-cu', 'EA', 'Test', 'lower-group', '1', '0', '0', '100', '50', '25'])
+            tmp_path = f.name
+
+        try:
+            mapping = generate_weekly_pdfs.build_cu_to_group_mapping(tmp_path)
+            self.assertIn('LOWER-CU', mapping)
+            self.assertEqual(mapping['LOWER-CU'], 'LOWER-GROUP')
+        finally:
+            os.unlink(tmp_path)
+
+
+class TestRecalculateRowPrice(unittest.TestCase):
+    """Tests for the date-based rate recalculation function."""
+
+    def setUp(self):
+        self.cu_to_group = {
+            'ANC-DHM-10-84-D1': 'ANC-M',
+            'ANC-DSC-16-96-D1': 'ANC-H',
+            'ARM-10D-60HS': 'ARM-DW',
+        }
+        self.rates_primary = {
+            'ANC-M': {'install': 224.06, 'removal': 29.46, 'transfer': 0.0},
+            'ANC-H': {'install': 814.28, 'removal': 29.45, 'transfer': 0.0},
+            'ARM-DW': {'install': 330.24, 'removal': 75.94, 'transfer': 183.98},
+        }
+
+    def test_basic_install_recalculation(self):
+        """Test basic install price recalculation via CU-to-group mapping."""
+        row = {'CU': 'ANC-DHM-10-84-D1', 'Work Type': 'Install', 'Quantity': '3', 'Units Total Price': '$650.00'}
+        result = generate_weekly_pdfs.recalculate_row_price(row, self.cu_to_group, self.rates_primary)
+        expected = round(224.06 * 3, 2)  # 672.18
+        self.assertAlmostEqual(result, expected)
+        self.assertAlmostEqual(row['Units Total Price'], expected)
+
+    def test_removal_work_type(self):
+        """Test removal work type mapping."""
+        row = {'CU': 'ARM-10D-60HS', 'Work Type': 'Removal', 'Quantity': '2', 'Units Total Price': '$100.00'}
+        result = generate_weekly_pdfs.recalculate_row_price(row, self.cu_to_group, self.rates_primary)
+        expected = round(75.94 * 2, 2)  # 151.88
+        self.assertAlmostEqual(result, expected)
+
+    def test_transfer_work_type(self):
+        """Test transfer work type mapping."""
+        row = {'CU': 'ARM-10D-60HS', 'Work Type': 'Transfer', 'Quantity': '1', 'Units Total Price': '$150.00'}
+        result = generate_weekly_pdfs.recalculate_row_price(row, self.cu_to_group, self.rates_primary)
+        self.assertAlmostEqual(result, 183.98)
+
+    def test_xfr_work_type(self):
+        """Test that 'xfr' maps to transfer rates."""
+        row = {'CU': 'ARM-10D-60HS', 'Work Type': 'XFR', 'Quantity': '1', 'Units Total Price': '$150.00'}
+        result = generate_weekly_pdfs.recalculate_row_price(row, self.cu_to_group, self.rates_primary)
+        self.assertAlmostEqual(result, 183.98)
+
+    def test_unknown_cu_keeps_smartsheet_price(self):
+        """Test that unknown CU codes keep the original SmartSheet price."""
+        row = {'CU': 'UNKNOWN-CU-999', 'Work Type': 'Install', 'Quantity': '1', 'Units Total Price': '$55.00'}
+        result = generate_weekly_pdfs.recalculate_row_price(row, self.cu_to_group, self.rates_primary)
+        self.assertAlmostEqual(result, 55.0)
+        # Original string should be unchanged
+        self.assertEqual(row['Units Total Price'], '$55.00')
+
+    def test_direct_group_code_lookup(self):
+        """Test that if SmartSheet row uses a group code directly, it still works."""
+        row = {'CU': 'ANC-M', 'Work Type': 'Install', 'Quantity': '2', 'Units Total Price': '$400.00'}
+        result = generate_weekly_pdfs.recalculate_row_price(row, self.cu_to_group, self.rates_primary)
+        expected = round(224.06 * 2, 2)  # 448.12
+        self.assertAlmostEqual(result, expected)
+
+    def test_cu_helper_preferred(self):
+        """Test that CU Helper field is preferred over CU field."""
+        row = {'CU Helper': 'ANC-DSC-16-96-D1', 'CU': 'ARM-10D-60HS', 'Work Type': 'Install', 'Quantity': '1', 'Units Total Price': '$300.00'}
+        result = generate_weekly_pdfs.recalculate_row_price(row, self.cu_to_group, self.rates_primary)
+        self.assertAlmostEqual(result, 814.28)  # ANC-H install rate
+
+    def test_arrowhead_discount_rates(self):
+        """Test that Arrowhead (subcontractor) rates are 90% of primary."""
+        arrowhead_rates = {
+            group: {
+                'install': round(r['install'] * 0.90, 2),
+                'removal': round(r['removal'] * 0.90, 2),
+                'transfer': round(r['transfer'] * 0.90, 2),
+            }
+            for group, r in self.rates_primary.items()
+        }
+        row = {'CU': 'ANC-DHM-10-84-D1', 'Work Type': 'Install', 'Quantity': '1', 'Units Total Price': '$200.00'}
+        result = generate_weekly_pdfs.recalculate_row_price(row, self.cu_to_group, arrowhead_rates)
+        expected = round(224.06 * 0.90, 2)  # 201.65
+        self.assertAlmostEqual(result, expected)
+
+    def test_zero_quantity(self):
+        """Test that zero quantity yields zero price."""
+        row = {'CU': 'ANC-DHM-10-84-D1', 'Work Type': 'Install', 'Quantity': '0', 'Units Total Price': '$0.00'}
+        result = generate_weekly_pdfs.recalculate_row_price(row, self.cu_to_group, self.rates_primary)
+        self.assertAlmostEqual(result, 0.0)
+
+
+class TestRateCutoffConfig(unittest.TestCase):
+    """Tests for rate cutoff configuration."""
+
+    def test_rate_cutoff_attribute_exists(self):
+        """Test that RATE_CUTOFF_DATE attribute exists on the module."""
+        self.assertTrue(hasattr(generate_weekly_pdfs, 'RATE_CUTOFF_DATE'))
+
+    def test_arrowhead_discount_value(self):
+        """Test that ARROWHEAD_DISCOUNT is 0.90 (10% reduction)."""
+        self.assertAlmostEqual(generate_weekly_pdfs.ARROWHEAD_DISCOUNT, 0.90)
+
+    def test_new_rates_csv_attribute(self):
+        """Test that NEW_RATES_CSV attribute exists and points to the new file."""
+        self.assertTrue(hasattr(generate_weekly_pdfs, 'NEW_RATES_CSV'))
+        self.assertIn('New Contract Rates', generate_weekly_pdfs.NEW_RATES_CSV)
+
+
 class TestExpandedHashCoverage(unittest.TestCase):
     """Tests for the expanded calculate_data_hash field coverage."""
 

--- a/tests/test_subcontractor_pricing.py
+++ b/tests/test_subcontractor_pricing.py
@@ -499,11 +499,20 @@ class TestRecalculateRowPrice(unittest.TestCase):
         expected = round(224.06 * 0.90, 2)  # 201.65
         self.assertAlmostEqual(result, expected)
 
-    def test_zero_quantity(self):
-        """Test that zero quantity yields zero price."""
-        row = {'CU': 'ANC-DHM-10-84-D1', 'Work Type': 'Install', 'Quantity': '0', 'Units Total Price': '$0.00'}
+    def test_zero_quantity_keeps_smartsheet_price(self):
+        """Test that zero quantity keeps original SmartSheet price instead of zeroing it out."""
+        row = {'CU': 'ANC-DHM-10-84-D1', 'Work Type': 'Install', 'Quantity': '0', 'Units Total Price': '$55.00'}
         result = generate_weekly_pdfs.recalculate_row_price(row, self.cu_to_group, self.rates_primary)
-        self.assertAlmostEqual(result, 0.0)
+        self.assertAlmostEqual(result, 55.0)
+        # Original string should be unchanged
+        self.assertEqual(row['Units Total Price'], '$55.00')
+
+    def test_missing_quantity_keeps_smartsheet_price(self):
+        """Test that missing/empty quantity keeps original SmartSheet price."""
+        row = {'CU': 'ANC-DHM-10-84-D1', 'Work Type': 'Install', 'Units Total Price': '$100.00'}
+        result = generate_weekly_pdfs.recalculate_row_price(row, self.cu_to_group, self.rates_primary)
+        self.assertAlmostEqual(result, 100.0)
+        self.assertEqual(row['Units Total Price'], '$100.00')
 
 
 class TestRateCutoffConfig(unittest.TestCase):

--- a/tests/test_subcontractor_pricing.py
+++ b/tests/test_subcontractor_pricing.py
@@ -522,6 +522,108 @@ class TestRateCutoffConfig(unittest.TestCase):
         self.assertTrue(hasattr(generate_weekly_pdfs, 'NEW_RATES_CSV'))
         self.assertIn('New Contract Rates', generate_weekly_pdfs.NEW_RATES_CSV)
 
+    def test_rates_fingerprint_attribute_exists(self):
+        """Test that _RATES_FINGERPRINT attribute exists on the module."""
+        self.assertTrue(hasattr(generate_weekly_pdfs, '_RATES_FINGERPRINT'))
+
+
+class TestRatesFingerprint(unittest.TestCase):
+    """Tests for rate table fingerprint computation."""
+
+    def test_fingerprint_deterministic(self):
+        """Test that same rates produce same fingerprint."""
+        rates = {'ANC-H': {'install': 100.0, 'removal': 50.0, 'transfer': 25.0}}
+        fp1 = generate_weekly_pdfs._compute_rates_fingerprint(rates)
+        fp2 = generate_weekly_pdfs._compute_rates_fingerprint(rates)
+        self.assertEqual(fp1, fp2)
+
+    def test_fingerprint_changes_with_rates(self):
+        """Test that different rates produce different fingerprints."""
+        rates1 = {'ANC-H': {'install': 100.0, 'removal': 50.0, 'transfer': 25.0}}
+        rates2 = {'ANC-H': {'install': 103.0, 'removal': 51.5, 'transfer': 25.75}}
+        fp1 = generate_weekly_pdfs._compute_rates_fingerprint(rates1)
+        fp2 = generate_weekly_pdfs._compute_rates_fingerprint(rates2)
+        self.assertNotEqual(fp1, fp2)
+
+    def test_fingerprint_is_12_chars(self):
+        """Test that fingerprint is 12 hex characters."""
+        rates = {'X': {'install': 1.0, 'removal': 2.0, 'transfer': 3.0}}
+        fp = generate_weekly_pdfs._compute_rates_fingerprint(rates)
+        self.assertEqual(len(fp), 12)
+
+
+class TestCutoffDateRecalculationIntegration(unittest.TestCase):
+    """Integration tests for date-based rate recalculation logic."""
+
+    def setUp(self):
+        self.cu_to_group = {
+            'ANC-DHM-10-84-D1': 'ANC-M',
+        }
+        self.rates_primary = {
+            'ANC-M': {'install': 224.06, 'removal': 29.46, 'transfer': 0.0},
+        }
+
+    def test_pre_cutoff_row_keeps_smartsheet_price(self):
+        """Verify a row with Snapshot Date before cutoff is not recalculated."""
+        import datetime as dt
+        cutoff = dt.date(2026, 4, 19)
+        row = {
+            'CU': 'ANC-DHM-10-84-D1', 'Work Type': 'Install',
+            'Quantity': '1', 'Units Total Price': '$200.00',
+            'Snapshot Date': '2026-04-18',
+        }
+        snap = generate_weekly_pdfs.excel_serial_to_date(row['Snapshot Date'])
+        snap_date = snap.date() if hasattr(snap, 'date') else snap
+        # Pre-cutoff: should NOT recalculate
+        self.assertLess(snap_date, cutoff)
+        # Price unchanged
+        self.assertEqual(row['Units Total Price'], '$200.00')
+
+    def test_post_cutoff_row_gets_recalculated(self):
+        """Verify a row with Snapshot Date on/after cutoff gets new rates."""
+        import datetime as dt
+        cutoff = dt.date(2026, 4, 19)
+        row = {
+            'CU': 'ANC-DHM-10-84-D1', 'Work Type': 'Install',
+            'Quantity': '2', 'Units Total Price': '$400.00',
+            'Snapshot Date': '2026-04-19',
+        }
+        snap = generate_weekly_pdfs.excel_serial_to_date(row['Snapshot Date'])
+        snap_date = snap.date() if hasattr(snap, 'date') else snap
+        self.assertGreaterEqual(snap_date, cutoff)
+        # Recalculate
+        new_price = generate_weekly_pdfs.recalculate_row_price(
+            row, self.cu_to_group, self.rates_primary)
+        self.assertAlmostEqual(new_price, 448.12)  # 224.06 * 2
+
+    def test_subcontractor_row_gets_discounted_rates(self):
+        """Verify subcontractor rows use 90% of primary rates."""
+        arrowhead_rates = {
+            'ANC-M': {
+                'install': round(224.06 * 0.90, 2),
+                'removal': round(29.46 * 0.90, 2),
+                'transfer': 0.0,
+            }
+        }
+        row = {
+            'CU': 'ANC-DHM-10-84-D1', 'Work Type': 'Install',
+            'Quantity': '1', 'Units Total Price': '$200.00',
+        }
+        new_price = generate_weekly_pdfs.recalculate_row_price(
+            row, self.cu_to_group, arrowhead_rates)
+        expected = round(224.06 * 0.90, 2)  # 201.65
+        self.assertAlmostEqual(new_price, expected)
+
+    def test_snapshot_date_parsing_iso_format(self):
+        """Test that ISO format snapshot dates are parsed correctly."""
+        dt = generate_weekly_pdfs.excel_serial_to_date('2026-04-19')
+        self.assertIsNotNone(dt)
+
+    def test_snapshot_date_parsing_returns_none_for_empty(self):
+        """Test that empty/None snapshot dates return None."""
+        self.assertIsNone(generate_weekly_pdfs.excel_serial_to_date(None))
+        self.assertIsNone(generate_weekly_pdfs.excel_serial_to_date(''))
+
 
 class TestExpandedHashCoverage(unittest.TestCase):
     """Tests for the expanded calculate_data_hash field coverage."""


### PR DESCRIPTION
## Summary
Implements a date-based rate contract versioning system that allows pricing to be recalculated based on new 2026 contract rates when a cutoff date is configured. Rows with snapshot dates on or after the cutoff get prices recalculated from new rate tables, while earlier rows retain their original SmartSheet pricing.

## Key Changes

- **Rate Configuration**: Added `RATE_CUTOFF_DATE` environment variable support and `ARROWHEAD_DISCOUNT` (0.90) constant to control when new rates apply and subcontractor pricing adjustments
- **New Rate Loading**: Implemented `load_new_contract_rates()` to parse the new 2026-format CSV with 3 metadata rows and group-level pricing codes
- **CU-to-Group Mapping**: Added `build_cu_to_group_mapping()` to map detailed CU codes from the old CSV to compatible unit group codes used in new rates
- **Rate Recalculation**: Implemented `recalculate_row_price()` to calculate new prices using rate × quantity, with support for Install/Removal/Transfer work types and subcontractor discount application
- **Rate Version Loading**: Added `load_rate_versions()` helper to load and precompute both primary and Arrowhead (subcontractor) rate tables
- **Date-Based Application**: Integrated rate recalculation into the main row processing pipeline—rows with snapshot dates >= cutoff get new rates applied, earlier rows keep original pricing
- **Hash Tracking**: Updated `calculate_data_hash()` to include rate cutoff date in hash metadata when versioning is enabled
- **Comprehensive Tests**: Added 20+ test cases covering CSV loading, CU-to-group mapping, price recalculation logic, work type handling, and configuration validation

## Implementation Details

- Rates are loaded once at startup via `load_rate_versions()` and cached for performance
- Arrowhead subcontractor rates are precomputed as 90% of primary rates
- CU code resolution follows the same chain as existing code (CU Helper → CU → Billable Unit Code)
- Unknown CU codes gracefully fall back to keeping the original SmartSheet price
- Work type matching is case-insensitive and supports partial matches (e.g., "xfr" → transfer)
- Logging includes debug messages for rate lookups and info messages for configuration status

https://claude.ai/code/session_01FnTNUw7D6M1Wja1t1yCYWL

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core pricing logic and changes acceptance behavior by recalculating prices before the zero/blank-price filter when a cutoff is enabled, which could alter generated billing outputs if misconfigured or if rate mappings are incomplete.
> 
> **Overview**
> Adds **date-based rate contract versioning** to `generate_weekly_pdfs.py`: when `RATE_CUTOFF_DATE` is set, rows with `Snapshot Date` on/after the cutoff have `Units Total Price` recalculated from a new 2026 rate table (group-code CSV) via CU→group mapping; otherwise pricing stays as captured from Smartsheet.
> 
> Introduces configurable `NEW_RATES_CSV`/`OLD_RATES_CSV` with path sanitization, preloads rate versions (including precomputed 10% discounted Arrowhead tables for future use), and extends the data-hash metadata with cutoff/fingerprint to force regeneration when rate tables change. Updates the workflow to pass these new env vars, documents that subcontractor sheets are explicitly excluded from recalculation, and adds extensive unit tests for CSV parsing, mapping, recalculation, and fingerprinting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3ddebe0e46a0d716c9e4ba7e7e92e56c09d974f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->