### PR TITLE
Improve artifact/excel safety, CSV sanitization, GitHub request hardening, and login rate-limiting

### DIFF
--- a/portal-v2/supabase/schema.sql
+++ b/portal-v2/supabase/schema.sql
@@ -127,7 +127,12 @@ CREATE POLICY "activity_logs_select"
 
 CREATE POLICY "activity_logs_insert"
   ON activity_logs FOR INSERT
-  WITH CHECK (auth.uid() IS NOT NULL);
+  WITH CHECK (
+    user_id = auth.uid()
+    OR EXISTS (
+      SELECT 1 FROM profiles WHERE id = auth.uid() AND role = 'admin'
+    )
+  );
 
 -- artifact_downloads: own rows; admins see all
 CREATE POLICY "artifact_downloads_select"

--- a/portal/routes/api.js
+++ b/portal/routes/api.js
@@ -6,12 +6,46 @@ const excel = require('../services/excel');
 const poller = require('../services/poller');
 
 const router = express.Router();
+const MAX_ARTIFACT_SIZE_BYTES = 50 * 1024 * 1024; // 50MB
+const MAX_ZIP_ENTRIES = 1000;
+const MAX_ZIP_ENTRY_SIZE_BYTES = 20 * 1024 * 1024; // 20MB
 
 function sanitizeFilename(name) {
   if (!name) return undefined;
   const normalized = path.posix.normalize(name);
   if (path.posix.isAbsolute(normalized) || normalized.includes('..')) return undefined;
   return normalized;
+}
+
+function sanitizeCsvCellValue(value) {
+  let safeValue = String(value ?? '');
+  const trimmed = safeValue.trimStart();
+  if (/^[=+\-@]/.test(trimmed)) {
+    safeValue = `'${safeValue}`;
+  }
+  return safeValue;
+}
+
+function validateArtifactZip(zipBuffer, entries) {
+  if (zipBuffer.length > MAX_ARTIFACT_SIZE_BYTES) {
+    const err = new Error('Artifact zip exceeds maximum allowed size');
+    err.statusCode = 413;
+    throw err;
+  }
+  if (entries.length > MAX_ZIP_ENTRIES) {
+    const err = new Error('Artifact zip has too many files');
+    err.statusCode = 413;
+    throw err;
+  }
+}
+
+function validateZipEntry(entry) {
+  if (!entry || entry.isDirectory) return;
+  if (entry.header && entry.header.size > MAX_ZIP_ENTRY_SIZE_BYTES) {
+    const err = new Error('Artifact file exceeds maximum allowed size');
+    err.statusCode = 413;
+    throw err;
+  }
 }
 
 router.use(requireAuth);
@@ -74,6 +108,7 @@ router.get('/artifacts/:artifactId/view', async (req, res) => {
     const AdmZip = require('adm-zip');
     const zip = new AdmZip(zipBuffer);
     const entries = zip.getEntries();
+    validateArtifactZip(zipBuffer, entries);
 
     const filename = sanitizeFilename(req.query.file);
     let targetEntry;
@@ -94,6 +129,7 @@ router.get('/artifacts/:artifactId/view', async (req, res) => {
       return res.json({ files: fileList, message: 'No Excel file found. Listing contents.' });
     }
 
+    validateZipEntry(targetEntry);
     const excelBuffer = targetEntry.getData();
     const parsed = await excel.parseExcelBuffer(excelBuffer);
 
@@ -103,7 +139,7 @@ router.get('/artifacts/:artifactId/view', async (req, res) => {
     });
   } catch (err) {
     console.error('Error viewing artifact:', err.message);
-    return res.status(502).json({ error: 'Failed to parse artifact' });
+    return res.status(err.statusCode || 502).json({ error: 'Failed to parse artifact' });
   }
 });
 
