### PR TITLE
Fix VAC crew hash aggregation for multi-member groups

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -398,40 +398,55 @@ When proposing new workflows, dynamically evaluate the absolute best technology.
   (`test_silent_fallthrough_when_neither_group_nor_cu_in_new_rates`).
 - [2026-04-22 00:00] VAC crew Excel files silently not regenerating
   when a non-first-sorted row's VAC crew fields change. **Root
-  cause:** `calculate_data_hash()` builds `vac_crew` variant
+  cause:** `calculate_data_hash()` built `vac_crew` variant
   metadata (VACCREW / VACCREW_DEPT / VACCREW_JOB) from
   `sorted_rows[0]` only — mirroring the helper pattern — but the
-  `vac_crew` group key at `generate_weekly_pdfs.py:2660`
-  (`{week}_{wr}_VACCREW`) does NOT split per foreman the way helper
+  `vac_crew` group key (`{week}_{wr}_VACCREW`, created in
+  `group_source_rows`) does NOT split per foreman the way helper
   groups do (`{week}_{wr}_HELPER_{helper}`). A single VAC crew
   group therefore contains every VAC crew member for that
-  WR+week. Editing the dept/job/name on a member that doesn't
-  sort first left the hash unchanged, the "unchanged + attachment
-  exists" skip at line 3695 fired, and no Excel regenerated even
-  though the row fully met VAC crew criteria (dept #, name, both
+  WR+week. Editing the dept/job/name on a member that didn't sort
+  first left the hash unchanged, the "unchanged + attachment
+  exists" skip path fired, and no Excel regenerated even though
+  the row fully met VAC crew criteria (dept #, name, both
   `Vac Crew Completed Unit?` and `Units Completed?` checked).
   Adding a row already regenerated (ROWCOUNT changed), so only
   *modifications* to existing rows were silently lost. **Fix:**
-  aggregate `__vac_crew_name`, `__vac_crew_dept`, `__vac_crew_job`
-  across ALL rows in the group (sorted, deduped, comma-joined)
-  instead of reading `sorted_rows[0]` — so any per-row VAC crew
-  field edit forces the hash to change. Helper metadata was left
-  alone because helper groups already partition by foreman and
-  every row in a helper group shares identical helper info.
-  **Secondary fix:** bumped `DISCOVERY_CACHE_VERSION` from 2 → 3
-  at `generate_weekly_pdfs.py:193` so any discovery cache created
-  before VAC crew columns were added to a particular existing
-  sheet in Smartsheet is re-validated on the next run rather than
-  waiting up to `DISCOVERY_CACHE_TTL_MIN` (default 7 days) for
-  the mapping to refresh. **New rules:** (1) Whenever a group key
-  variant does NOT include a disambiguating identifier (the way
-  `_VACCREW` doesn't include the VAC crew name the way
-  `_HELPER_<name>` does), the corresponding hash metadata MUST
-  aggregate across all rows in the group — `sorted_rows[0]`-only
-  metadata is a silent-skip trap. (2) When fixing a bug that
-  could leave existing discovery caches with incorrect column
-  mappings, bump `DISCOVERY_CACHE_VERSION` so the fix takes
-  effect immediately instead of eventually. Regression tests:
+  include `__vac_crew_name`, `__vac_crew_dept`, `__vac_crew_job`
+  directly in the per-row `row_str` that feeds the hash (scoped
+  to the `vac_crew` variant so primary/helper hash stability is
+  preserved). Per-row inclusion is strictly more sensitive than
+  aggregating values into `meta_parts` and avoids two review-caught
+  pitfalls of set-based aggregation: **set dedup** (depts
+  `{500, 500, 600}` + editing one row 500→600 leaves the set
+  unchanged) and **delimiter collision** (`','.join` on free-text
+  names cannot distinguish `['A,B','C']` from `['A','B,C']`).
+  Helper metadata was left on `sorted_rows[0]` because helper
+  groups already partition by foreman and every row in a helper
+  group shares identical helper info. **Secondary fix:** bumped
+  `DISCOVERY_CACHE_VERSION` from 2 → 3 so any discovery cache
+  created before VAC crew columns were added to a particular
+  existing sheet in Smartsheet is re-validated on the next run
+  rather than waiting up to `DISCOVERY_CACHE_TTL_MIN` (default 7
+  days) for the mapping to refresh. **New rules:** (1) Whenever a
+  group key variant does NOT include a disambiguating identifier
+  (the way `_VACCREW` doesn't include the VAC crew name the way
+  `_HELPER_<name>` does), the corresponding hash MUST capture
+  per-row field changes at the row level — a set-based
+  `meta_parts` aggregation of free-text values is a two-way
+  silent-skip trap (dedup + delimiter collision). (2) When fixing
+  a bug that could leave existing discovery caches with incorrect
+  column mappings, bump `DISCOVERY_CACHE_VERSION` so the fix takes
+  effect immediately instead of eventually. (3) Living-ledger
+  entries and code comments in this codebase must refer to
+  functions / group-key formats / env-var names — not hard-coded
+  line numbers — because line numbers drift as the file grows.
+  Regression tests:
   `tests/test_vac_crew.py::TestVacCrewHashAggregation` covers
-  dept-edit and name-edit on non-first rows plus hash stability
-  when nothing changes.
+  dept-edit and name-edit on non-first rows, the set-dedup
+  collision case (`{500, 500, 600}` with a 500→600 edit), the
+  delimiter-collision case (commas in free-text names), and
+  hash stability when nothing changes. The test class pins
+  `EXTENDED_CHANGE_DETECTION`, `RATE_CUTOFF_DATE`, and
+  `_RATES_FINGERPRINT` in `setUp`/`tearDown` so developer env-var
+  overrides don't destabilize the suite.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -396,3 +396,42 @@ When proposing new workflows, dynamically evaluate the absolute best technology.
   and the safety guard that still retains SmartSheet price when
   neither group nor CU is in new rates
   (`test_silent_fallthrough_when_neither_group_nor_cu_in_new_rates`).
+- [2026-04-22 00:00] VAC crew Excel files silently not regenerating
+  when a non-first-sorted row's VAC crew fields change. **Root
+  cause:** `calculate_data_hash()` builds `vac_crew` variant
+  metadata (VACCREW / VACCREW_DEPT / VACCREW_JOB) from
+  `sorted_rows[0]` only — mirroring the helper pattern — but the
+  `vac_crew` group key at `generate_weekly_pdfs.py:2660`
+  (`{week}_{wr}_VACCREW`) does NOT split per foreman the way helper
+  groups do (`{week}_{wr}_HELPER_{helper}`). A single VAC crew
+  group therefore contains every VAC crew member for that
+  WR+week. Editing the dept/job/name on a member that doesn't
+  sort first left the hash unchanged, the "unchanged + attachment
+  exists" skip at line 3695 fired, and no Excel regenerated even
+  though the row fully met VAC crew criteria (dept #, name, both
+  `Vac Crew Completed Unit?` and `Units Completed?` checked).
+  Adding a row already regenerated (ROWCOUNT changed), so only
+  *modifications* to existing rows were silently lost. **Fix:**
+  aggregate `__vac_crew_name`, `__vac_crew_dept`, `__vac_crew_job`
+  across ALL rows in the group (sorted, deduped, comma-joined)
+  instead of reading `sorted_rows[0]` — so any per-row VAC crew
+  field edit forces the hash to change. Helper metadata was left
+  alone because helper groups already partition by foreman and
+  every row in a helper group shares identical helper info.
+  **Secondary fix:** bumped `DISCOVERY_CACHE_VERSION` from 2 → 3
+  at `generate_weekly_pdfs.py:193` so any discovery cache created
+  before VAC crew columns were added to a particular existing
+  sheet in Smartsheet is re-validated on the next run rather than
+  waiting up to `DISCOVERY_CACHE_TTL_MIN` (default 7 days) for
+  the mapping to refresh. **New rules:** (1) Whenever a group key
+  variant does NOT include a disambiguating identifier (the way
+  `_VACCREW` doesn't include the VAC crew name the way
+  `_HELPER_<name>` does), the corresponding hash metadata MUST
+  aggregate across all rows in the group — `sorted_rows[0]`-only
+  metadata is a silent-skip trap. (2) When fixing a bug that
+  could leave existing discovery caches with incorrect column
+  mappings, bump `DISCOVERY_CACHE_VERSION` so the fix takes
+  effect immediately instead of eventually. Regression tests:
+  `tests/test_vac_crew.py::TestVacCrewHashAggregation` covers
+  dept-edit and name-edit on non-first rows plus hash stability
+  when nothing changes.

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -1172,6 +1172,11 @@ def calculate_data_hash(group_rows: list[dict]) -> str:
     # Extended mode: Use incremental hashing
     hasher = hashlib.sha256()
 
+    # Variant is a group-level property (all rows in a group share the same
+    # __variant). Compute it once before the row loop so per-row hash can
+    # include variant-scoped fields deterministically.
+    group_variant = sorted_rows[0].get('__variant', 'primary') if sorted_rows else 'primary'
+
     group_foreman = None
     for row in sorted_rows:
         foreman = row.get('__current_foreman') or row.get('Foreman') or ''
@@ -1180,7 +1185,7 @@ def calculate_data_hash(group_rows: list[dict]) -> str:
         # CRITICAL: Use parse_price() for normalization to avoid format-based false changes
         normalized_price = f"{parse_price(row.get('Units Total Price', 0)):.2f}"
 
-        row_str = "|".join([
+        row_fields = [
             str(row.get('Work Request #', '')),
             str(row.get('Snapshot Date', '') or ''),
             str(row.get('CU', '') or ''),
@@ -1198,7 +1203,27 @@ def calculate_data_hash(group_rows: list[dict]) -> str:
             str(row.get('CU Description', '') or ''),
             str(row.get('Unit of Measure', '') or ''),
             str(row.get('Area', '') or ''),
-        ])
+        ]
+        # VAC crew groups use a single `_VACCREW` key with no foreman suffix,
+        # so one group can hold multiple crew members. Including per-row VAC
+        # crew fields here lets each row contribute its own name/dept/job to
+        # the hash independently. This avoids two pitfalls of aggregating
+        # values into `meta_parts` as a set:
+        #   1. Set dedup — e.g. depts {500, 500, 600}: editing one row's dept
+        #      from 500→600 leaves {500, 600} unchanged, silently skipping
+        #      regeneration.
+        #   2. Delimiter collision — ','.join on free-text names cannot
+        #      distinguish ['A,B', 'C'] from ['A', 'B,C'].
+        # Scoped to vac_crew so hash stability for primary/helper rows is
+        # preserved (non-vac_crew row_str structure is unchanged).
+        if group_variant == 'vac_crew':
+            row_fields.extend([
+                str(row.get('__vac_crew_name') or ''),
+                str(row.get('__vac_crew_dept') or ''),
+                str(row.get('__vac_crew_job') or ''),
+            ])
+
+        row_str = "|".join(row_fields)
         # Update hash incrementally with newline separator
         hasher.update(row_str.encode('utf-8'))
         hasher.update(b"\n")
@@ -1211,12 +1236,14 @@ def calculate_data_hash(group_rows: list[dict]) -> str:
     meta_parts.append(f"FOREMAN={group_foreman or ''}")
     
     # Variant-specific hash tokens (replaces activity log USER= token)
-    variant = sorted_rows[0].get('__variant', 'primary') if sorted_rows else 'primary'
+    variant = group_variant
     meta_parts.append(f"VARIANT={variant}")
-    
+
     if variant == 'helper':
-        # Helper variant: include helper-specific metadata (helper_job is OPTIONAL)
-        # PERFORMANCE: Access row once, avoid repeated dict lookups
+        # Helper variant: include helper-specific metadata (helper_job is OPTIONAL).
+        # Helper groups are split per foreman (group key: `_HELPER_{helper}`),
+        # so every row in a helper group shares identical helper info —
+        # reading sorted_rows[0] here is safe.
         _first = sorted_rows[0] if sorted_rows else {}
         helper_foreman = _first.get('__helper_foreman', '')
         helper_dept = _first.get('__helper_dept', '')
@@ -1229,27 +1256,10 @@ def calculate_data_hash(group_rows: list[dict]) -> str:
         meta_parts.append(f"HELPER={helper_foreman}")
         meta_parts.append(f"HELPER_DEPT={helper_dept}")
         meta_parts.append(f"HELPER_JOB={helper_job}")  # Include even if empty for hash consistency
-    elif variant == 'vac_crew':
-        # VAC Crew variant is NOT split per foreman in the group key
-        # (line 2660 uses `_VACCREW` with no foreman suffix), so a single
-        # group can contain multiple VAC crew members. Reading only
-        # sorted_rows[0] would miss hash changes when VAC crew
-        # fields (name/dept/job) are edited on any row that is not first
-        # in sort order — the known "VAC crew sheet not regenerating even
-        # though criteria is met" bug. Aggregate across all rows so any
-        # per-row VAC crew field change forces a new hash.
-        vac_crew_names = sorted({
-            str(r.get('__vac_crew_name') or '') for r in sorted_rows
-        })
-        vac_crew_depts = sorted({
-            str(r.get('__vac_crew_dept') or '') for r in sorted_rows
-        })
-        vac_crew_jobs = sorted({
-            str(r.get('__vac_crew_job') or '') for r in sorted_rows
-        })
-        meta_parts.append(f"VACCREW={','.join(vac_crew_names)}")
-        meta_parts.append(f"VACCREW_DEPT={','.join(vac_crew_depts)}")
-        meta_parts.append(f"VACCREW_JOB={','.join(vac_crew_jobs)}")
+    # vac_crew variant intentionally has no meta_parts block: VAC crew
+    # name/dept/job are already captured per-row in the row_str loop above,
+    # which is strictly more sensitive than meta_parts aggregation and is not
+    # vulnerable to set-dedup collisions or comma-in-name delimiter collisions.
     
     meta_parts.append(f"DEPTS={','.join(unique_depts)}")
     meta_parts.append(f"TOTAL={total_price:.2f}")

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -190,7 +190,10 @@ FORCE_REDISCOVERY = os.getenv('FORCE_REDISCOVERY','false').lower() in ('1','true
 DISCOVERY_CACHE_PATH = os.path.join(OUTPUT_FOLDER, 'discovery_cache.json')
 # Bump this version whenever the column synonym dictionary changes so that stale caches
 # (missing newly-mapped columns like VAC Crew) are automatically invalidated.
-DISCOVERY_CACHE_VERSION = 2  # v2: added VAC Crew column synonyms
+# Also bump when a known bug would leave existing caches with incorrect mappings —
+# invalidating the cache is cheaper than waiting up to DISCOVERY_CACHE_TTL_MIN
+# (7 days by default) for those mappings to refresh on their own.
+DISCOVERY_CACHE_VERSION = 3  # v3: force re-validation to pick up VAC Crew columns added to existing sheets post-v2
 # Verbose debug tunables
 DEBUG_SAMPLE_ROWS = int(os.getenv('DEBUG_SAMPLE_ROWS','3') or 3)  # How many initial rows (across all sheets) to show full per-cell mapping
 DEBUG_ESSENTIAL_ROWS = int(os.getenv('DEBUG_ESSENTIAL_ROWS','5') or 5)  # How many initial rows to log essential field summary
@@ -1227,15 +1230,26 @@ def calculate_data_hash(group_rows: list[dict]) -> str:
         meta_parts.append(f"HELPER_DEPT={helper_dept}")
         meta_parts.append(f"HELPER_JOB={helper_job}")  # Include even if empty for hash consistency
     elif variant == 'vac_crew':
-        # VAC Crew variant: include VAC Crew-specific metadata so hash changes
-        # when VAC Crew name/dept/job change (mirrors helper pattern)
-        _first = sorted_rows[0] if sorted_rows else {}
-        vac_crew_name = _first.get('__vac_crew_name', '')
-        vac_crew_dept = _first.get('__vac_crew_dept', '')
-        vac_crew_job = _first.get('__vac_crew_job', '')
-        meta_parts.append(f"VACCREW={vac_crew_name}")
-        meta_parts.append(f"VACCREW_DEPT={vac_crew_dept}")
-        meta_parts.append(f"VACCREW_JOB={vac_crew_job}")
+        # VAC Crew variant is NOT split per foreman in the group key
+        # (line 2660 uses `_VACCREW` with no foreman suffix), so a single
+        # group can contain multiple VAC crew members. Reading only
+        # sorted_rows[0] would miss hash changes when VAC crew
+        # fields (name/dept/job) are edited on any row that is not first
+        # in sort order — the known "VAC crew sheet not regenerating even
+        # though criteria is met" bug. Aggregate across all rows so any
+        # per-row VAC crew field change forces a new hash.
+        vac_crew_names = sorted({
+            str(r.get('__vac_crew_name') or '') for r in sorted_rows
+        })
+        vac_crew_depts = sorted({
+            str(r.get('__vac_crew_dept') or '') for r in sorted_rows
+        })
+        vac_crew_jobs = sorted({
+            str(r.get('__vac_crew_job') or '') for r in sorted_rows
+        })
+        meta_parts.append(f"VACCREW={','.join(vac_crew_names)}")
+        meta_parts.append(f"VACCREW_DEPT={','.join(vac_crew_depts)}")
+        meta_parts.append(f"VACCREW_JOB={','.join(vac_crew_jobs)}")
     
     meta_parts.append(f"DEPTS={','.join(unique_depts)}")
     meta_parts.append(f"TOTAL={total_price:.2f}")

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -1139,27 +1139,40 @@ def calculate_data_hash(group_rows: list[dict]) -> str:
         return "0" * 16
 
     # Deterministic sorting across key business fields.
-    # VAC crew fields appear as tie-breakers so that multi-member VAC crew
-    # groups — where two rows can share (WR, Snapshot, CU, Pole, Qty) while
-    # belonging to different crew members — hash stably across runs. Without
-    # the tie-breaker, row insertion order (merged from parallel
+    #
+    # In EXTENDED mode, VAC crew fields appear as tie-breakers so multi-member
+    # VAC crew groups — where two rows can share (WR, Snapshot, CU, Pole, Qty)
+    # while belonging to different crew members — hash stably across runs.
+    # Without the tie-breaker, row insertion order (merged from parallel
     # `as_completed` futures in `get_all_source_rows`) bleeds into the hash
-    # because VAC crew fields are included per-row in row_str. Non-VAC-crew
-    # rows have empty VAC crew fields, so these keys are a no-op tie-breaker
-    # for primary/helper groups and do not change their hashes.
-    sorted_rows = sorted(
-        group_rows,
-        key=lambda x: (
-            str(x.get('Work Request #', '')),
-            str(x.get('Snapshot Date', '')),
-            str(x.get('CU', '')),
-            str(x.get('Pole #') or x.get('Point #') or x.get('Point Number') or ''),
-            str(x.get('Quantity', '')),
-            str(x.get('__vac_crew_name') or ''),
-            str(x.get('__vac_crew_dept') or ''),
-            str(x.get('__vac_crew_job') or ''),
-        )
+    # because VAC crew fields are included per-row in row_str.
+    #
+    # LEGACY mode (EXTENDED_CHANGE_DETECTION=0) intentionally keeps the
+    # original 5-key sort: the docstring promises legacy uses only the
+    # original minimal fields so hashes stay bit-stable for rollbacks.
+    # Adding tie-breakers there would change row order for tied rows whose
+    # legacy row_data still differs (Work Type / Units Completed? / price),
+    # invalidating the rollback-stability guarantee. Legacy mode's row_data
+    # also excludes VAC crew fields, so a vac_crew-specific tie-breaker
+    # there would be purely cosmetic — skip it.
+    _sort_base = lambda x: (
+        str(x.get('Work Request #', '')),
+        str(x.get('Snapshot Date', '')),
+        str(x.get('CU', '')),
+        str(x.get('Pole #') or x.get('Point #') or x.get('Point Number') or ''),
+        str(x.get('Quantity', '')),
     )
+    if EXTENDED_CHANGE_DETECTION:
+        sorted_rows = sorted(
+            group_rows,
+            key=lambda x: _sort_base(x) + (
+                str(x.get('__vac_crew_name') or ''),
+                str(x.get('__vac_crew_dept') or ''),
+                str(x.get('__vac_crew_job') or ''),
+            ),
+        )
+    else:
+        sorted_rows = sorted(group_rows, key=_sort_base)
 
     if not EXTENDED_CHANGE_DETECTION:
         # OPTIMIZATION: Use incremental hashing to avoid large string allocation

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -1138,7 +1138,15 @@ def calculate_data_hash(group_rows: list[dict]) -> str:
     if not group_rows:
         return "0" * 16
 
-    # Deterministic sorting across key business fields
+    # Deterministic sorting across key business fields.
+    # VAC crew fields appear as tie-breakers so that multi-member VAC crew
+    # groups — where two rows can share (WR, Snapshot, CU, Pole, Qty) while
+    # belonging to different crew members — hash stably across runs. Without
+    # the tie-breaker, row insertion order (merged from parallel
+    # `as_completed` futures in `get_all_source_rows`) bleeds into the hash
+    # because VAC crew fields are included per-row in row_str. Non-VAC-crew
+    # rows have empty VAC crew fields, so these keys are a no-op tie-breaker
+    # for primary/helper groups and do not change their hashes.
     sorted_rows = sorted(
         group_rows,
         key=lambda x: (
@@ -1147,6 +1155,9 @@ def calculate_data_hash(group_rows: list[dict]) -> str:
             str(x.get('CU', '')),
             str(x.get('Pole #') or x.get('Point #') or x.get('Point Number') or ''),
             str(x.get('Quantity', '')),
+            str(x.get('__vac_crew_name') or ''),
+            str(x.get('__vac_crew_dept') or ''),
+            str(x.get('__vac_crew_job') or ''),
         )
     )
 

--- a/tests/test_vac_crew.py
+++ b/tests/test_vac_crew.py
@@ -364,6 +364,27 @@ class TestVacCrewHashAggregation(unittest.TestCase):
             generate_weekly_pdfs.calculate_data_hash(list(reversed(rows))),
         )
 
+    def test_hash_stable_when_vac_crew_rows_share_primary_sort_keys(self):
+        """Regression: including VAC crew fields in row_str made the hash
+        sensitive to insertion order when multiple VAC crew rows share
+        (WR, Snapshot, CU, Pole, Qty). Because rows are merged from
+        parallel `as_completed` futures in `get_all_source_rows`,
+        insertion order is non-deterministic across runs. VAC crew fields
+        must act as tie-breakers in the sort key so identical datasets
+        hash identically regardless of which future returned first."""
+        rows = [
+            self._row('12345', 'CU-SAME', 1, '$100', 'Alice', '1000', 'J1'),
+            self._row('12345', 'CU-SAME', 1, '$100', 'Bob',   '2000', 'J2'),
+        ]
+        # All five primary sort keys match; only VAC crew fields differ.
+        self.assertEqual(
+            generate_weekly_pdfs.calculate_data_hash(rows),
+            generate_weekly_pdfs.calculate_data_hash(list(reversed(rows))),
+            "Hash changed when VAC crew rows with identical primary sort "
+            "keys were reversed — missing tie-breaker makes production "
+            "runs subject to insertion-order churn."
+        )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_vac_crew.py
+++ b/tests/test_vac_crew.py
@@ -225,15 +225,38 @@ class TestVacCrewGroupingLogic(unittest.TestCase):
 
 
 class TestVacCrewHashAggregation(unittest.TestCase):
-    """Regression tests for the VAC crew hash metadata aggregation bug.
+    """Regression tests for the VAC crew hash aggregation bug.
 
-    VAC crew groups are not split per foreman in the group key (all VAC crew
-    rows for a given WR+week share a single `_VACCREW` group), so a single
-    group can contain multiple VAC crew members. Prior to the fix, the hash
-    metadata read VAC crew name/dept/job only from sorted_rows[0], which meant
-    edits to VAC crew fields on any non-first row left the hash unchanged and
-    the file was skipped as "unchanged + attachment exists".
+    VAC crew groups are not split per foreman in the group key (all VAC
+    crew rows for a given WR+week share a single `_VACCREW` group), so a
+    single group can contain multiple VAC crew members. Prior to the fix,
+    the hash metadata read VAC crew name/dept/job only from sorted_rows[0],
+    which meant edits to VAC crew fields on any non-first row left the hash
+    unchanged and the file was skipped as "unchanged + attachment exists".
+
+    The final fix embeds VAC crew name/dept/job in the *per-row* row_str
+    (scoped to the vac_crew variant), which is strictly more sensitive than
+    meta_parts aggregation and is not vulnerable to set-dedup collisions or
+    comma-in-name delimiter collisions.
     """
+
+    def setUp(self):
+        # Pin module globals that calculate_data_hash() reads so tests are
+        # robust against env-var overrides in developer shells. The test
+        # suite intentionally covers the `EXTENDED_CHANGE_DETECTION=True`
+        # path — the production default — so other values are not exercised
+        # here.
+        self._saved_ext = generate_weekly_pdfs.EXTENDED_CHANGE_DETECTION
+        self._saved_cutoff = generate_weekly_pdfs.RATE_CUTOFF_DATE
+        self._saved_fp = generate_weekly_pdfs._RATES_FINGERPRINT
+        generate_weekly_pdfs.EXTENDED_CHANGE_DETECTION = True
+        generate_weekly_pdfs.RATE_CUTOFF_DATE = None
+        generate_weekly_pdfs._RATES_FINGERPRINT = ''
+
+    def tearDown(self):
+        generate_weekly_pdfs.EXTENDED_CHANGE_DETECTION = self._saved_ext
+        generate_weekly_pdfs.RATE_CUTOFF_DATE = self._saved_cutoff
+        generate_weekly_pdfs._RATES_FINGERPRINT = self._saved_fp
 
     def _row(self, wr, cu, qty, price, name, dept, job, snapshot='2026-04-19'):
         return {
@@ -283,15 +306,59 @@ class TestVacCrewHashAggregation(unittest.TestCase):
             generate_weekly_pdfs.calculate_data_hash(edited),
         )
 
+    def test_hash_changes_when_edited_value_collides_with_another_member(self):
+        """Regression: set-based dedup of VAC crew metadata silently missed
+        edits to a shared value. With three members having depts
+        {500, 500, 600}, editing one row's dept from 500→600 leaves the
+        set {500, 600} unchanged. Per-row row_str inclusion must still
+        register the change."""
+        base = [
+            self._row('12345', 'CU-A', 1, '$100', 'Alice',   '500', 'J1'),
+            self._row('12345', 'CU-B', 1, '$200', 'Bob',     '500', 'J2'),
+            self._row('12345', 'CU-C', 1, '$300', 'Charlie', '600', 'J3'),
+        ]
+        edited = [
+            self._row('12345', 'CU-A', 1, '$100', 'Alice',   '500', 'J1'),
+            self._row('12345', 'CU-B', 1, '$200', 'Bob',     '600', 'J2'),  # 500 → 600
+            self._row('12345', 'CU-C', 1, '$300', 'Charlie', '600', 'J3'),
+        ]
+        self.assertNotEqual(
+            generate_weekly_pdfs.calculate_data_hash(base),
+            generate_weekly_pdfs.calculate_data_hash(edited),
+            "Hash did not change when a VAC crew dept edit collided with "
+            "another member's dept — the old set-dedup behavior would "
+            "silently skip regeneration."
+        )
+
+    def test_hash_distinguishes_comma_in_name_edge_case(self):
+        """Regression: delimiter collision in ','.join aggregation.
+        Names 'A,B' + 'C' and 'A' + 'B,C' both produced the literal
+        token 'A,B,C', causing distinct group states to share a hash.
+        Per-row row_str inclusion isolates each row's fields, so these
+        two states must hash differently."""
+        state_1 = [
+            self._row('12345', 'CU-A', 1, '$100', 'A,B', '1', 'J'),
+            self._row('12345', 'CU-B', 1, '$200', 'C',   '2', 'J'),
+        ]
+        state_2 = [
+            self._row('12345', 'CU-A', 1, '$100', 'A',   '1', 'J'),
+            self._row('12345', 'CU-B', 1, '$200', 'B,C', '2', 'J'),
+        ]
+        self.assertNotEqual(
+            generate_weekly_pdfs.calculate_data_hash(state_1),
+            generate_weekly_pdfs.calculate_data_hash(state_2),
+            "Distinct VAC crew states collapsed to the same hash — "
+            "delimiter collision in aggregated metadata."
+        )
+
     def test_hash_stable_when_no_vac_crew_fields_change(self):
         """Same VAC crew data (in any row order) must produce the same hash."""
         rows = [
             self._row('12345', 'CU-A', 1, '$100', 'Alice', '1000', 'J1'),
             self._row('12345', 'CU-B', 1, '$200', 'Bob',   '2000', 'J2'),
         ]
-        # Shuffled input order must not change hash — calculate_data_hash
-        # already sorts deterministically, and the aggregated VAC crew
-        # metadata is sorted too.
+        # calculate_data_hash sorts rows deterministically before hashing,
+        # so input order must not affect the result.
         self.assertEqual(
             generate_weekly_pdfs.calculate_data_hash(rows),
             generate_weekly_pdfs.calculate_data_hash(list(reversed(rows))),

--- a/tests/test_vac_crew.py
+++ b/tests/test_vac_crew.py
@@ -364,6 +364,37 @@ class TestVacCrewHashAggregation(unittest.TestCase):
             generate_weekly_pdfs.calculate_data_hash(list(reversed(rows))),
         )
 
+    def test_legacy_mode_ignores_vac_crew_metadata_edits(self):
+        """Regression: legacy mode (EXTENDED_CHANGE_DETECTION=0) must remain
+        insensitive to VAC crew field edits. The docstring promises
+        legacy uses only the original minimal fields so hashes stay
+        bit-stable for rollbacks, and legacy row_data does not include
+        VAC crew fields. Applying VAC crew tie-breakers unconditionally
+        to the sort key would let VAC crew edits change the hash
+        indirectly by reordering rows whose legacy row_data differs on
+        non-primary fields (Work Type / Units Completed? / price)."""
+        generate_weekly_pdfs.EXTENDED_CHANGE_DETECTION = False
+        # Tied on primary sort keys but with differing legacy row_data
+        # (Work Type differs) — order matters for the hasher.
+        row_a = self._row('12345', 'CU-SAME', 1, '$100', 'Alice', '1000', 'J1')
+        row_b = self._row('12345', 'CU-SAME', 1, '$100', 'Bob',   '2000', 'J2')
+        row_a['Work Type'] = 'Install'
+        row_b['Work Type'] = 'Remove'
+
+        base_hash = generate_weekly_pdfs.calculate_data_hash([row_a, row_b])
+
+        # Edit a VAC crew field only — legacy hash must not change.
+        row_a_edited = dict(row_a, __vac_crew_dept='9999')
+        edited_hash = generate_weekly_pdfs.calculate_data_hash(
+            [row_a_edited, row_b]
+        )
+        self.assertEqual(
+            base_hash, edited_hash,
+            "Legacy hash changed after a VAC crew field edit — "
+            "tie-breakers must be gated behind EXTENDED_CHANGE_DETECTION "
+            "to preserve rollback-stability of legacy mode."
+        )
+
     def test_hash_stable_when_vac_crew_rows_share_primary_sort_keys(self):
         """Regression: including VAC crew fields in row_str made the hash
         sensitive to insertion order when multiple VAC crew rows share

--- a/tests/test_vac_crew.py
+++ b/tests/test_vac_crew.py
@@ -224,5 +224,79 @@ class TestVacCrewGroupingLogic(unittest.TestCase):
         self.assertEqual(len(groups[vaccrew_key[0]]), 3)
 
 
+class TestVacCrewHashAggregation(unittest.TestCase):
+    """Regression tests for the VAC crew hash metadata aggregation bug.
+
+    VAC crew groups are not split per foreman in the group key (all VAC crew
+    rows for a given WR+week share a single `_VACCREW` group), so a single
+    group can contain multiple VAC crew members. Prior to the fix, the hash
+    metadata read VAC crew name/dept/job only from sorted_rows[0], which meant
+    edits to VAC crew fields on any non-first row left the hash unchanged and
+    the file was skipped as "unchanged + attachment exists".
+    """
+
+    def _row(self, wr, cu, qty, price, name, dept, job, snapshot='2026-04-19'):
+        return {
+            'Work Request #': wr,
+            'Snapshot Date': snapshot,
+            'CU': cu,
+            'Quantity': qty,
+            'Units Total Price': price,
+            'Units Completed?': True,
+            '__variant': 'vac_crew',
+            '__is_vac_crew': True,
+            '__vac_crew_name': name,
+            '__vac_crew_dept': dept,
+            '__vac_crew_job': job,
+        }
+
+    def test_hash_changes_when_non_first_row_vac_crew_dept_edited(self):
+        """Editing VAC crew dept on a non-first sorted row must change the hash."""
+        base = [
+            self._row('12345', 'CU-A', 1, '$100', 'Alice', '1000', 'J1'),
+            self._row('12345', 'CU-B', 1, '$200', 'Bob',   '2000', 'J2'),
+        ]
+        edited = [
+            self._row('12345', 'CU-A', 1, '$100', 'Alice', '1000', 'J1'),
+            self._row('12345', 'CU-B', 1, '$200', 'Bob',   '2099', 'J2'),
+        ]
+        self.assertNotEqual(
+            generate_weekly_pdfs.calculate_data_hash(base),
+            generate_weekly_pdfs.calculate_data_hash(edited),
+            "Hash did not change after editing a non-first row's VAC crew "
+            "dept — regression: multi-member VAC crew groups will silently "
+            "skip regeneration."
+        )
+
+    def test_hash_changes_when_non_first_row_vac_crew_name_edited(self):
+        """Editing VAC crew name on a non-first sorted row must change the hash."""
+        base = [
+            self._row('12345', 'CU-A', 1, '$100', 'Alice', '1000', 'J1'),
+            self._row('12345', 'CU-B', 1, '$200', 'Bob',   '2000', 'J2'),
+        ]
+        edited = [
+            self._row('12345', 'CU-A', 1, '$100', 'Alice',   '1000', 'J1'),
+            self._row('12345', 'CU-B', 1, '$200', 'Bob Jr.', '2000', 'J2'),
+        ]
+        self.assertNotEqual(
+            generate_weekly_pdfs.calculate_data_hash(base),
+            generate_weekly_pdfs.calculate_data_hash(edited),
+        )
+
+    def test_hash_stable_when_no_vac_crew_fields_change(self):
+        """Same VAC crew data (in any row order) must produce the same hash."""
+        rows = [
+            self._row('12345', 'CU-A', 1, '$100', 'Alice', '1000', 'J1'),
+            self._row('12345', 'CU-B', 1, '$200', 'Bob',   '2000', 'J2'),
+        ]
+        # Shuffled input order must not change hash — calculate_data_hash
+        # already sorts deterministically, and the aggregated VAC crew
+        # metadata is sorted too.
+        self.assertEqual(
+            generate_weekly_pdfs.calculate_data_hash(rows),
+            generate_weekly_pdfs.calculate_data_hash(list(reversed(rows))),
+        )
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
Fixed a bug where edits to VAC crew fields (name/dept/job) on non-first-sorted rows were silently ignored, causing Excel files to skip regeneration even when criteria were met. The root cause was that hash metadata was only read from the first sorted row, but VAC crew groups are not split per foreman and can contain multiple crew members.

## Key Changes

- **Hash aggregation fix**: Modified `calculate_data_hash()` to aggregate `__vac_crew_name`, `__vac_crew_dept`, and `__vac_crew_job` across ALL rows in a VAC crew group (sorted, deduplicated, comma-joined) instead of reading only from `sorted_rows[0]`. This ensures any per-row VAC crew field edit changes the hash and triggers regeneration.

- **Cache invalidation**: Bumped `DISCOVERY_CACHE_VERSION` from 2 → 3 to force re-validation of existing discovery caches. This ensures sheets that had VAC crew columns added after v2 will properly pick up those mappings on the next run rather than waiting up to 7 days for automatic refresh.

- **Regression tests**: Added `TestVacCrewHashAggregation` test class with three test cases:
  - `test_hash_changes_when_non_first_row_vac_crew_dept_edited`: Verifies hash changes when dept is edited on a non-first row
  - `test_hash_changes_when_non_first_row_vac_crew_name_edited`: Verifies hash changes when name is edited on a non-first row
  - `test_hash_stable_when_no_vac_crew_fields_change`: Verifies hash is stable and order-independent when no VAC crew fields change

## Implementation Details

The fix recognizes that VAC crew groups use a single key (`{week}_{wr}_VACCREW`) without per-foreman disambiguation, unlike helper groups which use `{week}_{wr}_HELPER_{helper}`. This means a single group contains all VAC crew members for a WR+week combination. The aggregation approach (sorted sets, deduplicated, comma-joined) maintains hash stability while capturing all relevant metadata changes.

Documentation of the bug, fix, and new rules has been added to CLAUDE.md for future reference.

https://claude.ai/code/session_018XPtK1XraGyJHTfBUoUKB2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production-critical change-detection hashing and cache invalidation, which can force or skip Excel regeneration if wrong; added regression tests reduce the likelihood of unintended churn or missed updates.
> 
> **Overview**
> Fixes VAC crew Excel regeneration being incorrectly skipped when editing VAC crew name/dept/job on a non-first row by updating `calculate_data_hash()` to include VAC crew fields **per row** (only for the `vac_crew` variant) and adding VAC-crew tie-breakers to the extended-mode sort for deterministic hashing.
> 
> Bumps `DISCOVERY_CACHE_VERSION` to invalidate stale sheet/column mapping caches, and adds focused regression coverage in `tests/test_vac_crew.py` for non-first-row edits, set-dedup and comma-in-name collision edge cases, legacy-mode stability, and insertion-order stability. Documentation in `CLAUDE.md` records the incident, fix, and new rules for future hashing changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe2730408bc8bdf58994aecdb8a6852654f3e47d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->