### PR TITLE
Update documentation site URL to excel-website-documentation-runbook

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -7,7 +7,7 @@ const config: Config = {
   tagline: 'Living documentation for the Smartsheet Weekly PDF Generator',
   favicon: 'img/favicon.ico',
 
-  url: process.env.DOCS_SITE_URL ?? 'https://weekly-pdfs-runbook.vercel.app',
+  url: process.env.DOCS_SITE_URL ?? 'https://excel-website-documentation-runbook.vercel.app',
   baseUrl: '/',
 
   // Must match vercel.json's `"trailingSlash": false`. If these disagree, the


### PR DESCRIPTION
## Summary
Updated the default documentation site URL to reflect a change in the project's hosting or naming convention.

## Changes
- Updated the default `DOCS_SITE_URL` from `https://weekly-pdfs-runbook.vercel.app` to `https://excel-website-documentation-runbook.vercel.app` in the Docusaurus configuration

## Details
This change updates the fallback URL used when the `DOCS_SITE_URL` environment variable is not set. The new URL better reflects the current project scope and documentation purpose. The environment variable override remains in place, allowing for flexible deployment configurations.

https://claude.ai/code/session_012DFfqn2jyiaMnCztzCmTGS

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes the fallback `url` in `website/docusaurus.config.ts` when `DOCS_SITE_URL` is not set, affecting canonical/absolute link generation for the docs site.
> 
> **Overview**
> Updates the Docusaurus config to use `https://excel-website-documentation-runbook.vercel.app` as the default site `url` fallback (when `DOCS_SITE_URL` isn’t provided), replacing the previous `weekly-pdfs-runbook` Vercel domain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ed10de98d18ba92b7a2c00b5dba52027fb6036c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->