### PR TITLE
claude/fix-workflow-secrets-error-LUzyw

### DIFF
--- a/.github/workflows/weekly-excel-generation.yml
+++ b/.github/workflows/weekly-excel-generation.yml
@@ -114,6 +114,10 @@ jobs:
       PYTHONUNBUFFERED: 1
       GITHUB_ACTIONS: 'true'
       SKIP_CELL_HISTORY: 'true'
+      # Exposed at job level so the Sentry release step's `if:` can reliably
+      # gate on its presence — step-level env is not guaranteed to be in scope
+      # during that step's own `if:` evaluation.
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -245,7 +249,6 @@ jobs:
         if: always() && env.SENTRY_AUTH_TOKEN != ''
         continue-on-error: true
         env:
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ vars.SENTRY_ORG || '' }}
           SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT_WORKFLOW || '' }}
         run: |

--- a/.github/workflows/weekly-excel-generation.yml
+++ b/.github/workflows/weekly-excel-generation.yml
@@ -242,7 +242,7 @@ jobs:
         run: python generate_weekly_pdfs.py
       
       - name: Create Sentry release (optional)
-        if: always() && secrets.SENTRY_AUTH_TOKEN
+        if: always() && env.SENTRY_AUTH_TOKEN != ''
         continue-on-error: true
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}


### PR DESCRIPTION
GitHub Actions disallows the `secrets` context in step `if:` expressions, which
caused the workflow to fail to queue with:
"Unrecognized named-value: 'secrets'" at line 245.

Check the token via step-level `env.SENTRY_AUTH_TOKEN` instead, which is the
supported pattern for conditionally running a step based on an optional secret.

https://claude.ai/code/session_015ianQ3LsfFrcwEk3WkdVzL

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small GitHub Actions expression-scope change that only affects whether the optional Sentry release step runs; no production code or data paths are modified.
> 
> **Overview**
> Prevents `.github/workflows/weekly-excel-generation.yml` from failing to parse by **removing `secrets.*` usage in the step-level `if:`** for the Sentry release.
> 
> The workflow now **exports `SENTRY_AUTH_TOKEN` at the job level** and runs the “Create Sentry release” step only when `env.SENTRY_AUTH_TOKEN` is non-empty, dropping the redundant step-level token env wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9ebbcfd5efc66e82a7647acc32d18861c56bfd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->