### PR TITLE
Fix VAC crew post-cutoff pricing lag with rate recalc fallback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -349,3 +349,50 @@ When proposing new workflows, dynamically evaluate the absolute best technology.
   (`event_level=logging.ERROR`, so only ERROR+ creates issues;
   INFO/WARNING were already breadcrumbs and become searchable Logs
   only when the gate is on and the sanitizer lets them through).
+- [2026-04-21 22:35] VAC crew post-cutoff pricing lag was a *silent
+  fall-through* in `recalculate_row_price()`, not a cutoff-column
+  bug. **Context:** The cutoff rule is correctly keyed on
+  `Snapshot Date >= RATE_CUTOFF_DATE` at
+  `generate_weekly_pdfs.py:2127`; Weekly Reference Logged Date is
+  the wrong column for this check and must NOT be substituted —
+  operators depend on Snapshot Date semantics. **Real root cause:**
+  `build_cu_to_group_mapping()` reads the old CSV's
+  `Compatible Unit Group` column, which mixes short codes (e.g.
+  `ANC-M`, `CPD-SW`) with verbose names (e.g. `Vacuum Switch`,
+  `Overhead Switching"`, `Softswitch Type K"`, `1200 KVAR Switched
+  Bank`). The new contract CSV keys rates ONLY by short codes. So
+  any CU whose old-CSV group is a verbose name that isn't a key in
+  the new rates table (heavily concentrated on VAC crew specialty
+  work — vacuum switches, softswitches, switched banks) hit the
+  "group not in rates_dict" branch in `recalculate_row_price` and
+  returned the SmartSheet price unchanged with only a
+  `logging.debug` — invisible in production logs. **Fix (additive,
+  production-safe):** (1) In `recalculate_row_price` at the
+  "group not in rates_dict" branch, fall back to a direct CU-code
+  lookup in `rates_dict` before giving up; only activates on exact
+  match so it cannot mis-apply a rate. (2) When even the direct CU
+  lookup misses, elevate the log to WARNING with CU, mapped group,
+  qty, and work type so operators see it immediately. (3) Track
+  `{'recalculated', 'skipped'}` counters and a top-CU Counter per
+  sheet inside `_fetch_and_process_sheet`, and emit a per-sheet
+  WARNING summary when any skips happened — this surfaces the list
+  of CU codes the data team needs to add to
+  `NEW_RATES_CSV` / `New Contract Rates copy regenerated again.csv`
+  (the usual actual resolution). **New rules:** (1) When adding a
+  new CU classification (VAC crew, subcontractor variant, etc.),
+  verify at least one end-to-end row produces a WARNING-free rate
+  recalc before going to production — if the per-sheet summary
+  logs `N skipped`, those CUs are missing from the new rates CSV.
+  (2) Do NOT change the cutoff column from `Snapshot Date` to
+  `Weekly Reference Logged Date` — that was an earlier speculative
+  fix and was rolled back; the business rule is explicitly
+  snapshot-keyed. (3) Never promote recalc fall-through logs back
+  to DEBUG without adding an alternate visibility path — silent
+  price retention directly drives billing inaccuracy. Regression
+  tests:
+  `tests/test_subcontractor_pricing.py::TestRecalculateRowPrice`
+  now covers both the CU-direct fallback
+  (`test_cu_direct_fallback_when_mapped_group_absent_from_new_rates`)
+  and the safety guard that still retains SmartSheet price when
+  neither group nor CU is in new rates
+  (`test_silent_fallthrough_when_neither_group_nor_cu_in_new_rates`).

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -945,9 +945,7 @@ def revert_subcontractor_price(row_data, original_rates):
     """
     price_val = parse_price(row_data.get('Units Total Price'))
 
-    cu_code = str(row_data.get('CU Helper') or row_data.get('CU') or row_data.get('Billable Unit Code') or '').strip().upper()
-    if cu_code == 'NAN':
-        cu_code = str(row_data.get('CU') or '').strip().upper()
+    cu_code = _resolve_cu_code(row_data)
 
     work_type_raw = str(row_data.get('Work Type') or '').strip().lower()
 
@@ -2238,9 +2236,16 @@ def get_all_source_rows(client, source_sheets):
                                             # excluded so the summary WARNING
                                             # and top-CU list stay accurate.
                                             sheet_rate_recalc_counts['skipped'] += 1
-                                            cu_val = _resolve_cu_code(row_data)
-                                            if cu_val:
-                                                sheet_rate_recalc_skipped_cus[cu_val] += 1
+                                            # Always attribute the skip to a
+                                            # CU bucket so the per-sheet
+                                            # "N skipped / Top CUs: ..."
+                                            # summary totals stay aligned.
+                                            # Blank CU rows are attributed to
+                                            # '<blank>' so operators can see
+                                            # that category and investigate
+                                            # the missing CU code separately.
+                                            cu_val = _resolve_cu_code(row_data) or '<blank>'
+                                            sheet_rate_recalc_skipped_cus[cu_val] += 1
 
                         price_raw = row_data.get('Units Total Price')
                         has_price = (price_raw not in (None, "", "$0", "$0.00", "0", "0.0")) and price_val > 0

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -2200,6 +2200,7 @@ def get_all_source_rows(client, source_sheets):
                         # recalculation until a separate subcontractor cutoff date is
                         # provided. They keep SmartSheet pricing as-is for now.
                         _rate_recalc_ran_for_row = False
+                        _recalc_outcome = None
                         if RATE_CUTOFF_DATE and _rate_new_primary and not is_subcontractor_sheet:
                             snapshot_raw_pre = row_data.get('Snapshot Date')
                             if snapshot_raw_pre:
@@ -2404,16 +2405,25 @@ def get_all_source_rows(client, source_sheets):
                                 )
                                 if _is_specialized:
                                     _variant_tag = 'VAC crew' if (_vc_helping and _vc_completed) else 'helper'
-                                    # Only mention rate recalc when it actually
-                                    # ran for this row. The drop can fire when
-                                    # RATE_CUTOFF_DATE is unset, the row is
-                                    # pre-cutoff, Snapshot Date is blank, or
-                                    # the sheet is a subcontractor sheet — in
-                                    # all of which cases recalc was bypassed,
-                                    # not "failed".
+                                    # Only point operators at the per-sheet
+                                    # "Rate recalc summary" WARNING when that
+                                    # summary will actually contain this row:
+                                    # the summary is emitted only when at
+                                    # least one row in the sheet has outcome
+                                    # 'missing_rate', so the note is valid
+                                    # exactly when this row's outcome is
+                                    # 'missing_rate'. For other outcomes
+                                    # ('invalid_quantity', 'zero_rate', or
+                                    # recalc-bypassed rows where
+                                    # RATE_CUTOFF_DATE is unset, pre-cutoff,
+                                    # Snapshot Date blank, or subcontractor
+                                    # sheet), skip the breadcrumb so we
+                                    # don't send operators hunting for a
+                                    # summary line that isn't there.
                                     _recalc_note = (
-                                        " Rate recalc also ran; see 'Rate recalc summary' WARNING for the CU that could not be priced."
-                                        if _rate_recalc_ran_for_row else ""
+                                        " Rate recalc ran and reported no matching new-contract rate for this CU; see 'Rate recalc summary' WARNING on this sheet for the full CU list."
+                                        if _rate_recalc_ran_for_row and _recalc_outcome == 'missing_rate'
+                                        else ""
                                     )
                                     logging.warning(
                                         f"⚠️ Dropped {_variant_tag} row (price missing or zero): "

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -810,7 +810,27 @@ def load_rate_versions():
     return cu_to_group, new_rates_primary, new_rates_arrowhead, rates_fingerprint
 
 
-def recalculate_row_price(row_data, cu_to_group, rates_dict):
+def _resolve_cu_code(row_data):
+    """Return the CU code for a row using the same priority chain as
+    ``recalculate_row_price`` and ``revert_subcontractor_price``.
+
+    Resolution order: ``CU Helper`` → ``CU`` → ``Billable Unit Code``,
+    with the sentinel string ``'NAN'`` (produced by pandas when a float
+    NaN is stringified) falling back to ``CU``. Returns an uppercased,
+    stripped string (possibly empty if no column yields a value).
+    """
+    cu_code = str(
+        row_data.get('CU Helper')
+        or row_data.get('CU')
+        or row_data.get('Billable Unit Code')
+        or ''
+    ).strip().upper()
+    if cu_code == 'NAN':
+        cu_code = str(row_data.get('CU') or '').strip().upper()
+    return cu_code
+
+
+def recalculate_row_price(row_data, cu_to_group, rates_dict, *, out_status=None):
     """Recalculate a row's price using new contract rates.
 
     Looks up the CU code, maps it to its Compatible Unit Group, then
