### PR TITLE
security: pin create-pull-request action to immutable SHA

### DIFF
--- a/.github/workflows/docs-changelog.yml
+++ b/.github/workflows/docs-changelog.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Open pull request with runbook entry
         id: open_pr
         if: steps.generate.outputs.post_path != ''
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
         with:
           # Using the default GITHUB_TOKEN means the resulting PR does not
           # re-trigger push/pull_request workflows (a built-in GitHub safety)


### PR DESCRIPTION
### Motivation
- Mitigate a supply-chain risk where the workflow `/.github/workflows/docs-changelog.yml` referenced the third-party action `peter-evans/create-pull-request@v6` (a mutable tag) while the workflow grants write-scoped permissions, which would allow a retagged or compromised action to modify the repository.

### Description
- Replace the mutable reference `uses: peter-evans/create-pull-request@v6` in `.github/workflows/docs-changelog.yml` with an immutable commit pin `uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6` to preserve behavior while removing the retagging risk.

### Testing
- Confirmed the vulnerable reference existed at HEAD, ran `git ls-remote https://github.com/peter-evans/create-pull-request refs/tags/v6`, committed the single-line change, and validated with `git diff --check -- .github/workflows/docs-changelog.yml` and `git diff -- .github/workflows/docs-changelog.yml`, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7d1ab529c8326ba6fce75023d7a34)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a one-line GitHub Actions change that pins a third-party action to a specific commit, reducing supply-chain risk without altering workflow logic.
> 
> **Overview**
> Pins `peter-evans/create-pull-request` in `.github/workflows/docs-changelog.yml` from the mutable `@v6` tag to an immutable commit SHA (still *v6*) to reduce supply-chain/retagging risk while keeping behavior the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3e3b4a5dfb2774a08137570ae5b913cd8dfac03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->