### PR TITLE
claude/fix-dependabot-vulnerabilities-TkhPt

### DIFF
--- a/portal-v2/package-lock.json
+++ b/portal-v2/package-lock.json
@@ -27,7 +27,7 @@
         "postcss": "^8.4.47",
         "tailwindcss": "^3.4.14",
         "typescript": "^5.6.3",
-        "vite": "^6.4.1"
+        "vite": "^6.4.2"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -3507,9 +3507,9 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/portal-v2/package.json
+++ b/portal-v2/package.json
@@ -29,6 +29,6 @@
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.14",
     "typescript": "^5.6.3",
-    "vite": "^6.4.1"
+    "vite": "^6.4.2"
   }
 }

--- a/portal/package-lock.json
+++ b/portal/package-lock.json
@@ -4544,9 +4544,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/portal/package.json
+++ b/portal/package.json
@@ -38,6 +38,7 @@
   "overrides": {
     "minimatch": "^10.2.3",
     "glob": "^11.0.0",
-    "rimraf": "^6.0.0"
+    "rimraf": "^6.0.0",
+    "vite": "^6.4.2"
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ sentry-sdk>=2.35.0
 # Core Dependencies
 smartsheet-python-sdk>=3.0.3
 openpyxl==3.1.5
-Pillow==12.1.1
+Pillow==12.2.0
 python-dateutil==2.9.0.post0
 python-dotenv==1.0.1
 
@@ -16,7 +16,7 @@ pandera==0.20.3
 psutil==6.0.0
 
 # Testing and Coverage
-pytest==8.3.3
+pytest==9.0.3
 pytest-cov==6.0.0
 
 # Notion Dashboard Integration (used by scripts/notion_sync.py)


### PR DESCRIPTION
- portal: add vite ^6.4.2 override to resolve transitive vite vuln
  via vitest (GHSA-4w7w-66w2-5vf9, GHSA-p9ff-h696-f583)
- portal-v2: bump vite ^6.4.1 -> ^6.4.2 (same advisories)
- requirements.txt: bump Pillow 12.1.1 -> 12.2.0 (CVE-2026-40192)
- requirements.txt: bump pytest 8.3.3 -> 9.0.3 (CVE-2025-71176)

All audits clean (npm audit, pip-audit). Portal vitest suite (30/30)
and Python pytest suite (80/80) pass; portal-v2 vite build succeeds.
No production code changes.

https://claude.ai/code/session_01SZ6x9itLPB8us3e3QqMyMn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only updates (build/test tooling and a Python library) with no code changes; main risk is potential build/test regressions from version bumps.
> 
> **Overview**
> Updates frontend tooling dependencies to remediate advisories: `portal-v2` bumps `vite` from `^6.4.1` to `^6.4.2`, and `portal` pins transitive `vite` via an `overrides` entry while updating lockfiles accordingly.
> 
> Updates Python dependencies in `requirements.txt` by bumping `Pillow` (`12.1.1` → `12.2.0`) and `pytest` (`8.3.3` → `9.0.3`) for security fixes; no application/runtime logic changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d6ae5d39acd6ed062d3e95df353c118fa13fac3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->