@@ -821,16 +841,34 @@ def recalculate_row_price(row_data, cu_to_group, rates_dict):
         row_data: Dict of row field values (modified in-place).
         cu_to_group: Dict mapping detailed CU codes to group codes.
         rates_dict: Dict mapping group codes to {install, removal, transfer} rates.
+        out_status: Optional dict that, when provided, receives an
+            ``'outcome'`` key describing why the function returned:
+              * ``'recalculated'`` — a rate was successfully applied
+                (the returned price may still equal the original
+                SmartSheet price if the computed rate × qty matches it
+                exactly; lookup succeeded either way).
+              * ``'missing_rate'`` — neither the mapped group nor the
+                CU code is present in ``rates_dict``; SmartSheet price
+                retained. This is the only outcome the per-sheet
+                "skipped" summary counts toward, because it is the
+                actionable signal that ``NEW_RATES_CSV`` needs a new
+                entry.
+              * ``'invalid_quantity'`` — quantity is zero/missing/
+                unparseable; SmartSheet price retained.
+              * ``'zero_rate'`` — new rate for the resolved work type
+                is zero; SmartSheet price retained.
 
     Returns:
         float: The (possibly recalculated) price value.
     """
+    def _set_status(s):
+        if out_status is not None:
+            out_status['outcome'] = s
+
     price_val = parse_price(row_data.get('Units Total Price'))
 
     # Resolve CU code (same chain as revert_subcontractor_price)
-    cu_code = str(row_data.get('CU Helper') or row_data.get('CU') or row_data.get('Billable Unit Code') or '').strip().upper()
-    if cu_code == 'NAN':
-        cu_code = str(row_data.get('CU') or '').strip().upper()
+    cu_code = _resolve_cu_code(row_data)
 
     # Map detailed CU code to group code
     group_code = cu_to_group.get(cu_code)
@@ -840,6 +878,7 @@ def recalculate_row_price(row_data, cu_to_group, rates_dict):
             group_code = cu_code
         else:
             logging.debug(f"Rate recalculation: CU '{cu_code}' not found in CU-to-group mapping or rates, keeping SmartSheet price")
+            _set_status('missing_rate')
             return price_val
 
     # If the mapped group isn't in the new rates table (e.g. old CSV maps
@@ -855,6 +894,7 @@ def recalculate_row_price(row_data, cu_to_group, rates_dict):
             group_code = cu_code
         else:
             logging.warning(f"Rate recalculation SKIPPED: CU '{cu_code}' maps to group '{group_code}' but neither is in new rates — keeping SmartSheet price (Qty={row_data.get('Quantity')}, Work Type={row_data.get('Work Type')})")
+            _set_status('missing_rate')
             return price_val
 
     # Determine work type
@@ -874,15 +914,18 @@ def recalculate_row_price(row_data, cu_to_group, rates_dict):
 
     if qty <= 0:
         logging.debug(f"Rate recalculation: quantity '{qty_str}' is zero/missing for CU '{cu_code}', keeping SmartSheet price")
+        _set_status('invalid_quantity')
         return price_val
 
     rate = rates_dict[group_code].get(wt_key, 0.0)
     if rate <= 0:
         logging.debug(f"Rate recalculation: rate is zero for group '{group_code}' work type '{wt_key}', keeping SmartSheet price")
+        _set_status('zero_rate')
         return price_val
 
     new_price = round(rate * qty, 2)
     row_data['Units Total Price'] = new_price
+    _set_status('recalculated')
     return new_price
 
 
@@ -2156,6 +2199,7 @@ def get_all_source_rows(client, source_sheets):
                         # NOTE: Subcontractor (Arrowhead) sheets are EXCLUDED from
                         # recalculation until a separate subcontractor cutoff date is
                         # provided. They keep SmartSheet pricing as-is for now.
+                        _rate_recalc_ran_for_row = False
                         if RATE_CUTOFF_DATE and _rate_new_primary and not is_subcontractor_sheet:
                             snapshot_raw_pre = row_data.get('Snapshot Date')
                             if snapshot_raw_pre:
@@ -2164,19 +2208,36 @@ def get_all_source_rows(client, source_sheets):
                                     snap_date_pre = snap_dt_pre.date() if hasattr(snap_dt_pre, 'date') else snap_dt_pre
                                     if snap_date_pre >= RATE_CUTOFF_DATE:
                                         old_price = price_val
-                                        price_val = recalculate_row_price(row_data, _rate_cu_to_group, _rate_new_primary)
-                                        if price_val != old_price:
+                                        _recalc_status = {}
+                                        price_val = recalculate_row_price(
+                                            row_data,
+                                            _rate_cu_to_group,
+                                            _rate_new_primary,
+                                            out_status=_recalc_status,
+                                        )
+                                        _rate_recalc_ran_for_row = True
+                                        _recalc_outcome = _recalc_status.get('outcome')
+                                        if _recalc_outcome == 'recalculated':
                                             sheet_rate_recalc_counts['recalculated'] += 1
-                                            logging.debug(f"Rate recalc: CU={row_data.get('CU')}, "
-                                                          f"old=${old_price:.2f} -> new=${price_val:.2f}, "
-                                                          f"date={snap_date_pre}")
-                                        else:
-                                            # Post-cutoff row silently kept original
-                                            # SmartSheet price because recalc could
-                                            # not find a matching rate. Track so
-                                            # the per-sheet summary can surface it.
+                                            if price_val != old_price:
+                                                logging.debug(f"Rate recalc: CU={row_data.get('CU')}, "
+                                                              f"old=${old_price:.2f} -> new=${price_val:.2f}, "
+                                                              f"date={snap_date_pre}")
+                                        elif _recalc_outcome == 'missing_rate':
+                                            # Only count as "skipped" in the
+                                            # per-sheet summary when recalc
+                                            # explicitly reported that neither
+                                            # the mapped group nor the CU code
+                                            # is in the new rates table — that
+                                            # is the actionable signal for
+                                            # updating NEW_RATES_CSV. Outcomes
+                                            # like 'invalid_quantity' /
+                                            # 'zero_rate' are data-entry or
+                                            # contract gaps and are intentionally
+                                            # excluded so the summary WARNING
+                                            # and top-CU list stay accurate.
                                             sheet_rate_recalc_counts['skipped'] += 1
-                                            cu_val = str(row_data.get('CU') or row_data.get('Billable Unit Code') or '').strip().upper()
+                                            cu_val = _resolve_cu_code(row_data)
                                             if cu_val:
                                                 sheet_rate_recalc_skipped_cus[cu_val] += 1
 
@@ -2343,15 +2404,26 @@ def get_all_source_rows(client, source_sheets):
                                 )
                                 if _is_specialized:
                                     _variant_tag = 'VAC crew' if (_vc_helping and _vc_completed) else 'helper'
+                                    # Only mention rate recalc when it actually
+                                    # ran for this row. The drop can fire when
+                                    # RATE_CUTOFF_DATE is unset, the row is
+                                    # pre-cutoff, Snapshot Date is blank, or
+                                    # the sheet is a subcontractor sheet — in
+                                    # all of which cases recalc was bypassed,
+                                    # not "failed".
+                                    _recalc_note = (
+                                        " Rate recalc also ran; see 'Rate recalc summary' WARNING for the CU that could not be priced."
+                                        if _rate_recalc_ran_for_row else ""
+                                    )
                                     logging.warning(
                                         f"⚠️ Dropped {_variant_tag} row (price missing or zero): "
                                         f"WR={wr_key_for_diag}, Weekly={weekly_date}, "
                                         f"Snapshot={row_data.get('Snapshot Date') or '<blank>'}, "
-                                        f"CU={row_data.get('CU') or row_data.get('Billable Unit Code') or '<blank>'}, "
+                                        f"CU={_resolve_cu_code(row_data) or '<blank>'}, "
                                         f"Qty={row_data.get('Quantity') or '<blank>'}, "
                                         f"SmartSheet price={row_data.get('Units Total Price') or '<blank>'}. "
-                                        f"Row has VAC/helper criteria checked but Units Total Price is zero/blank and "
-                                        f"rate recalc could not price it (see 'Rate recalc summary' WARNING for reason)."
+                                        f"Row has VAC/helper criteria checked but Units Total Price is zero/blank."
+                                        f"{_recalc_note}"
                                     )
 
                     sheet_row_counter += 1

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -22,6 +22,32 @@ import logging
 from dateutil import parser
 import smartsheet
 import smartsheet.exceptions as ss_exc
+
+# Upstream SDK workaround: smartsheet-python-sdk 3.8.0 raises an
+# AttributeError from smartsheet.smartsheet.Smartsheet._request_with_retry
+# whenever the API returns a retryable error (429, 5xx). At
+# smartsheet/smartsheet.py:303 it does
+# ``getattr(sys.modules[__name__], native.result.name)`` to look up the
+# exception class to raise, but that module's top-level imports only
+# expose ApiError / HttpError / UnexpectedRequestError. The retryable
+# exception classes (RateLimitExceededError, UnexpectedErrorShouldRetry-
+# Error, InternalServerError, ServerTimeoutExceededError, SystemMainte-
+# nanceError) live in smartsheet.exceptions and were never re-exported
+# into smartsheet.smartsheet, so the getattr fails and our retry
+# wrapper never gets the real exception. Re-export the missing names
+# here so the SDK's internal lookup succeeds. The ``if not hasattr``
+# guard makes this a no-op if the upstream SDK ever re-exports them.
+import smartsheet.smartsheet as _ss_smartsheet_module
+for _exc_name in (
+    'RateLimitExceededError',
+    'UnexpectedErrorShouldRetryError',
+    'InternalServerError',
+    'ServerTimeoutExceededError',
+    'SystemMaintenanceError',
+):
+    if not hasattr(_ss_smartsheet_module, _exc_name) and hasattr(ss_exc, _exc_name):
+        setattr(_ss_smartsheet_module, _exc_name, getattr(ss_exc, _exc_name))
+del _ss_smartsheet_module, _exc_name
 import openpyxl
 from openpyxl.styles import Font, numbers, Alignment, PatternFill
 from openpyxl.drawing.image import Image
@@ -2297,6 +2323,36 @@ def get_all_source_rows(client, source_sheets):
                                 sheet_exclusion_counts['price_missing_or_zero'] += 1
                                 if wr_key_for_diag:
                                     sheet_wr_exclusion_reasons[wr_key_for_diag]['price_missing_or_zero'] += 1
+                                # Row-level visibility: surface drops that
+                                # otherwise look "correct" to operators —
+                                # specifically VAC crew / helper rows whose
+                                # only missing piece is a zero or blank
+                                # SmartSheet price. These previously
+                                # disappeared into the per-sheet counter
+                                # with no per-row log, which is why VAC
+                                # crew / helping-foreman Excel files could
+                                # silently fail to generate even after
+                                # RESET_HASH_HISTORY.
+                                _vc_helping = str(row_data.get('VAC Crew Helping?') or '').strip()
+                                _vc_completed = is_checked(row_data.get('Vac Crew Completed Unit?'))
+                                _fh_helping = str(row_data.get('Foreman Helping?') or '').strip()
+                                _fh_completed = is_checked(row_data.get('Helping Foreman Completed Unit?'))
+                                _is_specialized = (
+                                    (bool(_vc_helping) and _vc_completed)
+                                    or (bool(_fh_helping) and _fh_completed)
+                                )
+                                if _is_specialized:
+                                    _variant_tag = 'VAC crew' if (_vc_helping and _vc_completed) else 'helper'
+                                    logging.warning(
+                                        f"⚠️ Dropped {_variant_tag} row (price missing or zero): "
+                                        f"WR={wr_key_for_diag}, Weekly={weekly_date}, "
+                                        f"Snapshot={row_data.get('Snapshot Date') or '<blank>'}, "
+                                        f"CU={row_data.get('CU') or row_data.get('Billable Unit Code') or '<blank>'}, "
+                                        f"Qty={row_data.get('Quantity') or '<blank>'}, "
+                                        f"SmartSheet price={row_data.get('Units Total Price') or '<blank>'}. "
+                                        f"Row has VAC/helper criteria checked but Units Total Price is zero/blank and "
+                                        f"rate recalc could not price it (see 'Rate recalc summary' WARNING for reason)."
+                                    )
 
                     sheet_row_counter += 1
 

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -816,9 +816,20 @@ def recalculate_row_price(row_data, cu_to_group, rates_dict):
             logging.debug(f"Rate recalculation: CU '{cu_code}' not found in CU-to-group mapping or rates, keeping SmartSheet price")
             return price_val
 
+    # If the mapped group isn't in the new rates table (e.g. old CSV maps
+    # CU -> a verbose group name like "Vacuum Switch" that never appears
+    # in the new rates' short-code keys), fall back to looking up the CU
+    # code directly in the rates table. This recovers specialized work
+    # items (common on VAC crew sheets) where the detailed CU code is
+    # itself a key in the new contract rates. Only activates on exact
+    # match, so no chance of mis-applying a rate.
     if group_code not in rates_dict:
-        logging.debug(f"Rate recalculation: group '{group_code}' (from CU '{cu_code}') not found in new rates, keeping SmartSheet price")
-        return price_val
+        if cu_code in rates_dict:
+            logging.debug(f"Rate recalculation: mapped group '{group_code}' not in new rates for CU '{cu_code}'; matched CU directly")
+            group_code = cu_code
+        else:
+            logging.warning(f"Rate recalculation SKIPPED: CU '{cu_code}' maps to group '{group_code}' but neither is in new rates — keeping SmartSheet price (Qty={row_data.get('Quantity')}, Work Type={row_data.get('Work Type')})")
+            return price_val
 
     # Determine work type
     work_type_raw = str(row_data.get('Work Type') or '').strip().lower()
@@ -1990,6 +2001,12 @@ def get_all_source_rows(client, source_sheets):
         sheet_foreman_counts = collections.defaultdict(lambda: collections.Counter())
         sheet_wr_exclusion_reasons = collections.defaultdict(lambda: collections.Counter())
         sheet_row_counter = 0
+        # Track post-cutoff rate recalc outcomes for operator visibility
+        # ('skipped' covers rows where Snapshot Date>=cutoff but the new
+        # rates table has no matching group/CU, so the SmartSheet price
+        # is retained — the known VAC-crew pricing-lag signal).
+        sheet_rate_recalc_counts = {'recalculated': 0, 'skipped': 0}
+        sheet_rate_recalc_skipped_cus = collections.Counter()
         try:
             logging.info(f"⚡ Processing: {source['name']} (ID: {source['id']})")
             is_subcontractor_sheet = source['id'] in SUBCONTRACTOR_SHEET_IDS
@@ -2123,9 +2140,19 @@ def get_all_source_rows(client, source_sheets):
                                         old_price = price_val
                                         price_val = recalculate_row_price(row_data, _rate_cu_to_group, _rate_new_primary)
                                         if price_val != old_price:
+                                            sheet_rate_recalc_counts['recalculated'] += 1
                                             logging.debug(f"Rate recalc: CU={row_data.get('CU')}, "
                                                           f"old=${old_price:.2f} -> new=${price_val:.2f}, "
                                                           f"date={snap_date_pre}")
+                                        else:
+                                            # Post-cutoff row silently kept original
+                                            # SmartSheet price because recalc could
+                                            # not find a matching rate. Track so
+                                            # the per-sheet summary can surface it.
+                                            sheet_rate_recalc_counts['skipped'] += 1
+                                            cu_val = str(row_data.get('CU') or row_data.get('Billable Unit Code') or '').strip().upper()
+                                            if cu_val:
+                                                sheet_rate_recalc_skipped_cus[cu_val] += 1
 
                         price_raw = row_data.get('Units Total Price')
                         has_price = (price_raw not in (None, "", "$0", "$0.00", "0", "0.0")) and price_val > 0
@@ -2279,6 +2306,30 @@ def get_all_source_rows(client, source_sheets):
                     "accepted_so_far": sheet_exclusion_counts['accepted'],
                     "is_subcontractor": is_subcontractor_sheet,
                 })
+
+                # Per-sheet summary of post-cutoff rate-recalc outcomes.
+                # A non-zero 'skipped' count means rows qualified by
+                # Snapshot Date but the new rates table could not price
+                # them, so they kept their SmartSheet price. This is the
+                # signal operators need to investigate missing entries
+                # in NEW_RATES_CSV (common on VAC crew specialized work
+                # like vacuum switches, softswitches, switched banks).
+                if RATE_CUTOFF_DATE and _rate_new_primary:
+                    skipped = sheet_rate_recalc_counts['skipped']
+                    recalculated = sheet_rate_recalc_counts['recalculated']
+                    if skipped:
+                        top_cus = ', '.join(f"{cu}×{cnt}" for cu, cnt in sheet_rate_recalc_skipped_cus.most_common(10))
+                        logging.warning(
+                            f"⚠️ Rate recalc summary for {source['name']}: "
+                            f"{recalculated} recalculated, {skipped} skipped "
+                            f"(post-cutoff rows that kept SmartSheet price because no matching "
+                            f"new-contract rate was found). Top CUs: {top_cus}"
+                        )
+                    elif recalculated:
+                        logging.info(
+                            f"📊 Rate recalc summary for {source['name']}: "
+                            f"{recalculated} rows recalculated, 0 skipped"
+                        )
 
             except Exception as e:
                 logging.error(f"Error processing sheet {source['id']}: {e}")

--- a/tests/test_subcontractor_pricing.py
+++ b/tests/test_subcontractor_pricing.py
@@ -612,6 +612,45 @@ class TestRecalculateRowPrice(unittest.TestCase):
         self.assertAlmostEqual(result, 75.0)
         self.assertEqual(row['Units Total Price'], '$75.00')
 
+    def test_cu_direct_fallback_when_mapped_group_absent_from_new_rates(self):
+        """Regression for VAC crew pricing lag: when the old CSV maps a CU to
+        a verbose group name that is NOT a key in the new rates table, the
+        recalc should fall back to looking up the CU code directly before
+        giving up. Prevents silent old-price retention on specialized work
+        items (e.g. vacuum switches) whose CU codes are themselves the key
+        in the new contract rates.
+        """
+        cu_to_group = {'CPD-VS-15-20': 'VACUUM SWITCH'}  # verbose group name
+        rates = {
+            'CPD-VS-15-20': {'install': 500.00, 'removal': 100.00, 'transfer': 0.0},
+        }
+        row = {
+            'CU': 'CPD-VS-15-20',
+            'Work Type': 'Install',
+            'Quantity': '2',
+            'Units Total Price': '$250.00',
+        }
+        result = generate_weekly_pdfs.recalculate_row_price(row, cu_to_group, rates)
+        self.assertAlmostEqual(result, 1000.00)
+        self.assertAlmostEqual(row['Units Total Price'], 1000.00)
+
+    def test_silent_fallthrough_when_neither_group_nor_cu_in_new_rates(self):
+        """When the mapped group is absent AND the CU is also absent from the
+        new rates, the row must retain its SmartSheet price unchanged — no
+        invented rate. This guards against the CU-direct fallback being too
+        aggressive."""
+        cu_to_group = {'CPD-VS-15-20': 'VACUUM SWITCH'}
+        rates = {'ANC-M': {'install': 224.06, 'removal': 29.46, 'transfer': 0.0}}
+        row = {
+            'CU': 'CPD-VS-15-20',
+            'Work Type': 'Install',
+            'Quantity': '2',
+            'Units Total Price': '$250.00',
+        }
+        result = generate_weekly_pdfs.recalculate_row_price(row, cu_to_group, rates)
+        self.assertAlmostEqual(result, 250.00)
+        self.assertEqual(row['Units Total Price'], '$250.00')
+
 
 class TestRateCutoffConfig(unittest.TestCase):
     """Tests for rate cutoff configuration."""

--- a/tests/test_subcontractor_pricing.py
+++ b/tests/test_subcontractor_pricing.py
@@ -634,11 +634,11 @@ class TestRecalculateRowPrice(unittest.TestCase):
         self.assertAlmostEqual(result, 1000.00)
         self.assertAlmostEqual(row['Units Total Price'], 1000.00)
 
-    def test_silent_fallthrough_when_neither_group_nor_cu_in_new_rates(self):
+    def test_retains_smartsheet_price_when_neither_group_nor_cu_in_new_rates(self):
         """When the mapped group is absent AND the CU is also absent from the
