### PR TITLE
claude/fix-workflow-deprecation-uFi3u

### DIFF
--- a/.github/instructions/copilot-setup.instructions.md
+++ b/.github/instructions/copilot-setup.instructions.md
@@ -216,7 +216,7 @@ MAX_GROUPS=50 REGEN_WEEKS=081725,082425 RESET_WR_LIST=WR123,WR456
 **Configuration & Deployment:**
 - `.github/workflows/weekly-excel-generation.yml` - Production workflow with 10-input consolidation
 - `.env.example`, `.env.template`, `.env.audit.example` - Environment variable references
-- `requirements.txt` - Dependencies (sentry-sdk>=2.35.0, smartsheet-python-sdk==3.0.3, etc.)
+- `requirements.txt` - Dependencies (sentry-sdk>=2.35.0, smartsheet-python-sdk>=3.1.0, etc.)
 
 **Runtime Artifacts:**
 - `generated_docs/` - Output directory (safe to clear)

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -793,27 +793,44 @@ def discover_folder_sheets(client, folder_ids: list[int], label: str) -> set[int
                 sheets: list = []
                 subfolders: list = []
                 last_key = None
-                # Safety cap: guards against a misbehaving API that perpetually
-                # returns a non-falsy last_key, which would otherwise hang production.
-                max_pages = 1000
+                # Safety caps: guard against a misbehaving API that perpetually
+                # returns a non-falsy or repeated last_key, which would otherwise
+                # create a large API burst (amplifying Smartsheet 300 req/min limits).
+                max_pages = 100
+                pages_fetched = 0
+                page_start_time = time.monotonic()
+                seen_last_keys: set = set()
                 for _page_num in range(max_pages):
                     page = client.Folders.get_folder_children(
                         fid,
                         children_resource_types=["sheets", "folders"],
                         last_key=last_key,
                     )
+                    pages_fetched += 1
                     for item in getattr(page, 'data', None) or []:
                         if isinstance(item, _SmartsheetSheet):
                             sheets.append(item)
                         elif isinstance(item, _SmartsheetFolder):
                             subfolders.append(item)
-                    last_key = getattr(page, 'last_key', None)
-                    if not last_key:
+                    next_last_key = getattr(page, 'last_key', None)
+                    if not next_last_key:
                         break
+                    if next_last_key in seen_last_keys:
+                        elapsed = time.monotonic() - page_start_time
+                        logging.warning(
+                            f"⚠️ Repeated pagination token detected for {label} folder {fid}; "
+                            f"stopping after {pages_fetched} page(s) in {elapsed:.2f}s "
+                            f"with {len(sheets)} sheet(s)"
+                        )
+                        break
+                    seen_last_keys.add(next_last_key)
+                    last_key = next_last_key
                 else:
+                    elapsed = time.monotonic() - page_start_time
                     logging.warning(
                         f"⚠️ Pagination safety cap ({max_pages}) reached for {label} folder {fid}; "
-                        f"truncating results at {len(sheets)} sheet(s)"
+                        f"stopping after {pages_fetched} page(s) in {elapsed:.2f}s "
+                        f"with {len(sheets)} sheet(s)"
                     )
                 ids = {s.id for s in sheets}
                 span.set_data("folder_id", fid)

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -787,16 +787,32 @@ def discover_folder_sheets(client, folder_ids: list[int], label: str) -> set[int
             logging.warning(f"⚠️ Max folder recursion depth ({max_depth}) reached for {label} folder {fid}")
             return set()
         try:
-            with sentry_sdk.start_span(op="smartsheet.api", description=f"Get folder {fid} ({label} depth={depth})") as span:
-                folder = client.Folders.get_folder(fid)
-                sheets = getattr(folder, 'sheets', None) or []
+            with sentry_sdk.start_span(op="smartsheet.api", name=f"Get folder {fid} ({label} depth={depth})") as span:
+                from smartsheet.models.sheet import Sheet as _SmartsheetSheet
+                from smartsheet.models.folder import Folder as _SmartsheetFolder
+                sheets: list = []
+                subfolders: list = []
+                last_key = None
+                while True:
+                    page = client.Folders.get_folder_children(
+                        fid,
+                        children_resource_types=["sheets", "folders"],
+                        last_key=last_key,
+                    )
+                    for item in getattr(page, 'data', None) or []:
+                        if isinstance(item, _SmartsheetSheet):
+                            sheets.append(item)
+                        elif isinstance(item, _SmartsheetFolder):
+                            subfolders.append(item)
+                    last_key = getattr(page, 'last_key', None)
+                    if not last_key:
+                        break
                 ids = {s.id for s in sheets}
                 span.set_data("folder_id", fid)
                 span.set_data("sheets_found", len(sheets))
                 span.set_data("depth", depth)
             logging.info(f"{'  ' * depth}📂 Folder {fid} ({label}): found {len(sheets)} direct sheet(s)")
             # Recurse into subfolders to discover ALL sheets in the hierarchy
-            subfolders = getattr(folder, 'folders', None) or []
             for subfolder in subfolders:
                 sub_id = subfolder.id
                 sub_ids = _fetch_folder_recursive(sub_id, depth + 1, max_depth)
@@ -1786,7 +1802,7 @@ def get_all_source_rows(client, source_sheets):
                 # PERFORMANCE FIX: Use column_ids parameter to only fetch mapped columns
                 column_mapping = source['column_mapping']
                 required_column_ids = list(column_mapping.values())
-                with sentry_sdk.start_span(op="smartsheet.api", description=f"Fetch sheet {source['name']}") as api_span:
+                with sentry_sdk.start_span(op="smartsheet.api", name=f"Fetch sheet {source['name']}") as api_span:
                     sheet = client.Sheets.get_sheet(
                         source['id'], 
                         column_ids=required_column_ids
@@ -2894,7 +2910,7 @@ def create_target_sheet_map(client):
         Tuple of (target_map dict, target_sheet object) for reuse in cleanup.
     """
     try:
-        with sentry_sdk.start_span(op="smartsheet.api", description="Fetch target sheet for WR mapping") as span:
+        with sentry_sdk.start_span(op="smartsheet.api", name="Fetch target sheet for WR mapping") as span:
             target_sheet = client.Sheets.get_sheet(TARGET_SHEET_ID)
             span.set_data("target_sheet_id", TARGET_SHEET_ID)
             span.set_data("row_count", len(target_sheet.rows) if target_sheet.rows else 0)
@@ -3044,7 +3060,7 @@ def main():
         logging.info("📊 PHASE 1: Discovering source sheets...")
         logging.info(f"{'='*60}")
         sentry_add_breadcrumb("discovery", "Starting source sheet discovery")
-        with sentry_sdk.start_span(op="smartsheet.discovery", description="Discover and validate source sheets") as span:
+        with sentry_sdk.start_span(op="smartsheet.discovery", name="Discover and validate source sheets") as span:
             source_sheets = discover_source_sheets(client)
             span.set_data("sheets_discovered", len(source_sheets) if source_sheets else 0)
         
@@ -3060,7 +3076,7 @@ def main():
         logging.info(f"\n{'='*60}")
         logging.info("📋 PHASE 2: Fetching source data...")
         logging.info(f"{'='*60}")
-        with sentry_sdk.start_span(op="smartsheet.fetch_rows", description="Fetch all source rows from Smartsheet") as span:
+        with sentry_sdk.start_span(op="smartsheet.fetch_rows", name="Fetch all source rows from Smartsheet") as span:
             all_rows = get_all_source_rows(client, source_sheets)
             span.set_data("source_sheets_count", len(source_sheets))
             span.set_data("rows_fetched", len(all_rows) if all_rows else 0)
@@ -3081,7 +3097,7 @@ def main():
         if AUDIT_SYSTEM_AVAILABLE and not DISABLE_AUDIT_FOR_TESTING:
             try:
                 sentry_add_breadcrumb("audit", "Starting billing audit", data={"skip_cell_history": SKIP_CELL_HISTORY})
-                with sentry_sdk.start_span(op="audit.financial", description="Run billing audit on source data") as audit_span:
+                with sentry_sdk.start_span(op="audit.financial", name="Run billing audit on source data") as audit_span:
                     audit_system = BillingAudit(client, skip_cell_history=SKIP_CELL_HISTORY)
                     audit_results = audit_system.audit_financial_data(source_sheets, all_rows)
                     audit_span.set_data("risk_level", audit_results.get('summary', {}).get('risk_level', 'UNKNOWN'))
@@ -3111,14 +3127,14 @@ def main():
 
     # Group rows by work request and week ending
         logging.info("📂 Grouping data...")
-        with sentry_sdk.start_span(op="data.grouping", description="Group source rows by WR/week/variant") as span:
+        with sentry_sdk.start_span(op="data.grouping", name="Group source rows by WR/week/variant") as span:
             groups = group_source_rows(all_rows)
             span.set_data("input_rows", len(all_rows))
             span.set_data("groups_created", len(groups) if groups else 0)
 
         # Optional full/partial hash reset purge BEFORE processing groups if requested
         if RESET_HASH_HISTORY or RESET_WR_LIST:
-            with sentry_sdk.start_span(op="smartsheet.purge", description="Purge existing hashed outputs") as span:
+            with sentry_sdk.start_span(op="smartsheet.purge", name="Purge existing hashed outputs") as span:
                 if RESET_WR_LIST:
                     logging.info(f"🧨 Hash reset requested for specific WRs: {sorted(list(RESET_WR_LIST))}")
                     span.set_data("purge_type", "wr_subset")
@@ -3149,7 +3165,7 @@ def main():
         target_map = {}
         _target_sheet_obj = None  # Cached for cleanup to avoid redundant API call
         if not TEST_MODE:
-            with sentry_sdk.start_span(op="smartsheet.target_map", description="Create target sheet map for uploads") as span:
+            with sentry_sdk.start_span(op="smartsheet.target_map", name="Create target sheet map for uploads") as span:
                 target_map, _target_sheet_obj = create_target_sheet_map(client)
                 span.set_data("wr_count", len(target_map))
 
@@ -3158,7 +3174,7 @@ def main():
         # Each row's attachments are fetched once here instead of 2-3 times in the group loop.
         attachment_cache = {}  # row_id -> list of attachment objects
         if target_map and not TEST_MODE:
-            with sentry_sdk.start_span(op="smartsheet.attachment_prefetch", description="Pre-fetch row attachments") as span:
+            with sentry_sdk.start_span(op="smartsheet.attachment_prefetch", name="Pre-fetch row attachments") as span:
                 logging.info(f"🚀 Starting parallel attachment pre-fetch with {PARALLEL_WORKERS} workers for {len(target_map)} target rows...")
                 _att_start = datetime.datetime.now()
 
@@ -3298,7 +3314,7 @@ def main():
                             })
                 
                 # Generate Excel file with complete fixes
-                with sentry_sdk.start_span(op="excel.generate", description=f"Generate Excel for WR {wr_num}") as gen_span:
+                with sentry_sdk.start_span(op="excel.generate", name=f"Generate Excel for WR {wr_num}") as gen_span:
                     gen_span.set_data("group_key", group_key)
                     gen_span.set_data("row_count", len(group_rows))
                     gen_span.set_data("variant", variant)
@@ -3501,12 +3517,12 @@ def main():
         if not TEST_MODE:
             # Invalidate stale attachment cache after upload phase — uploads added/deleted attachments
             _cleanup_cache = attachment_cache if not _upload_tasks else None
-            with sentry_sdk.start_span(op="smartsheet.cleanup", description="Cleanup untracked sheet attachments"):
+            with sentry_sdk.start_span(op="smartsheet.cleanup", name="Cleanup untracked sheet attachments"):
                 cleanup_untracked_sheet_attachments(client, TARGET_SHEET_ID, valid_wr_weeks, TEST_MODE, attachment_cache=_cleanup_cache, target_sheet=_target_sheet_obj)
 
         # Cleanup legacy / stale Excel files so only current system outputs remain
         try:
-            with sentry_sdk.start_span(op="file.cleanup", description="Cleanup stale local Excel files"):
+            with sentry_sdk.start_span(op="file.cleanup", name="Cleanup stale local Excel files"):
                 removed = cleanup_stale_excels(OUTPUT_FOLDER, set(generated_filenames))
             logging.info(f"🧹 Cleanup complete: removed {len(removed)} stale file(s)")
         except Exception as e:

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -793,7 +793,10 @@ def discover_folder_sheets(client, folder_ids: list[int], label: str) -> set[int
                 sheets: list = []
                 subfolders: list = []
                 last_key = None
-                while True:
+                # Safety cap: guards against a misbehaving API that perpetually
+                # returns a non-falsy last_key, which would otherwise hang production.
+                max_pages = 1000
+                for _page_num in range(max_pages):
                     page = client.Folders.get_folder_children(
                         fid,
                         children_resource_types=["sheets", "folders"],
@@ -807,6 +810,11 @@ def discover_folder_sheets(client, folder_ids: list[int], label: str) -> set[int
                     last_key = getattr(page, 'last_key', None)
                     if not last_key:
                         break
+                else:
+                    logging.warning(
+                        f"⚠️ Pagination safety cap ({max_pages}) reached for {label} folder {fid}; "
+                        f"truncating results at {len(sheets)} sheet(s)"
+                    )
                 ids = {s.id for s in sheets}
                 span.set_data("folder_id", fid)
                 span.set_data("sheets_found", len(sheets))

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,8 @@
 sentry-sdk>=2.35.0
 
 # Core Dependencies
-smartsheet-python-sdk>=3.0.3
+# 3.1.0+ required for Folders.get_folder_children (replacement for deprecated get_folder)
+smartsheet-python-sdk>=3.1.0
 openpyxl==3.1.5
 Pillow==12.1.1
 python-dateutil==2.9.0.post0

--- a/tests/test_subcontractor_pricing.py
+++ b/tests/test_subcontractor_pricing.py
@@ -286,6 +286,45 @@ class TestDiscoverFolderSheets(unittest.TestCase):
         result = generate_weekly_pdfs.discover_folder_sheets(mock_client, [], 'test')
         self.assertEqual(result, set())
 
+    def test_discover_folder_sheets_paginates_last_key(self):
+        """Multi-page last_key pagination is followed until last_key is falsy."""
+        from unittest.mock import MagicMock
+        mock_client = MagicMock()
+        # Page 1 returns two sheets + a continuation token; page 2 returns one more and terminates.
+        mock_client.Folders.get_folder_children.side_effect = [
+            _make_children_page(sheet_ids=[301, 302], last_key='k1'),
+            _make_children_page(sheet_ids=[303], last_key=None),
+        ]
+
+        result = generate_weekly_pdfs.discover_folder_sheets(mock_client, [4242], 'test')
+        self.assertEqual(result, {301, 302, 303})
+        self.assertEqual(mock_client.Folders.get_folder_children.call_count, 2)
+        # The second call should forward the last_key from the first response.
+        second_kwargs = mock_client.Folders.get_folder_children.call_args_list[1].kwargs
+        self.assertEqual(second_kwargs.get('last_key'), 'k1')
+
+    def test_discover_folder_sheets_recurses_into_subfolders(self):
+        """Folder children returned as subfolders trigger recursive discovery."""
+        from unittest.mock import MagicMock
+        mock_client = MagicMock()
+
+        def _children(fid, **kwargs):
+            if fid == 10:
+                # Top folder has one sheet and one subfolder child
+                return _make_children_page(sheet_ids=[401], subfolder_ids=[11])
+            if fid == 11:
+                # Subfolder has two sheets and no further nesting
+                return _make_children_page(sheet_ids=[402, 403])
+            return _make_children_page()
+
+        mock_client.Folders.get_folder_children.side_effect = _children
+
+        result = generate_weekly_pdfs.discover_folder_sheets(mock_client, [10], 'test')
+        self.assertEqual(result, {401, 402, 403})
+        called_ids = [c.args[0] for c in mock_client.Folders.get_folder_children.call_args_list]
+        self.assertIn(10, called_ids)
+        self.assertIn(11, called_ids)
+
 
 class TestIdentityNormalization(unittest.TestCase):
     """Tests for the None vs '' identity comparison fix."""

--- a/tests/test_subcontractor_pricing.py
+++ b/tests/test_subcontractor_pricing.py
@@ -325,6 +325,47 @@ class TestDiscoverFolderSheets(unittest.TestCase):
         self.assertIn(10, called_ids)
         self.assertIn(11, called_ids)
 
+    def test_discover_folder_sheets_stops_on_repeated_last_key(self):
+        """A repeated last_key must short-circuit pagination to avoid an API burst."""
+        from unittest.mock import MagicMock
+        mock_client = MagicMock()
+        # A misbehaving API keeps returning the same continuation token forever.
+        # The discovery loop should stop after detecting the repeat rather than
+        # calling through to max_pages.
+        mock_client.Folders.get_folder_children.side_effect = [
+            _make_children_page(sheet_ids=[501], last_key='stuck'),
+            _make_children_page(sheet_ids=[502], last_key='stuck'),
+            _make_children_page(sheet_ids=[503], last_key='stuck'),
+        ]
+
+        result = generate_weekly_pdfs.discover_folder_sheets(mock_client, [7777], 'test')
+        # Sheets from pages fetched before the repeat-stop are preserved.
+        self.assertEqual(result, {501, 502})
+        # Exactly 2 calls: page 1 (token 'stuck' recorded), page 2 (token repeats → stop).
+        self.assertEqual(mock_client.Folders.get_folder_children.call_count, 2)
+
+    def test_discover_folder_sheets_stops_at_max_pages(self):
+        """Pagination must terminate at the 100-page safety cap."""
+        from unittest.mock import MagicMock
+        mock_client = MagicMock()
+        # Generate a unique last_key per call so the repeated-token guard never trips —
+        # only the max_pages ceiling can terminate the loop.
+        counter = {'n': 0}
+
+        def _children(fid, **kwargs):
+            counter['n'] += 1
+            return _make_children_page(
+                sheet_ids=[1000 + counter['n']],
+                last_key=f"token-{counter['n']}",
+            )
+
+        mock_client.Folders.get_folder_children.side_effect = _children
+
+        result = generate_weekly_pdfs.discover_folder_sheets(mock_client, [8888], 'test')
+        # Exactly max_pages (100) calls — not unbounded.
+        self.assertEqual(mock_client.Folders.get_folder_children.call_count, 100)
+        self.assertEqual(len(result), 100)
+
 
 class TestIdentityNormalization(unittest.TestCase):
     """Tests for the None vs '' identity comparison fix."""

--- a/tests/test_subcontractor_pricing.py
+++ b/tests/test_subcontractor_pricing.py
@@ -230,6 +230,19 @@ class TestRevertSubcontractorPrice(unittest.TestCase):
         self.assertAlmostEqual(result, 0.0)
 
 
+def _make_children_page(sheet_ids=(), subfolder_ids=(), last_key=None):
+    """Build a MagicMock paginated children result containing real Sheet/Folder instances."""
+    from unittest.mock import MagicMock
+    from smartsheet.models.sheet import Sheet
+    from smartsheet.models.folder import Folder
+    data = [Sheet({'id': sid, 'name': f'sheet-{sid}'}) for sid in sheet_ids]
+    data += [Folder({'id': fid, 'name': f'folder-{fid}'}) for fid in subfolder_ids]
+    page = MagicMock()
+    page.data = data
+    page.last_key = last_key
+    return page
+
+
 class TestDiscoverFolderSheets(unittest.TestCase):
     """Tests for folder-based sheet discovery."""
 
@@ -237,20 +250,19 @@ class TestDiscoverFolderSheets(unittest.TestCase):
         """Test discover_folder_sheets returns a set of ints."""
         from unittest.mock import MagicMock
         mock_client = MagicMock()
-        sheet1 = MagicMock(); sheet1.id = 111
-        sheet2 = MagicMock(); sheet2.id = 222
-        folder = MagicMock(); folder.sheets = [sheet1, sheet2]
-        mock_client.Folders.get_folder.return_value = folder
+        mock_client.Folders.get_folder_children.return_value = _make_children_page(sheet_ids=[111, 222])
 
         result = generate_weekly_pdfs.discover_folder_sheets(mock_client, [9999], 'test')
         self.assertEqual(result, {111, 222})
-        mock_client.Folders.get_folder.assert_called_once_with(9999)
+        mock_client.Folders.get_folder_children.assert_called_once()
+        call_args = mock_client.Folders.get_folder_children.call_args
+        self.assertEqual(call_args.args[0], 9999)
 
     def test_discover_folder_sheets_handles_api_error(self):
         """Test graceful handling when folder API call fails."""
         from unittest.mock import MagicMock
         mock_client = MagicMock()
-        mock_client.Folders.get_folder.side_effect = Exception("API error")
+        mock_client.Folders.get_folder_children.side_effect = Exception("API error")
 
         result = generate_weekly_pdfs.discover_folder_sheets(mock_client, [9999], 'test')
         self.assertEqual(result, set())
@@ -259,12 +271,10 @@ class TestDiscoverFolderSheets(unittest.TestCase):
         """Test discovery across multiple folder IDs with deduplication."""
         from unittest.mock import MagicMock
         mock_client = MagicMock()
-        sheet_a = MagicMock(); sheet_a.id = 100
-        sheet_b = MagicMock(); sheet_b.id = 200
-        sheet_c = MagicMock(); sheet_c.id = 100  # duplicate
-        folder1 = MagicMock(); folder1.sheets = [sheet_a, sheet_b]
-        folder2 = MagicMock(); folder2.sheets = [sheet_c]
-        mock_client.Folders.get_folder.side_effect = [folder1, folder2]
+        mock_client.Folders.get_folder_children.side_effect = [
+            _make_children_page(sheet_ids=[100, 200]),
+            _make_children_page(sheet_ids=[100]),  # duplicate 100
+        ]
 
         result = generate_weekly_pdfs.discover_folder_sheets(mock_client, [1, 2], 'test')
         self.assertEqual(result, {100, 200})

--- a/tests/test_vac_crew.py
+++ b/tests/test_vac_crew.py
@@ -36,41 +36,41 @@ class TestVacCrewSheetIdsConfig(unittest.TestCase):
             self.assertEqual(len(generate_weekly_pdfs.VAC_CREW_FOLDER_IDS), 0)
 
 
+def _make_children_page(sheet_ids=(), subfolder_ids=(), last_key=None):
+    """Build a MagicMock paginated children result containing real Sheet/Folder instances."""
+    from smartsheet.models.sheet import Sheet
+    from smartsheet.models.folder import Folder
+    data = [Sheet({'id': sid, 'name': f'sheet-{sid}'}) for sid in sheet_ids]
+    data += [Folder({'id': fid, 'name': f'folder-{fid}'}) for fid in subfolder_ids]
+    page = MagicMock()
+    page.data = data
+    page.last_key = last_key
+    return page
+
+
 class TestVacCrewFolderDiscovery(unittest.TestCase):
     """Tests for VAC Crew folder-based sheet discovery using discover_folder_sheets."""
 
     def test_vac_crew_folder_discovery_returns_ids(self):
         """discover_folder_sheets returns correct sheet IDs for vac_crew label."""
         mock_client = MagicMock()
-        sheet_a = MagicMock()
-        sheet_a.id = 5001
-        sheet_b = MagicMock()
-        sheet_b.id = 5002
-        folder = MagicMock()
-        folder.sheets = [sheet_a, sheet_b]
-        mock_client.Folders.get_folder.return_value = folder
+        mock_client.Folders.get_folder_children.return_value = _make_children_page(sheet_ids=[5001, 5002])
 
         result = generate_weekly_pdfs.discover_folder_sheets(mock_client, [8888], 'vac crew')
         self.assertEqual(result, {5001, 5002})
-        mock_client.Folders.get_folder.assert_called_once_with(8888)
+        mock_client.Folders.get_folder_children.assert_called_once()
+        self.assertEqual(mock_client.Folders.get_folder_children.call_args.args[0], 8888)
 
     def test_vac_crew_folder_discovery_multiple_folders(self):
         """discover_folder_sheets merges IDs across multiple VAC Crew folder IDs."""
         mock_client = MagicMock()
 
-        def _get_folder(fid):
-            folder = MagicMock()
+        def _children(fid, **kwargs):
             if fid == 1111:
-                s = MagicMock()
-                s.id = 5001
-                folder.sheets = [s]
-            else:
-                s = MagicMock()
-                s.id = 5002
-                folder.sheets = [s]
-            return folder
+                return _make_children_page(sheet_ids=[5001])
+            return _make_children_page(sheet_ids=[5002])
 
-        mock_client.Folders.get_folder.side_effect = _get_folder
+        mock_client.Folders.get_folder_children.side_effect = _children
 
         result = generate_weekly_pdfs.discover_folder_sheets(mock_client, [1111, 2222], 'vac crew')
         self.assertEqual(result, {5001, 5002})
@@ -80,12 +80,12 @@ class TestVacCrewFolderDiscovery(unittest.TestCase):
         mock_client = MagicMock()
         result = generate_weekly_pdfs.discover_folder_sheets(mock_client, [], 'vac crew')
         self.assertEqual(result, set())
-        mock_client.Folders.get_folder.assert_not_called()
+        mock_client.Folders.get_folder_children.assert_not_called()
 
     def test_vac_crew_folder_discovery_api_error_graceful(self):
         """discover_folder_sheets handles API errors gracefully for vac_crew folders."""
         mock_client = MagicMock()
-        mock_client.Folders.get_folder.side_effect = Exception("Smartsheet API error")
+        mock_client.Folders.get_folder_children.side_effect = Exception("Smartsheet API error")
 
         result = generate_weekly_pdfs.discover_folder_sheets(mock_client, [9999], 'vac crew')
         self.assertEqual(result, set())


### PR DESCRIPTION
- Swap client.Folders.get_folder for get_folder_children with pagination,
  filtering results into sheets/subfolders via isinstance checks so the
  recursive discovery logic is preserved.
- Replace deprecated `description=` keyword with `name=` in all
  sentry_sdk.start_span calls to silence SDK 2.x DeprecationWarnings.

https://claude.ai/code/session_0192gJk7Wxp5rVkYFQkc22vP

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Smartsheet folder discovery to a new paginated API with recursion/safety caps and bumps the SDK version, which could affect what sheets are discovered or increase API calls if misconfigured. Span keyword updates are low risk but touch broad instrumentation paths.
> 
> **Overview**
> Updates Smartsheet folder sheet discovery to use `Folders.get_folder_children` (with `last_key` pagination), while preserving recursive subfolder traversal and adding guards against repeated tokens and a 100-page safety cap to avoid runaway API bursts.
> 
> Replaces deprecated `sentry_sdk.start_span(..., description=...)` usage with `name=` across the workflow for Sentry SDK 2.x compatibility, bumps `smartsheet-python-sdk` to `>=3.1.0`, and expands tests to cover pagination, recursion, and safety-stop behavior in folder discovery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58a1d7a6c458bc87c4398eeab8e801eee3669430. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->