@@ -114,6 +150,7 @@ router.get('/artifacts/:artifactId/files', async (req, res) => {
     const AdmZip = require('adm-zip');
     const zip = new AdmZip(zipBuffer);
     const entries = zip.getEntries();
+    validateArtifactZip(zipBuffer, entries);
 
     const files = entries
       .filter((e) => !e.isDirectory)
@@ -126,7 +163,7 @@ router.get('/artifacts/:artifactId/files', async (req, res) => {
     return res.json({ files });
   } catch (err) {
     console.error('Error listing files:', err.message);
-    return res.status(502).json({ error: 'Failed to list artifact files' });
+    return res.status(err.statusCode || 502).json({ error: 'Failed to list artifact files' });
   }
 });
 
@@ -139,6 +176,7 @@ router.get('/artifacts/:artifactId/export', async (req, res) => {
     const AdmZip = require('adm-zip');
     const zip = new AdmZip(zipBuffer);
     const entries = zip.getEntries();
+    validateArtifactZip(zipBuffer, entries);
 
     let targetEntry;
     if (filename) {
@@ -151,6 +189,7 @@ router.get('/artifacts/:artifactId/export', async (req, res) => {
       return res.status(404).json({ error: 'No file found in artifact' });
     }
 
+    validateZipEntry(targetEntry);
     const excelBuffer = targetEntry.getData();
     const baseName = path.basename(targetEntry.entryName, '.xlsx');
 
@@ -173,7 +212,7 @@ router.get('/artifacts/:artifactId/export', async (req, res) => {
         const cols = [];
         for (let col = 1; col <= maxCol; col++) {
           const cell = cellMap[col];
-          let val = cell ? String(cell.value ?? '') : '';
+          let val = cell ? sanitizeCsvCellValue(cell.value) : '';
           if (val.includes(',') || val.includes('"') || val.includes('\n')) {
             val = '"' + val.replace(/"/g, '""') + '"';
           }
@@ -193,7 +232,7 @@ router.get('/artifacts/:artifactId/export', async (req, res) => {
     return res.send(excelBuffer);
   } catch (err) {
     console.error('Error exporting artifact:', err.message);
-    return res.status(502).json({ error: 'Failed to export artifact' });
+    return res.status(err.statusCode || 502).json({ error: 'Failed to export artifact' });
   }
 });
 
@@ -293,3 +332,4 @@ router.get('/poller-status', (req, res) => {
 
 module.exports = router;
 module.exports.sanitizeFilename = sanitizeFilename;
+module.exports.sanitizeCsvCellValue = sanitizeCsvCellValue;

--- a/portal/routes/auth.js
+++ b/portal/routes/auth.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const bcrypt = require('bcryptjs');
+const rateLimit = require('express-rate-limit');
 const router = express.Router();
 
 const ADMIN_USERNAME = process.env.ADMIN_USERNAME || 'admin';
@@ -9,7 +10,15 @@ if (!ADMIN_PASSWORD_HASH) {
   console.warn('WARNING: ADMIN_PASSWORD_HASH not set. Generate one with: node -e "console.log(require(\'bcryptjs\').hashSync(\'yourpassword\', 12))"');
 }
 
-router.post('/login', express.json(), async (req, res) => {
+const loginLimiter = rateLimit({
+  windowMs: parseInt(process.env.LOGIN_RATE_LIMIT_WINDOW_MS, 10) || (15 * 60 * 1000),
+  max: parseInt(process.env.LOGIN_RATE_LIMIT_MAX_ATTEMPTS, 10) || 10,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: 'Too many login attempts. Please try again later.' },
+});
+
+router.post('/login', loginLimiter, express.json(), async (req, res) => {
   const { username, password } = req.body;
 
   if (!username || !password) {

--- a/portal/services/excel.js
+++ b/portal/services/excel.js
@@ -1,14 +1,27 @@
 const ExcelJS = require('exceljs');
 
-async function parseExcelBuffer(buffer) {
+const DEFAULT_PARSE_LIMITS = {
+  maxSheets: 25,
+  maxRowsPerSheet: 10000,
+  maxColsPerRow: 250,
+  maxTotalCells: 750000,
+};
+
+async function parseExcelBuffer(buffer, limits = DEFAULT_PARSE_LIMITS) {
   const workbook = new ExcelJS.Workbook();
   await workbook.xlsx.load(buffer);
 
   const sheets = [];
+  let totalCells = 0;
+
+  if (workbook.worksheets.length > limits.maxSheets) {
+    throw new Error(`Excel parse limit exceeded: too many sheets (${workbook.worksheets.length})`);
+  }
 
   workbook.eachSheet((worksheet) => {
     const rows = [];
     const merges = [];
+    let processedRows = 0;
 
     if (worksheet.merges) {
       for (const merge of Object.values(worksheet.merges)) {
@@ -17,8 +30,24 @@ async function parseExcelBuffer(buffer) {
     }
 
     worksheet.eachRow({ includeEmpty: true }, (row, rowNumber) => {
+      processedRows += 1;
+      if (processedRows > limits.maxRowsPerSheet) {
+        throw new Error(`Excel parse limit exceeded: too many rows in worksheet "${worksheet.name}"`);
+      }
+
       const cells = [];
+      let processedCols = 0;
       row.eachCell({ includeEmpty: true }, (cell, colNumber) => {
+        processedCols += 1;
+        if (processedCols > limits.maxColsPerRow) {
+          throw new Error(`Excel parse limit exceeded: too many columns in worksheet "${worksheet.name}"`);
+        }
+
+        totalCells += 1;
+        if (totalCells > limits.maxTotalCells) {
+          throw new Error('Excel parse limit exceeded: too many cells');
+        }
+
         let value = cell.value;
 
         if (value && typeof value === 'object') {

--- a/portal/services/github.js
+++ b/portal/services/github.js
@@ -3,14 +3,31 @@ const { Readable } = require('node:stream');
 const config = require('../config/default');
 
 const API_BASE = 'https://api.github.com';
+const REDIRECT_HOST_ALLOWLIST = [
+  'api.github.com',
+  'github.com',
+  'objects.githubusercontent.com',
+  'pipelines.actions.githubusercontent.com',
+  'productionresultssa0.blob.core.windows.net',
+  'productionresultssa1.blob.core.windows.net',
+  'productionresultssa2.blob.core.windows.net',
+];
 
-function makeHeaders() {
+function isAllowedRedirectHost(hostname) {
+  return REDIRECT_HOST_ALLOWLIST.includes(hostname);
+}
+
+function shouldAttachGithubAuth(hostname) {
+  return hostname === 'api.github.com';
+}
+
+function makeHeaders(hostname) {
   const headers = {
     'Accept': 'application/vnd.github+json',
     'User-Agent': 'LinetecReportPortal/1.0',
     'X-GitHub-Api-Version': '2022-11-28',
   };
-  if (config.github.token) {
+  if (config.github.token && shouldAttachGithubAuth(hostname)) {
     headers['Authorization'] = `Bearer ${config.github.token}`;
   }
   return headers;
@@ -19,11 +36,19 @@ function makeHeaders() {
 function request(urlPath, options = {}) {
   return new Promise((resolve, reject) => {
     const url = urlPath.startsWith('http') ? new URL(urlPath) : new URL(`${API_BASE}${urlPath}`);
+    if (url.protocol !== 'https:') {
+      return reject(new Error(`Refusing non-HTTPS request: ${url.protocol}`));
+    }
+
+    if (urlPath.startsWith('http') && !isAllowedRedirectHost(url.hostname)) {
+      return reject(new Error(`Blocked redirect to untrusted host: ${url.hostname}`));
+    }
+
     const reqOptions = {
       hostname: url.hostname,
       path: url.pathname + url.search,
       method: options.method || 'GET',
-      headers: { ...makeHeaders(), ...options.headers },
+      headers: { ...makeHeaders(url.hostname), ...options.headers },
     };
 
     const req = https.request(reqOptions, (res) => {
@@ -127,4 +152,8 @@ module.exports = {
   listRunArtifacts,
   downloadArtifact,
   getArtifactsByWorkRequest,
+  _internal: {
+    shouldAttachGithubAuth,
+    isAllowedRedirectHost,
+  },
 };

--- a/portal/tests/portal.test.js
+++ b/portal/tests/portal.test.js
@@ -176,6 +176,25 @@ describe('Excel service', () => {
     expect(csvRows[1]).toContain('"with, comma"');
     expect(csvRows[2]).toBe('Beta,2000,clean');
   });
+
+  it('enforces parse limits for oversized worksheets', async () => {
+    const ExcelJS = require('exceljs');
+    const excel = require('../services/excel');
+
+    const workbook = new ExcelJS.Workbook();
+    const sheet = workbook.addWorksheet('TooWide');
+    sheet.addRow(['a', 'b', 'c', 'd', 'e']);
+    const buffer = await workbook.xlsx.writeBuffer();
+
+    await expect(
+      excel.parseExcelBuffer(buffer, {
+        maxSheets: 5,
+        maxRowsPerSheet: 100,
+        maxColsPerRow: 3,
+        maxTotalCells: 500,
+      })
+    ).rejects.toThrow('Excel parse limit exceeded');
+  });
 });
 
 describe('sanitizeFilename', () => {
@@ -206,6 +225,37 @@ describe('sanitizeFilename', () => {
   it('blocks encoded traversal patterns after normalization', () => {
     expect(sanitizeFilename('folder/..%2f..%2fetc/passwd')).toBeUndefined();
     expect(sanitizeFilename('a/b/../../../c')).toBeUndefined();
+  });
+});
+
+describe('CSV export sanitization', () => {
+  const { sanitizeCsvCellValue } = require('../routes/api');
+
+  it('neutralizes spreadsheet formulas', () => {
+    expect(sanitizeCsvCellValue('=SUM(A1:A2)')).toBe("'=SUM(A1:A2)");
+    expect(sanitizeCsvCellValue('+2+3')).toBe("'+2+3");
+    expect(sanitizeCsvCellValue('-cmd')).toBe("'-cmd");
+    expect(sanitizeCsvCellValue('@NOW()')).toBe("'@NOW()");
+  });
+
+  it('preserves normal values', () => {
+    expect(sanitizeCsvCellValue('safe')).toBe('safe');
+    expect(sanitizeCsvCellValue('  42')).toBe('  42');
+  });
+});
+
+describe('GitHub redirect hardening helpers', () => {
+  const github = require('../services/github');
+
+  it('only attaches auth to api.github.com', () => {
+    expect(github._internal.shouldAttachGithubAuth('api.github.com')).toBe(true);
+    expect(github._internal.shouldAttachGithubAuth('github.com')).toBe(false);
+    expect(github._internal.shouldAttachGithubAuth('objects.githubusercontent.com')).toBe(false);
+  });
+
+  it('allows only trusted redirect hosts', () => {
+    expect(github._internal.isAllowedRedirectHost('objects.githubusercontent.com')).toBe(true);
+    expect(github._internal.isAllowedRedirectHost('evil.example.com')).toBe(false);
   });
 });
 


### PR DESCRIPTION
### Motivation
- Harden file/zip and Excel parsing to mitigate large/abusive artifacts and spreadsheet injection risks, and reduce attack surface for GitHub requests and authentication endpoints.

### Description
- Add zip and entry size/count limits and validation via `validateArtifactZip` and `validateZipEntry` and propagate appropriate HTTP status codes on failure in `portal/routes/api.js`.
- Add CSV cell sanitization via `sanitizeCsvCellValue` to neutralize formula injection when exporting Excel sheets to CSV and export the helper from the router module.
- Add limits for Excel parsing in `portal/services/excel.js` with `DEFAULT_PARSE_LIMITS` and checks for max sheets, rows, columns, and total cells to prevent excessive memory/CPU use.
- Harden GitHub service requests in `portal/services/github.js` by refusing non-HTTPS, restricting redirect targets to an allowlist, and only attaching auth to `api.github.com` requests; expose small `_internal` helpers for testing.
- Add login rate limiting to `portal/routes/auth.js` using `express-rate-limit` to throttle repeated login attempts.
- Fix a Supabase policy in `portal-v2/supabase/schema.sql` to ensure `activity_logs` inserts require the `user_id` to match the authenticated user or the requester to be an admin.

### Testing
- Updated and added unit tests in `portal/tests/portal.test.js` covering CSV sanitization, Excel parse limits, and GitHub redirect/auth helpers, and ran the project test suite with `npm test` against these cases.
- The automated unit tests that exercise the new CSV sanitization, parse-limit rejection, and GitHub helper behavior all succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de3f8fa75c8326b680fe7a53e63e35)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches security-sensitive paths (auth throttling, GitHub redirect/auth handling, and Supabase RLS), which could cause unexpected access/availability changes if misconfigured. Changes are bounded and covered by new unit tests, but impact production request/parse behavior.
> 
> **Overview**
> **Hardens artifact viewing/export against abusive inputs.** Adds zip-level and per-entry size/count limits for artifact zip handling, returns `413` on violations, and sanitizes CSV exports via `sanitizeCsvCellValue` to mitigate spreadsheet formula injection.
> 
> **Adds guardrails around parsing and outbound requests.** Enforces configurable Excel parse limits (sheets/rows/cols/total cells) to prevent resource exhaustion, tightens GitHub download redirect handling (HTTPS-only, allowlisted redirect hosts, and only attach auth to `api.github.com`), and rate-limits `/auth/login` attempts.
> 
> **Tightens data write permissions.** Updates Supabase `activity_logs` insert RLS policy to require `user_id` match the authenticated user (or admin).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 483a83c2b554520900a9448124dd8c4066d78ee4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->