-        new rates, the row must retain its SmartSheet price unchanged — no
-        invented rate. This guards against the CU-direct fallback being too
-        aggressive."""
+        new rates, the row must retain its SmartSheet price unchanged rather
+        than inventing a rate. This guards against the CU-direct fallback
+        being too aggressive."""
         cu_to_group = {'CPD-VS-15-20': 'VACUUM SWITCH'}
         rates = {'ANC-M': {'install': 224.06, 'removal': 29.46, 'transfer': 0.0}}
         row = {
@@ -650,6 +650,81 @@ class TestRecalculateRowPrice(unittest.TestCase):
         result = generate_weekly_pdfs.recalculate_row_price(row, cu_to_group, rates)
         self.assertAlmostEqual(result, 250.00)
         self.assertEqual(row['Units Total Price'], '$250.00')
+
+    def test_out_status_recalculated_on_successful_lookup(self):
+        """recalculate_row_price writes outcome='recalculated' when a rate
+        was successfully applied (even if the new price equals the existing
+        SmartSheet price)."""
+        row = {'CU': 'ANC-DHM-10-84-D1', 'Work Type': 'Install', 'Quantity': '3', 'Units Total Price': '$672.18'}
+        status = {}
+        generate_weekly_pdfs.recalculate_row_price(row, self.cu_to_group, self.rates_primary, out_status=status)
+        self.assertEqual(status.get('outcome'), 'recalculated')
+
+    def test_out_status_missing_rate_when_cu_unmapped_and_absent(self):
+        """When the CU isn't in cu_to_group and also isn't a direct key in
+        the rates dict, out_status['outcome'] must be 'missing_rate' — this
+        is the only outcome the per-sheet 'skipped' summary should count."""
+        row = {'CU': 'UNKNOWN-999', 'Work Type': 'Install', 'Quantity': '2', 'Units Total Price': '$100.00'}
+        status = {}
+        generate_weekly_pdfs.recalculate_row_price(row, self.cu_to_group, self.rates_primary, out_status=status)
+        self.assertEqual(status.get('outcome'), 'missing_rate')
+
+    def test_out_status_missing_rate_when_group_absent_and_no_cu_fallback(self):
+        """When CU maps to a verbose group name that isn't in the new rates
+        table AND the CU itself also isn't a direct key, out_status reports
+        'missing_rate'."""
+        cu_to_group = {'CPD-VS-15-20': 'VACUUM SWITCH'}
+        rates = {'ANC-M': {'install': 224.06, 'removal': 29.46, 'transfer': 0.0}}
+        row = {'CU': 'CPD-VS-15-20', 'Work Type': 'Install', 'Quantity': '2', 'Units Total Price': '$250.00'}
+        status = {}
+        generate_weekly_pdfs.recalculate_row_price(row, cu_to_group, rates, out_status=status)
+        self.assertEqual(status.get('outcome'), 'missing_rate')
+
+    def test_out_status_invalid_quantity(self):
+        """Zero/missing quantity short-circuits with outcome='invalid_quantity',
+        not 'missing_rate' — the per-sheet 'skipped' summary must not
+        attribute this to CSV coverage gaps."""
+        row = {'CU': 'ANC-DHM-10-84-D1', 'Work Type': 'Install', 'Quantity': '0', 'Units Total Price': '$55.00'}
+        status = {}
+        generate_weekly_pdfs.recalculate_row_price(row, self.cu_to_group, self.rates_primary, out_status=status)
+        self.assertEqual(status.get('outcome'), 'invalid_quantity')
+
+    def test_out_status_zero_rate(self):
+        """Zero rate for the resolved work type yields outcome='zero_rate'."""
+        # ANC-M has transfer rate = 0.0 in the fixture
+        row = {'CU': 'ANC-DHM-10-84-D1', 'Work Type': 'Transfer', 'Quantity': '2', 'Units Total Price': '$75.00'}
+        status = {}
+        generate_weekly_pdfs.recalculate_row_price(row, self.cu_to_group, self.rates_primary, out_status=status)
+        self.assertEqual(status.get('outcome'), 'zero_rate')
+
+    def test_out_status_optional_preserves_backward_compat(self):
+        """Callers that omit out_status must continue to get a float price."""
+        row = {'CU': 'ANC-DHM-10-84-D1', 'Work Type': 'Install', 'Quantity': '3', 'Units Total Price': '$650.00'}
+        result = generate_weekly_pdfs.recalculate_row_price(row, self.cu_to_group, self.rates_primary)
+        self.assertIsInstance(result, float)
+        self.assertAlmostEqual(result, round(224.06 * 3, 2))
+
+
+class TestResolveCuCode(unittest.TestCase):
+    """Tests for the _resolve_cu_code helper used by both recalc and the
+    per-sheet skipped-CU summary counter, so they agree on which CU a row
+    is attributed to."""
+
+    def test_prefers_cu_helper_over_cu(self):
+        row = {'CU Helper': 'ANC-DSC-16-96-D1', 'CU': 'ARM-10D-60HS', 'Billable Unit Code': 'BLT-12'}
+        self.assertEqual(generate_weekly_pdfs._resolve_cu_code(row), 'ANC-DSC-16-96-D1')
+
+    def test_nan_helper_falls_back_to_cu(self):
+        row = {'CU Helper': 'nan', 'CU': 'ARM-10D-60HS'}
+        self.assertEqual(generate_weekly_pdfs._resolve_cu_code(row), 'ARM-10D-60HS')
+
+    def test_falls_back_to_billable_unit_code(self):
+        row = {'Billable Unit Code': 'Something-Mixed'}
+        self.assertEqual(generate_weekly_pdfs._resolve_cu_code(row), 'SOMETHING-MIXED')
+
+    def test_returns_empty_when_all_blank(self):
+        self.assertEqual(generate_weekly_pdfs._resolve_cu_code({}), '')
+        self.assertEqual(generate_weekly_pdfs._resolve_cu_code({'CU': None, 'Billable Unit Code': ''}), '')
 
 
 class TestRateCutoffConfig(unittest.TestCase):


### PR DESCRIPTION
## Summary
Fixes a silent pricing bug where VAC crew and specialized work items (vacuum switches, softswitches, switched banks) retained incorrect SmartSheet prices during post-cutoff rate recalculation. The root cause was that the old CSV's `Compatible Unit Group` column contains verbose group names that don't exist as keys in the new contract rates table, causing the recalc to silently fall through with only a DEBUG log.

## Key Changes

- **SDK workaround**: Added re-export of missing retryable exception classes (`RateLimitExceededError`, `UnexpectedErrorShouldRetryError`, etc.) from `smartsheet.exceptions` into `smartsheet.smartsheet` module to work around a bug in smartsheet-python-sdk 3.8.0 where internal exception lookup fails.

- **Rate recalc fallback logic**: Modified `recalculate_row_price()` to fall back to direct CU-code lookup in the rates table when the mapped group is absent. Only activates on exact match, preventing mis-application of rates.

- **Improved logging visibility**: 
  - Elevated "group not found" logs from DEBUG to WARNING when neither the mapped group nor the CU code exists in new rates
  - Added per-row WARNING logs for dropped VAC crew/helper rows with zero/blank prices
  - Added per-sheet rate recalc summary showing count of recalculated vs. skipped rows and top CUs that couldn't be priced

- **Tracking and diagnostics**: Added counters (`sheet_rate_recalc_counts`, `sheet_rate_recalc_skipped_cus`) to track post-cutoff rate recalc outcomes per sheet, surfacing which CU codes are missing from the new rates CSV.

- **Test coverage**: Added two regression tests:
  - `test_cu_direct_fallback_when_mapped_group_absent_from_new_rates`: Verifies CU-direct fallback works
  - `test_silent_fallthrough_when_neither_group_nor_cu_in_new_rates`: Ensures SmartSheet price is retained when no rate match exists

## Implementation Details

The fix is additive and production-safe:
1. The CU-direct fallback only activates when the mapped group is missing, and only on exact CU match
2. When both group and CU lookups fail, the original SmartSheet price is retained (no invented rates)
3. WARNING logs now surface the specific CU codes and quantities that couldn't be priced, enabling operators to identify missing entries in `NEW_RATES_CSV`
4. Per-sheet summaries make it immediately visible when rate recalc skips occur, rather than silently disappearing into counters

This addresses the known VAC crew pricing-lag signal where post-cutoff rows kept old prices due to missing rate table entries.

https://claude.ai/code/session_01J8i3CGgm2cqd4ReeSP9o8S

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production billing price recalculation and adds a runtime monkeypatch for the Smartsheet SDK, so incorrect rate application or unexpected SDK behavior could impact generated billing outputs; changes are guarded and covered by new tests.
> 
> **Overview**
> Fixes a post-cutoff pricing edge case where rows could silently keep SmartSheet prices when the CU→group mapping produced verbose group names not present in the new contract rate table.
> 
> `recalculate_row_price()` now centralizes CU resolution via `_resolve_cu_code()`, falls back to direct CU-key lookup when the mapped group is missing from `rates_dict`, and reports explicit outcomes (e.g. `missing_rate`, `invalid_quantity`, `zero_rate`) for callers to surface actionable skips.
> 
> Sheet processing adds per-row/per-sheet WARNING visibility for skipped post-cutoff recalcs (including top skipped CUs), and includes a small Smartsheet SDK workaround that re-exports retryable exception classes to restore proper retry behavior. Test coverage is expanded with regressions for the CU-direct fallback, safety retention when no match exists, and `_resolve_cu_code` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 477938dfe389f9b9a7301c978c2994ee6836523b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->