### PR TITLE
Potential fix for code scanning alert no. 51: Uncontrolled data used in path expression

### DIFF
--- a/scripts/generate_artifact_manifest.py
+++ b/scripts/generate_artifact_manifest.py
@@ -11,6 +11,28 @@ import hashlib
 import datetime
 from pathlib import Path
 
+def sanitize_docs_folder(docs_folder):
+    """
+    Sanitize the user-provided docs_folder argument to avoid unsafe paths.
+
+    Only allow normalized, non-absolute paths that do not traverse upwards (no "..").
+    """
+    if not docs_folder:
+        raise ValueError("docs_folder must not be empty")
+
+    # Normalize the path to collapse any '..' or '.' segments
+    normalized = os.path.normpath(docs_folder)
+
+    # Disallow absolute paths to avoid referencing arbitrary locations
+    if os.path.isabs(normalized):
+        raise ValueError(f"Absolute paths are not allowed for docs_folder: {normalized}")
+
+    # Disallow directory traversal outside the working directory
+    if normalized == os.pardir or normalized.startswith(os.pardir + os.sep):
+        raise ValueError(f"Parent-directory traversal is not allowed for docs_folder: {normalized}")
+
+    return normalized
+
 def calculate_file_hash(filepath):
     """Calculate SHA256 hash of a file."""
     sha256_hash = hashlib.sha256()
@@ -208,7 +230,13 @@ def generate_manifest(docs_folder='generated_docs', output_file='artifact_manife
 
 if __name__ == '__main__':
     import sys
-    docs_folder = sys.argv[1] if len(sys.argv) > 1 else 'generated_docs'
+    docs_folder_arg = sys.argv[1] if len(sys.argv) > 1 else 'generated_docs'
     output_file = sys.argv[2] if len(sys.argv) > 2 else 'artifact_manifest.json'
+
+    try:
+        docs_folder = sanitize_docs_folder(docs_folder_arg)
+    except ValueError as e:
+        print(f"Error: {e}")
+        sys.exit(1)
     
     manifest = generate_manifest(docs_folder, output_file)


### PR DESCRIPTION
Potential fix for [https://github.com/JFlo21/Generate-Weekly-PDFs-DSR-Resiliency/security/code-scanning/51](https://github.com/JFlo21/Generate-Weekly-PDFs-DSR-Resiliency/security/code-scanning/51)

General approach: Normalize any user-supplied path and constrain it to a known safe root, or at least ensure it is a safe, relative directory name. For this script, a minimal, non-breaking fix is to (a) normalize `docs_folder`, (b) ensure it is not an absolute path or one containing `..` path traversal segments, and (c) then use that sanitized `docs_folder` for further operations. If validation fails, exit with an error instead of walking arbitrary paths.

Best concrete fix here:

1. Add a small helper `sanitize_docs_folder` that:
   - Accepts the raw `docs_folder` argument.
   - Uses `os.path.normpath` to normalize it.
   - Rejects:
     - empty strings,
     - absolute paths (`os.path.isabs`),
     - backslashes on non-Windows if you want to be stricter (optional),
     - any path whose normalized form starts with `os.pardir + os.sep` or equals `os.pardir` (to block `..` traversal).
   - Returns the safe, normalized folder name; otherwise raises `ValueError`.

2. In the `if __name__ == '__main__':` block:
   - After computing `docs_folder` from `sys.argv`, pass it through `sanitize_docs_folder`.
   - Use the sanitized value in the call to `generate_manifest`.

3. Within `generate_manifest`, keep the behavior the same, but now `docs_folder` is guaranteed to be safe because it passed validation.

All changes are in `scripts/generate_artifact_manifest.py`. We only introduce a small helper function and adjust the main block; no new external dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds simple input validation in a standalone script and exits early on invalid paths, with minimal impact beyond rejecting previously-accepted unsafe arguments.
> 
> **Overview**
> Adds `sanitize_docs_folder` to normalize and validate the user-supplied `docs_folder` (rejecting empty, absolute, and parent-traversal paths).
> 
> Updates the script entrypoint to validate the CLI argument and exit with an error before calling `generate_manifest`, preventing the manifest generator from walking or writing to arbitrary filesystem locations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2aadaf38a32a099593777e35d41998f481fe2a2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->