### PR TITLE
Standardize Sentry release naming across workflows

### DIFF
--- a/.github/workflows/system-health-check.yml
+++ b/.github/workflows/system-health-check.yml
@@ -22,10 +22,15 @@ jobs:
       SMARTSHEET_API_TOKEN: ${{ secrets.SMARTSHEET_API_TOKEN }}
       SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
       SENTRY_ENVIRONMENT: production
-      SENTRY_RELEASE: ${{ github.repository }}@${{ github.sha }}
+      # SENTRY_RELEASE is exported slash-free via $GITHUB_ENV in the
+      # "Compute Sentry release" step below — Sentry rejects slashes in
+      # release versions, so we sanitize `owner/repo` to `owner-repo`.
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Compute Sentry release
+        run: echo "SENTRY_RELEASE=${GITHUB_REPOSITORY//\//-}@${GITHUB_SHA}" >> "$GITHUB_ENV"
       
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/weekly-excel-generation.yml
+++ b/.github/workflows/weekly-excel-generation.yml
@@ -121,6 +121,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Compute Sentry release
+        # Sentry release versions disallow slashes, so sanitize the
+        # `owner/repo` form into `owner-repo` before composing the
+        # release tag. This must run before any step that references
+        # $SENTRY_RELEASE (Python job env below and the sentry-cli
+        # release step further down) so both use an identical value.
+        run: echo "SENTRY_RELEASE=${GITHUB_REPOSITORY//\//-}@${GITHUB_SHA}" >> "$GITHUB_ENV"
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -187,7 +194,10 @@ jobs:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           ENVIRONMENT: production
           RELEASE: ${{ github.sha }}
-          SENTRY_RELEASE: ${{ github.repository }}@${{ github.sha }}
+          # SENTRY_RELEASE is exported slash-free via $GITHUB_ENV in the
+          # "Compute Sentry release" step above so it satisfies Sentry's
+          # version constraints and matches the tag used by the
+          # sentry-cli release step below.
           EXECUTION_TYPE: ${{ steps.exec.outputs.execution_type }}
           
           # Basic Operation Controls
@@ -252,7 +262,11 @@ jobs:
           SENTRY_ORG: ${{ vars.SENTRY_ORG || '' }}
           SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT_WORKFLOW || '' }}
         run: |
-          RELEASE="${{ github.repository }}@${{ github.sha }}"
+          # Sentry release versions cannot contain slashes; reuse the
+          # sanitized SENTRY_RELEASE exported by the "Compute Sentry
+          # release" step so the CLI-created release matches the tag
+          # the Python process reports events against.
+          RELEASE="$SENTRY_RELEASE"
           npx --yes @sentry/cli releases new "$RELEASE"
           npx --yes @sentry/cli releases set-commits "$RELEASE" --auto
           npx --yes @sentry/cli releases finalize "$RELEASE"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -303,3 +303,15 @@ When proposing new workflows, dynamically evaluate the absolute best technology.
   architecture, conventions, guardrails, validation commands — with
   `uv` flagged aspirational and `pytest tests/ -v` kept authoritative)
   while preserving every pre-existing section verbatim.
+- [2026-04-20 00:00] Sentry release naming in GitHub Actions: release
+  versions must be slash-free or `sentry-cli releases new` fails with
+  `Invalid release version`. Standardized on composing
+  `SENTRY_RELEASE` via a "Compute Sentry release" step that exports
+  `${GITHUB_REPOSITORY//\//-}@${GITHUB_SHA}` into `$GITHUB_ENV`, then
+  reusing that single value for both the Python process and the
+  `sentry-cli` release step. Applied in
+  `.github/workflows/weekly-excel-generation.yml` and
+  `.github/workflows/system-health-check.yml`. Any new workflow that
+  creates a Sentry release or tags events with `SENTRY_RELEASE` MUST
+  follow this same pattern — do not reintroduce the raw
+  `${{ github.repository }}@${{ github.sha }}` form.


### PR DESCRIPTION
## Summary
Fixed Sentry release version naming to comply with Sentry's constraints by removing slashes from the `owner/repo` format. Standardized the approach across workflows to ensure consistency between Python event reporting and `sentry-cli` release creation.

## Changes
- **Added "Compute Sentry release" step** in both `weekly-excel-generation.yml` and `system-health-check.yml` workflows that sanitizes `$GITHUB_REPOSITORY` (converting slashes to hyphens) and exports `SENTRY_RELEASE` to `$GITHUB_ENV` before any step that references it
- **Updated Python job environment** in `weekly-excel-generation.yml` to reference the computed `SENTRY_RELEASE` from `$GITHUB_ENV` instead of inline template syntax
- **Updated sentry-cli release step** in `weekly-excel-generation.yml` to reuse the computed `SENTRY_RELEASE` environment variable instead of composing it inline
- **Added documentation** in `CLAUDE.md` establishing the pattern as a requirement for all future workflows that use Sentry

## Implementation Details
The root issue: `sentry-cli releases new` fails with "Invalid release version" when the version string contains slashes. The solution computes a slash-free release identifier once at the start of each workflow using bash parameter expansion (`${GITHUB_REPOSITORY//\//-}`), exports it to the workflow environment, and reuses that single value across all steps. This ensures both the Python process and `sentry-cli` commands reference identical release versions while satisfying Sentry's naming constraints.

https://claude.ai/code/session_011HSJMFxqcmXwKrNqAXE2E2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change, but it affects Sentry event/release attribution and could disable release creation if the env var isn’t exported as expected.
> 
> **Overview**
> Standardizes GitHub Actions Sentry release naming to avoid `sentry-cli` failures on `owner/repo` values containing slashes.
> 
> Both `weekly-excel-generation.yml` and `system-health-check.yml` now add a **"Compute Sentry release"** step that exports `SENTRY_RELEASE=${GITHUB_REPOSITORY//\//-}@${GITHUB_SHA}` via `$GITHUB_ENV`, and the weekly workflow reuses that same value for the Python run and the `sentry-cli` release creation.
> 
> Documents this as the required pattern for future workflows in `CLAUDE.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff241854e7d419d7a6242763413b78913719c870. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->