### PR TITLE
Fix Docusaurus broken-link warnings by adding / redirect

### DIFF
--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { Redirect } from '@docusaurus/router';
+
+export default function Home(): React.JSX.Element {
+  return <Redirect to="/docs/" />;
+}

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -2,5 +2,5 @@ import React from 'react';
 import { Redirect } from '@docusaurus/router';
 
 export default function Home(): React.JSX.Element {
-  return <Redirect to="/docs/" />;
+  return <Redirect to="/docs" />;
 }


### PR DESCRIPTION
## Summary

- Adds `website/src/pages/index.tsx` — a 6-line component that redirects `/` → `/docs/` via `@docusaurus/router`.
- Silences the eight `Broken link on source page path = /docs/runbook/* -> linking to /` warnings the Vercel build has been emitting on every deploy.

## Why

The navbar title defaults to linking to `baseUrl` (`/`). But `docs/intro.md` has `slug: /` and the docs plugin keeps its default `routeBasePath` of `/docs`, so intro lives at `/docs/` and nothing was served at `/`. Every doc page renders the navbar, so every doc page reported a broken link to `/`.

Making `/` a real route by adding a minimal redirect is the least-invasive fix: no URL changes, no config edits, no sidebar or markdown edits, no touching of the `portal/` or `portal-v2/` Vercel projects.

## What was NOT touched

- `website/docusaurus.config.ts`, `website/sidebars.ts`, any doc markdown
- `website/vercel.json`, `portal-v2/`, `portal/`
- GitHub workflows, `package.json`, lockfiles
- `onBrokenLinks` / `onBrokenMarkdownLinks` stay at `'warn'`

## Test plan

- [x] `cd website && npm ci && npm run build` — local build completes with **zero** `Broken link on source page path` warnings (previously emitted 8)
- [ ] Wait for `excel-website-documentation-runbook` Vercel preview to go Ready on this PR
- [ ] Confirm the preview's Vercel build log is free of broken-link warnings
- [ ] Visit the preview root URL and confirm it redirects to `/docs/`
- [ ] Confirm existing URLs (`/docs/runbook/workflows`, `/docs/reference/environment`, `/blog`) still resolve unchanged

https://claude.ai/code/session_01LixB2GJL53WvKpvMJDiEbV

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a single route-level redirect with minimal logic and no changes to build config, content, or data handling; risk is limited to potential unexpected root URL behavior.
> 
> **Overview**
> Adds a new Docusaurus page at `website/src/pages/index.tsx` to make `/` a real route that **redirects to** `/docs` via `@docusaurus/router`.
> 
> This is intended to eliminate broken-link warnings from navigation links pointing at the site root while keeping existing docs URLs unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87a11cddbd1ddb3ec172cdc5e1cfb691f9c5b747. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->