### PR TITLE
Classify PostgREST errors to avoid retry spam on permanent failures

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1195,3 +1195,82 @@ When proposing new workflows, dynamically evaluate the absolute best technology.
   the broader quarantine. A reusable ``_run_pre_scan`` test
   helper mirrors the production pre-scan so the test drift
   between case-setups is eliminated.
+- [2026-04-24 10:50] Production incident: the billing_audit
+  attribution-snapshot integration spammed the session log with
+  repeated retries against Supabase — HTTP 406 Not Acceptable on
+  every call to ``feature_flag``, ``freeze_attribution``,
+  ``pipeline_run_select``, and ``pipeline_run_upsert``. Each op
+  burned the full 4-attempt × (1.5 + 2.5 + 4.5s) backoff budget
+  before each op's circuit breaker tripped independently at 3
+  exhaustions. **Root cause:** ``billing_audit/client.py``'s
+  ``with_retry`` treated EVERY ``postgrest.APIError`` as
+  transient. A 406 from PostgREST is actually a PERMANENT
+  rejection — in this case code ``PGRST106`` ("The schema must
+  be one of the following: public"), which means the
+  ``billing_audit`` schema is not in Supabase's exposed-schemas
+  list. No amount of retrying can fix a server-side
+  schema-exposure configuration. **Fix (additive,
+  production-safe):** (1) New ``_classify_postgrest_error(exc)
+  -> (is_transient, is_global_kill, reason_code)`` helper
+  inspects ``APIError.code``: codes starting with ``PGRST1`` /
+  ``PGRST2`` / ``PGRST3`` and HTTP ``4xx`` stringified codes
+  are classified permanent (bail after first attempt); codes
+  in ``_PGRST_GLOBAL_KILL_CODES`` (``PGRST106`` schema not
+  exposed, ``PGRST301`` / ``PGRST302`` JWT invalid/expired)
+  additionally flip a run-global kill switch
+  (``_global_disable_reason``). An APIError with no code
+  (exotic body-parse failure) and HTTP ``5xx`` codes stay
+  transient. (2) ``get_client()`` now returns ``None`` when the
+  kill switch is set, so every downstream writer path
+  (``freeze_row``, ``emit_run_fingerprint``,
+  ``any_flag_enabled``) silently no-ops for the rest of the
+  run — identical to the "missing credentials" and ``TEST_MODE``
+  paths. Preserves the existing fail-safe contract: a
+  misconfigured billing_audit integration must never break the
+  billing pipeline itself. (3) New ``_disable_for_run`` emits
+  exactly ONE operator-facing WARNING on first trip, naming the
+  reason code and pointing at the concrete fix — for PGRST106,
+  "Supabase: Project Settings → API → Data API Settings →
+  'Exposed schemas': add 'billing_audit', save, and reload the
+  schema cache". For PGRST301/302, points at
+  ``SUPABASE_SERVICE_ROLE_KEY`` rotation. (4) Non-global
+  permanent errors (generic PGRST1xx from a malformed payload,
+  etc.) still increment the per-op circuit breaker counter but
+  do NOT poison unrelated ops — the existing per-op breaker
+  isolation contract is preserved. **New rules:** (1) When
+  wrapping a library exception type (``APIError``,
+  ``ClientError``) in a retry helper, classify by the
+  exception's carried metadata (``code``, ``status_code``,
+  SQLSTATE), not by the class itself. Treating a class as
+  uniformly transient burns retry budget on permanent errors
+  and spams operator logs. The classifier is the single place
+  to teach the retry helper which codes are worth retrying.
+  (2) When a failure is INTEGRATION-WIDE (schema exposure,
+  auth key), a per-op circuit breaker alone is insufficient —
+  it measures N endpoints to a schema all failing, which is
+  already known from the first failure. Ship a run-global kill
+  switch that flips ``get_client()`` to ``None`` on detection
+  so the rest of the run skips ALL integration work at the
+  zero-network cost. (3) Permanent-error WARNINGs must tell
+  operators WHERE TO FIX IT, not just WHAT HAPPENED. For every
+  code in ``_PGRST_GLOBAL_KILL_CODES`` the disable message
+  names the exact Supabase Dashboard path or env-var to check
+  — a 2 AM on-call engineer should not have to read the
+  PostgREST docs to understand what to do. (4) The kill
+  switch is test-reset-sensitive: ``reset_cache_for_tests``
+  MUST clear ``_global_disable_reason`` and
+  ``_global_disable_logged`` or one test's tripped state leaks
+  into unrelated tests in the same pytest run. Regression
+  tests: new
+  ``tests/test_billing_audit_shadow.py::PostgrestErrorClassificationTests``
+  (11 tests) — classifier contract (global-kill for PGRST106 /
+  PGRST301, op-permanent for generic PGRST1xx, permanent for
+  HTTP 4xx, transient for HTTP 5xx / missing code), retry
+  short-circuit (one attempt on permanent APIError, no
+  ``time.sleep`` backoff), global kill (one WARNING with
+  "Exposed schemas" text, ``get_client()`` returns None after
+  trip, other ops fast-fail without fn invocation), and
+  ``reset_cache_for_tests`` resets both new state variables.
+  Zero changes to group-processing, Excel-generation, upload,
+  or hash-history paths — the billing pipeline itself is
+  untouched by this fix.

--- a/billing_audit/client.py
+++ b/billing_audit/client.py
@@ -277,6 +277,20 @@ def _classify_postgrest_error(
     no ``code`` attribute still classifies cleanly.
     """
     code = getattr(exc, "code", None)
+
+    # Coerce integer codes to string. ``postgrest.exceptions.
+    # generate_default_error_message`` (invoked when the HTTP
+    # response body isn't valid JSON) populates ``APIError.code``
+    # with the raw ``httpx.Response.status_code`` — an ``int``.
+    # Without this coercion a non-JSON 406 / 401 / 404 body would
+    # fail the ``isinstance(code, str)`` check, fall into the
+    # "no code → transient" branch, and burn the full retry
+    # budget on an inherently-permanent HTTP rejection — exactly
+    # the retry-spam mode this classifier exists to prevent.
+    # (Codex P2 2026-04-24.)
+    if isinstance(code, int):
+        code = str(code)
+
     if not isinstance(code, str) or not code:
         # No code field — assume transient. This matches the
         # pre-fix behaviour for exotic APIError shapes and keeps

--- a/billing_audit/client.py
+++ b/billing_audit/client.py
@@ -63,6 +63,59 @@ _CIRCUIT_BREAKER_THRESHOLD = 3
 _consecutive_failures: dict[str, int] = {}
 _open_circuits: set[str] = set()
 
+# ── PostgREST error classification ────────────────────────────────
+# PostgREST returns a JSON error body with a ``code`` field.
+# postgrest-py lifts that into ``APIError.code`` (a string). Some
+# codes indicate a PERMANENT error that no amount of retrying will
+# fix (schema not exposed, JWT invalid, malformed query), while
+# others (or a missing code on a transient body-parse failure) can
+# still be transient.
+#
+# The pre-fix behaviour treated EVERY ``APIError`` as transient, so
+# a misconfigured Supabase (e.g. ``billing_audit`` schema not in the
+# project's "Exposed schemas" list → HTTP 406 / ``PGRST106`` on every
+# call) burned the full 4-attempt × 8.5s backoff budget per call,
+# per op, before each op's circuit breaker tripped. The result was
+# ~60-120s of log-spammed retries per session with zero chance of
+# success.
+_PGRST_PERMANENT_PREFIXES: tuple[str, ...] = (
+    "PGRST1",  # parser / schema / content-negotiation errors
+    "PGRST2",  # auth errors (JWT invalid/expired, RLS denial)
+    "PGRST3",  # miscellaneous permanent (e.g. profile-switching)
+)
+
+# HTTP status codes that PostgREST sometimes surfaces as stringified
+# values via ``generate_default_error_message`` when the response
+# body isn't valid JSON. A 4xx means "client request was rejected"
+# — retrying the same request won't make the server change its mind.
+_HTTP_PERMANENT_CODES: frozenset[str] = frozenset({
+    "400", "401", "403", "404", "405", "406",
+    "409", "410", "415", "422",
+})
+
+# PostgREST error codes that indicate the ENTIRE billing_audit
+# integration is misconfigured for this run — not a transient /
+# per-endpoint issue. The schema-exposure / JWT problems here affect
+# every table + RPC in ``billing_audit`` equally, so letting each op
+# independently exhaust its per-op circuit breaker is pure waste.
+# Detecting these once flips a run-global kill switch that makes
+# ``get_client()`` return None for the rest of the run.
+_PGRST_GLOBAL_KILL_CODES: frozenset[str] = frozenset({
+    "PGRST106",  # Schema not in db-schemas (Supabase "Exposed schemas")
+    "PGRST301",  # JWT expired
+    "PGRST302",  # Anonymous access forbidden / JWT invalid
+})
+
+# Run-global kill switch. Set the first time a ``_PGRST_GLOBAL_KILL_CODES``
+# error is observed by ``with_retry``. Once set, ``get_client()``
+# short-circuits to ``None`` and the main pipeline's per-row
+# ``freeze_row`` / ``emit_run_fingerprint`` calls all silently no-op
+# — identical to the "credentials missing" path. Preserves the
+# fail-safe contract: a misconfigured billing_audit integration must
+# never break the billing pipeline itself.
+_global_disable_reason: str | None = None
+_global_disable_logged: bool = False
+
 
 def _is_test_mode() -> bool:
     """Match the pipeline's TEST_MODE semantics without importing it.
@@ -110,8 +163,22 @@ def get_client() -> Any:
     - ``SUPABASE_URL`` or ``SUPABASE_SERVICE_ROLE_KEY`` is missing.
     - The ``supabase`` package is not installed.
     - Client construction raises.
+    - A run-global PostgREST misconfiguration was detected earlier
+      this run (schema not exposed, JWT invalid); see
+      ``_PGRST_GLOBAL_KILL_CODES`` and ``with_retry``.
     """
     global _client_cache, _client_initialized
+
+    # Run-global kill switch: a prior call tripped a permanent,
+    # integration-wide PostgREST error (e.g. the ``billing_audit``
+    # schema is not in Supabase's exposed-schemas list). Every
+    # subsequent RPC would hit the same error — short-circuit all
+    # downstream callers to the same "client unavailable" path that
+    # missing credentials and TEST_MODE already use. No log spam
+    # (the disable WARNING was already emitted once by
+    # ``_disable_for_run``).
+    if _global_disable_reason is not None:
+        return None
 
     if _client_initialized:
         return _client_cache
@@ -167,11 +234,125 @@ def get_client() -> Any:
 def reset_cache_for_tests() -> None:
     """Clear module-level caches. Test-only helper."""
     global _client_cache, _client_initialized, _flag_cache
+    global _global_disable_reason, _global_disable_logged
     _client_cache = None
     _client_initialized = False
     _flag_cache = {}
     _consecutive_failures.clear()
     _open_circuits.clear()
+    _global_disable_reason = None
+    _global_disable_logged = False
+
+
+def _classify_postgrest_error(
+    exc: Exception,
+) -> tuple[bool, bool, str | None]:
+    """Classify a ``postgrest.APIError`` for retry purposes.
+
+    Returns ``(is_transient, is_global_kill, reason_code)``.
+
+    - ``is_transient`` — True when retrying MIGHT succeed. Network-
+      level issues surface as ``httpx.HTTPError`` / name-matched
+      exceptions (handled separately in ``with_retry``); the only
+      APIError shape we keep as transient is "no code field" (rare;
+      usually a 5xx whose body wasn't valid JSON).
+    - ``is_global_kill`` — True when the error applies to every
+      table + RPC in the ``billing_audit`` schema (schema not
+      exposed, auth invalid). Tripping the per-op breaker four
+      times doesn't fix a schema-exposure problem.
+    - ``reason_code`` — the ``APIError.code`` string for logs /
+      breadcrumbs. ``None`` when the exception carries no code.
+
+    Called only for already-confirmed APIError instances, so the
+    ``getattr`` fallback is defensive — a malformed subclass with
+    no ``code`` attribute still classifies cleanly.
+    """
+    code = getattr(exc, "code", None)
+    if not isinstance(code, str) or not code:
+        # No code field — assume transient. This matches the
+        # pre-fix behaviour for exotic APIError shapes and keeps
+        # unrelated 5xx body-parse blips retryable.
+        return True, False, None
+
+    if code in _PGRST_GLOBAL_KILL_CODES:
+        return False, True, code
+
+    if code.startswith(_PGRST_PERMANENT_PREFIXES):
+        return False, False, code
+
+    if code in _HTTP_PERMANENT_CODES:
+        return False, False, code
+
+    # Unknown code — default to transient. Better to waste one
+    # backoff budget on a novel error than to silently suppress
+    # a genuinely-retryable condition.
+    return True, False, code
+
+
+def _disable_for_run(reason_code: str, exc: Exception) -> None:
+    """Trip the run-global kill switch.
+
+    Subsequent ``get_client()`` calls return ``None``, which makes
+    every downstream writer path (``freeze_row``,
+    ``emit_run_fingerprint``, flag probes) silently no-op for the
+    rest of the session. The pipeline's Excel generation, upload,
+    and hash-history paths are unaffected.
+
+    Idempotent in its user-visible output: the operator-facing
+    WARNING fires only on the first trip. Subsequent calls update
+    ``_global_disable_reason`` without re-emitting the log line.
+    """
+    global _global_disable_reason, _global_disable_logged
+    _global_disable_reason = reason_code
+
+    if _global_disable_logged:
+        return
+    _global_disable_logged = True
+
+    message = getattr(exc, "message", None) or ""
+    hint = getattr(exc, "hint", None) or ""
+
+    if reason_code == "PGRST106":
+        operator_hint = (
+            "The 'billing_audit' schema is not exposed by PostgREST. "
+            "In Supabase: Project Settings → API → Data API Settings "
+            "→ 'Exposed schemas': add 'billing_audit', save, and "
+            "reload the schema cache. The billing pipeline itself "
+            "continues unaffected."
+        )
+    elif reason_code in ("PGRST301", "PGRST302"):
+        operator_hint = (
+            "Supabase authentication rejected the service-role key. "
+            "Verify SUPABASE_SERVICE_ROLE_KEY is current (check for "
+            "rotation) and that the key grants access to the "
+            "'billing_audit' schema. The billing pipeline itself "
+            "continues unaffected."
+        )
+    else:  # Defensive — only codes in _PGRST_GLOBAL_KILL_CODES reach here.
+        operator_hint = (
+            f"billing_audit returned permanent error {reason_code}; "
+            "integration disabled for this run."
+        )
+
+    # Keep the message sanitized — server response bodies can quote
+    # identifiers, but for PGRST106/301/302 they only quote schema /
+    # role names, which are operational context (not row PII).
+    logging.warning(
+        f"🔌 billing_audit disabled for this run "
+        f"(code={reason_code}). {operator_hint} "
+        f"Server message: {message.strip()!r}. "
+        f"Server hint: {hint.strip()!r}."
+    )
+    _sentry_breadcrumb(
+        "billing_audit",
+        "Integration globally disabled",
+        level="warning",
+        data={
+            "reason_code": reason_code,
+            "server_message": message,
+            "server_hint": hint,
+        },
+    )
 
 
 def is_flag_resolved(key: str) -> bool:
@@ -302,6 +483,16 @@ def with_retry(fn: Callable[..., Any], *args: Any,
     Returns ``fn``'s return value on success. On final failure, logs
     a WARNING, emits a Sentry breadcrumb, and returns ``None``.
     """
+    # Run-global kill switch check: a prior op detected a
+    # schema-exposure / auth misconfiguration. All subsequent calls
+    # to any op short-circuit. ``get_client()`` already short-
+    # circuits at the writer layer, but a caller that captured the
+    # client reference before the kill switch tripped could still
+    # reach here — this guard is the belt to the ``get_client``
+    # suspenders.
+    if _global_disable_reason is not None:
+        return None
+
     if op in _open_circuits:
         # Fast path: breaker is open for THIS op; skip all RPC
         # work. Other ops are unaffected.
@@ -320,8 +511,23 @@ def with_retry(fn: Callable[..., Any], *args: Any,
             last_error_name = err_name
             is_transient = False
             if _PGAPIError is not None and isinstance(exc, _PGAPIError):
-                is_transient = True
-            if _HTTPError is not None and isinstance(exc, _HTTPError):
+                # Classify by the PostgREST error code. Permanent
+                # PGRST1xx / PGRST2xx / PGRST3xx codes and HTTP
+                # 4xx codes bail after the first attempt — no
+                # retry will fix a schema-not-exposed or auth
+                # rejection. Run-global kill codes also trip the
+                # module-wide kill switch so every other op
+                # short-circuits to ``None`` without making the
+                # doomed round trip.
+                is_transient, is_global_kill, reason_code = (
+                    _classify_postgrest_error(exc)
+                )
+                if is_global_kill:
+                    _disable_for_run(reason_code or "UNKNOWN", exc)
+                    # Skip the retry loop entirely — no benefit.
+                    final_was_transient = False
+                    break
+            elif _HTTPError is not None and isinstance(exc, _HTTPError):
                 is_transient = True
             if any(marker in err_name for marker in _TRANSIENT_ERROR_MARKERS):
                 is_transient = True

--- a/billing_audit/client.py
+++ b/billing_audit/client.py
@@ -87,11 +87,20 @@ _PGRST_PERMANENT_PREFIXES: tuple[str, ...] = (
 # HTTP status codes that PostgREST sometimes surfaces as stringified
 # values via ``generate_default_error_message`` when the response
 # body isn't valid JSON. A 4xx means "client request was rejected"
-# — retrying the same request won't make the server change its mind.
-_HTTP_PERMANENT_CODES: frozenset[str] = frozenset({
-    "400", "401", "403", "404", "405", "406",
-    "409", "410", "415", "422",
-})
+# — retrying the same request won't make the server change its mind
+# — with two documented exceptions that are genuinely retryable:
+# ``408 Request Timeout`` (server-side timeout, transient) and
+# ``429 Too Many Requests`` (rate limit, transient with backoff).
+# Treating the whole 4xx range minus those two as permanent keeps
+# the contract honest against any code PostgREST might stringify
+# in the future, rather than a hand-maintained subset that silently
+# routes novel 4xxs (e.g. 411/413/414/418) into the retry-spam path
+# the classifier was introduced to fix.
+_HTTP_PERMANENT_CODES: frozenset[str] = frozenset(
+    str(status_code)
+    for status_code in range(400, 500)
+    if status_code not in {408, 429}
+)
 
 # PostgREST error codes that indicate the ENTIRE billing_audit
 # integration is misconfigured for this run — not a transient /
@@ -524,9 +533,21 @@ def with_retry(fn: Callable[..., Any], *args: Any,
                 )
                 if is_global_kill:
                     _disable_for_run(reason_code or "UNKNOWN", exc)
-                    # Skip the retry loop entirely — no benefit.
-                    final_was_transient = False
-                    break
+                    # Global kill replaces ALL per-op bookkeeping for
+                    # this call: skip the per-op circuit breaker
+                    # counter, skip the generic "RPC failed after N
+                    # attempt(s)" WARNING, skip the generic Sentry
+                    # breadcrumb. The operator-facing WARNING from
+                    # ``_disable_for_run`` is the single source of
+                    # truth for this run, matching the "exactly one
+                    # WARNING per run" contract in the PR description.
+                    # Incrementing the per-op counter here would also
+                    # race ahead of the breaker threshold (threshold
+                    # = 3 but the integration is already disabled),
+                    # producing a misleading "circuit breaker OPEN
+                    # after 1 consecutive immediate failures" line
+                    # that contradicts the disable message.
+                    return None
             elif _HTTPError is not None and isinstance(exc, _HTTPError):
                 is_transient = True
             if any(marker in err_name for marker in _TRANSIENT_ERROR_MARKERS):

--- a/billing_audit/client.py
+++ b/billing_audit/client.py
@@ -64,12 +64,17 @@ _consecutive_failures: dict[str, int] = {}
 _open_circuits: set[str] = set()
 
 # ── PostgREST error classification ────────────────────────────────
-# PostgREST returns a JSON error body with a ``code`` field.
-# postgrest-py lifts that into ``APIError.code`` (a string). Some
-# codes indicate a PERMANENT error that no amount of retrying will
-# fix (schema not exposed, JWT invalid, malformed query), while
-# others (or a missing code on a transient body-parse failure) can
-# still be transient.
+# PostgREST returns a JSON error body with a ``code`` field, and
+# postgrest-py lifts that into ``APIError.code`` — **``str | int``**:
+# usually a PostgREST error-code string (``PGRST106``, ``PGRST301``,
+# …) or a SQLSTATE, but sometimes an HTTP status-code integer when
+# the response body isn't valid JSON and the library falls back to
+# ``generate_default_error_message``. The classifier normalizes
+# both shapes to ``str`` before prefix / membership checks.
+# Some codes indicate a PERMANENT error that no amount of retrying
+# will fix (schema not exposed, JWT invalid, malformed query),
+# while others (or a missing code on a transient body-parse
+# failure) can still be transient.
 #
 # The pre-fix behaviour treated EVERY ``APIError`` as transient, so
 # a misconfigured Supabase (e.g. ``billing_audit`` schema not in the
@@ -262,15 +267,24 @@ def _classify_postgrest_error(
 
     - ``is_transient`` — True when retrying MIGHT succeed. Network-
       level issues surface as ``httpx.HTTPError`` / name-matched
-      exceptions (handled separately in ``with_retry``); the only
-      APIError shape we keep as transient is "no code field" (rare;
-      usually a 5xx whose body wasn't valid JSON).
+      exceptions (handled separately in ``with_retry``). For
+      ``APIError`` instances, transient cases are:
+        * missing / malformed ``code`` (``None`` or empty string,
+          after the ``int`` → ``str`` coercion);
+        * unknown codes that don't match any ``PGRST`` prefix or
+          ``_HTTP_PERMANENT_CODES`` membership;
+        * HTTP status codes NOT listed as permanent, which includes
+          the retryable 4xx escape hatches (``408`` request
+          timeout, ``429`` rate-limit) and all 5xx server errors
+          when ``APIError.code`` is populated from the raw HTTP
+          status via ``generate_default_error_message``.
     - ``is_global_kill`` — True when the error applies to every
       table + RPC in the ``billing_audit`` schema (schema not
       exposed, auth invalid). Tripping the per-op breaker four
       times doesn't fix a schema-exposure problem.
-    - ``reason_code`` — the ``APIError.code`` string for logs /
-      breadcrumbs. ``None`` when the exception carries no code.
+    - ``reason_code`` — the ``APIError.code`` (stringified, after
+      int coercion) for logs / breadcrumbs. ``None`` when the
+      exception carries no code at all.
 
     Called only for already-confirmed APIError instances, so the
     ``getattr`` fallback is defensive — a malformed subclass with

--- a/tests/test_billing_audit_shadow.py
+++ b/tests/test_billing_audit_shadow.py
@@ -1436,6 +1436,18 @@ class WithRetryAttemptReportingTests(unittest.TestCase):
         self.assertTrue(rpc_failed[0]["data"]["was_transient"])
 
 
+try:
+    from postgrest import APIError as _POSTGREST_API_ERROR_CLS  # type: ignore
+except Exception:
+    _POSTGREST_API_ERROR_CLS = None  # type: ignore[assignment]
+
+
+@unittest.skipIf(
+    _POSTGREST_API_ERROR_CLS is None,
+    "postgrest not installed — skipping PostgREST APIError classification "
+    "tests (the classifier itself is a no-op in that environment since "
+    "``with_retry`` also bails on the ``isinstance(exc, _PGAPIError)`` check).",
+)
 class PostgrestErrorClassificationTests(unittest.TestCase):
     """with_retry must classify ``postgrest.APIError`` by its
     ``code`` field instead of blanket-treating every APIError as
@@ -1449,6 +1461,14 @@ class PostgrestErrorClassificationTests(unittest.TestCase):
     permanent codes, and the run-global kill switch that disables
     the entire billing_audit integration on a
     ``_PGRST_GLOBAL_KILL_CODES`` error.
+
+    Skip gating happens at the class decorator (not inside the
+    helper) because several tests invoke ``_make_api_error`` from a
+    callback passed to ``with_retry``. ``with_retry``'s
+    ``except Exception as exc`` catches ``unittest.SkipTest`` — a
+    subclass of ``Exception`` — and converts it into a regular RPC
+    failure, which would turn "postgrest missing" into
+    assertion-failures instead of a proper skip. Codex P2 2026-04-24.
     """
 
     def setUp(self):
@@ -1459,14 +1479,12 @@ class PostgrestErrorClassificationTests(unittest.TestCase):
 
     def _make_api_error(self, code, message="", hint="", details=""):
         """Build a real ``postgrest.APIError`` the same way postgrest-py
-        does when unwrapping the JSON response body. Skips the test
-        if postgrest isn't importable (CI-safety).
+        does when unwrapping the JSON response body. Safe to call from
+        within a ``with_retry`` callback — the missing-dependency check
+        lives on the class decorator, so this helper never raises
+        ``SkipTest`` that would be swallowed by the retry wrapper.
         """
-        try:
-            from postgrest import APIError  # type: ignore
-        except Exception:
-            self.skipTest("postgrest not installed")
-        return APIError({
+        return _POSTGREST_API_ERROR_CLS({
             "code": code,
             "message": message,
             "hint": hint,
@@ -1562,6 +1580,45 @@ class PostgrestErrorClassificationTests(unittest.TestCase):
                 self.assertTrue(is_transient)
                 self.assertFalse(is_global_kill)
 
+    def test_classifier_transient_for_retryable_4xx(self):
+        """HTTP 408 (Request Timeout) and 429 (Too Many Requests)
+        are the two 4xx codes that ARE retryable — they indicate
+        transient server-side conditions rather than permanent
+        client-side rejections. Copilot 2026-04-24.
+        """
+        from billing_audit import client as ba_client
+        for code in ("408", "429"):
+            with self.subTest(code=code):
+                exc = self._make_api_error(code, message=f"HTTP {code}")
+                is_transient, is_global_kill, _ = (
+                    ba_client._classify_postgrest_error(exc)
+                )
+                self.assertTrue(is_transient)
+                self.assertFalse(is_global_kill)
+
+    def test_classifier_permanent_for_full_4xx_range(self):
+        """Any stringified 4xx other than 408/429 must classify as
+        permanent, so a novel PostgREST 4xx (e.g. 411/413/414/418)
+        doesn't silently fall back into the transient retry-spam
+        path the classifier was introduced to close. Copilot
+        2026-04-24.
+        """
+        from billing_audit import client as ba_client
+        transient_4xx = {"408", "429"}
+        # Spot-check the edges and a handful of uncommon codes that
+        # a hand-maintained subset would likely miss.
+        for status_code in (400, 411, 413, 414, 418, 423, 451, 499):
+            code = str(status_code)
+            if code in transient_4xx:
+                continue
+            with self.subTest(code=code):
+                exc = self._make_api_error(code, message=f"HTTP {code}")
+                is_transient, is_global_kill, _ = (
+                    ba_client._classify_postgrest_error(exc)
+                )
+                self.assertFalse(is_transient)
+                self.assertFalse(is_global_kill)
+
     # ── with_retry short-circuit behaviour ───────────────────────
 
     def test_with_retry_bails_after_one_attempt_on_permanent_api_error(self):
@@ -1629,6 +1686,31 @@ class PostgrestErrorClassificationTests(unittest.TestCase):
         self.assertEqual(len(disabled_lines), 1, cm.output)
         self.assertIn("Exposed schemas", disabled_lines[0])
         self.assertIn("billing_audit", disabled_lines[0])
+
+        # Regression guard (Copilot 2026-04-24): the global-kill
+        # path must NOT also emit the generic "RPC failed after N
+        # attempt(s)" WARNING. The disable WARNING is the single
+        # source of truth for this run. If with_retry later
+        # regresses to ``break`` + fall-through, both lines would
+        # fire and this assertion catches it.
+        generic_failure_lines = [
+            line for line in cm.output
+            if "RPC failed after" in line
+        ]
+        self.assertEqual(generic_failure_lines, [], cm.output)
+
+        # Global-kill path must also skip the per-op breaker
+        # bookkeeping: the misleading "circuit breaker OPEN after 1
+        # consecutive immediate failures" line would contradict the
+        # disable WARNING.
+        breaker_lines = [
+            line for line in cm.output
+            if "circuit breaker OPEN" in line
+        ]
+        self.assertEqual(breaker_lines, [], cm.output)
+        self.assertEqual(
+            ba_client._consecutive_failures.get("feature_flag", 0), 0
+        )
 
     def test_with_retry_global_kill_is_logged_once(self):
         """Multiple PGRST106 calls (e.g. because an op captured a
@@ -1706,6 +1788,87 @@ class PostgrestErrorClassificationTests(unittest.TestCase):
         ba_client.reset_cache_for_tests()
         self.assertIsNone(ba_client._global_disable_reason)
         self.assertFalse(ba_client._global_disable_logged)
+
+    def test_disable_for_run_pgrst301_guidance_points_at_service_role_key(self):
+        """JWT invalid/expired must emit an operator-facing message
+        that names the env var to rotate. Asymmetric from the
+        PGRST106 path (which points at the Dashboard), so the
+        branch needs its own test.
+        """
+        from billing_audit import client as ba_client
+
+        def failing():
+            raise self._make_api_error(
+                "PGRST301",
+                message="JWT expired",
+                hint="Refresh your authentication token",
+            )
+
+        ba_client._client_cache = mock.Mock()
+        ba_client._client_initialized = True
+        with mock.patch(
+            "billing_audit.client.time.sleep"
+        ), self.assertLogs(level="WARNING") as cm:
+            ba_client.with_retry(failing, op="feature_flag")
+
+        self.assertEqual(ba_client._global_disable_reason, "PGRST301")
+        disabled_lines = [
+            line for line in cm.output
+            if "disabled for this run" in line
+        ]
+        self.assertEqual(len(disabled_lines), 1, cm.output)
+        self.assertIn("SUPABASE_SERVICE_ROLE_KEY", disabled_lines[0])
+
+    def test_disable_for_run_second_call_is_idempotent(self):
+        """Defense in depth: a caller that invokes ``_disable_for_run``
+        twice directly (e.g. a future code path that flips the kill
+        switch both at the retry loop and at an enclosing guard)
+        must NOT re-emit the operator-facing WARNING — the reason
+        code is captured on the first call and subsequent calls are
+        silent updates. This matches the ``_global_disable_logged``
+        contract documented on the helper.
+        """
+        from billing_audit import client as ba_client
+
+        exc = self._make_api_error(
+            "PGRST106", message="Schema not exposed"
+        )
+        with self.assertLogs(level="WARNING") as cm:
+            ba_client._disable_for_run("PGRST106", exc)
+            ba_client._disable_for_run("PGRST106", exc)
+
+        disabled_lines = [
+            line for line in cm.output
+            if "disabled for this run" in line
+        ]
+        self.assertEqual(len(disabled_lines), 1, cm.output)
+        self.assertEqual(ba_client._global_disable_reason, "PGRST106")
+
+    def test_disable_for_run_defensive_fallback_for_unknown_code(self):
+        """The ``else`` branch in ``_disable_for_run`` is defensive —
+        ``with_retry`` only invokes it for codes in
+        ``_PGRST_GLOBAL_KILL_CODES``, so no production flow reaches
+        the fallback message. Test it directly so a future code
+        addition to ``_PGRST_GLOBAL_KILL_CODES`` that forgets to
+        add a matching operator-facing branch in ``_disable_for_run``
+        still emits a non-empty WARNING naming the unhandled code
+        (rather than crashing or logging an empty hint).
+        """
+        from billing_audit import client as ba_client
+
+        exc = self._make_api_error(
+            "PGRST999", message="Hypothetical future code"
+        )
+        with self.assertLogs(level="WARNING") as cm:
+            ba_client._disable_for_run("PGRST999", exc)
+
+        disabled_lines = [
+            line for line in cm.output
+            if "disabled for this run" in line
+        ]
+        self.assertEqual(len(disabled_lines), 1, cm.output)
+        self.assertIn("PGRST999", disabled_lines[0])
+        self.assertIn("integration disabled", disabled_lines[0])
 
 
 class BackfillCliDateValidationTests(unittest.TestCase):

--- a/tests/test_billing_audit_shadow.py
+++ b/tests/test_billing_audit_shadow.py
@@ -1569,6 +1569,73 @@ class PostgrestErrorClassificationTests(unittest.TestCase):
         self.assertFalse(is_global_kill)
         self.assertIsNone(reason)
 
+    def test_classifier_coerces_integer_code_from_default_error(self):
+        """``postgrest.exceptions.generate_default_error_message`` is
+        invoked whenever the HTTP response body isn't valid JSON
+        (common for misconfigured proxies, WAF-intercepted errors,
+        and 5xx HTML bodies). It populates ``APIError.code`` with
+        the raw ``httpx.Response.status_code`` — an ``int``, not a
+        ``str``. The classifier must coerce before the
+        ``isinstance(code, str)`` gate; otherwise an integer 406
+        would land in the "no code → transient" branch and
+        reintroduce the retry-spam this fix was written to close.
+
+        Codex P2 2026-04-24.
+        """
+        from billing_audit import client as ba_client
+        # Permanent 4xx returned with a non-JSON body — postgrest-
+        # py constructs ``APIError({"code": 406, ...})`` with the
+        # status code as an int. Round-trip through APIError
+        # confirms the classifier sees what postgrest-py produces
+        # in the wild, not a mocked string.
+        for status_code in (400, 401, 403, 404, 406, 422):
+            with self.subTest(status_code=status_code):
+                exc = _POSTGREST_API_ERROR_CLS({
+                    "message": "JSON could not be generated",
+                    "code": status_code,  # int, as in the real path
+                    "hint": "Refer to full message for details",
+                    "details": "<html>...</html>",
+                })
+                self.assertIsInstance(exc.code, int)  # sanity
+                is_transient, is_global_kill, reason = (
+                    ba_client._classify_postgrest_error(exc)
+                )
+                self.assertFalse(
+                    is_transient,
+                    f"HTTP {status_code} (int code) must be permanent",
+                )
+                self.assertFalse(is_global_kill)
+                self.assertEqual(reason, str(status_code))
+
+        # And the transient 4xx escape hatches still work when the
+        # code arrives as int: 408/429 remain retryable.
+        for status_code in (408, 429):
+            with self.subTest(status_code=status_code):
+                exc = _POSTGREST_API_ERROR_CLS({
+                    "message": "JSON could not be generated",
+                    "code": status_code,
+                    "hint": "",
+                    "details": "",
+                })
+                is_transient, _, _ = (
+                    ba_client._classify_postgrest_error(exc)
+                )
+                self.assertTrue(is_transient)
+
+        # 5xx as int still transient.
+        for status_code in (500, 502, 503):
+            with self.subTest(status_code=status_code):
+                exc = _POSTGREST_API_ERROR_CLS({
+                    "message": "JSON could not be generated",
+                    "code": status_code,
+                    "hint": "",
+                    "details": "",
+                })
+                is_transient, _, _ = (
+                    ba_client._classify_postgrest_error(exc)
+                )
+                self.assertTrue(is_transient)
+
     def test_classifier_transient_for_http_5xx_stringified(self):
         from billing_audit import client as ba_client
         for code in ("500", "502", "503", "504"):

--- a/tests/test_billing_audit_shadow.py
+++ b/tests/test_billing_audit_shadow.py
@@ -1436,6 +1436,278 @@ class WithRetryAttemptReportingTests(unittest.TestCase):
         self.assertTrue(rpc_failed[0]["data"]["was_transient"])
 
 
+class PostgrestErrorClassificationTests(unittest.TestCase):
+    """with_retry must classify ``postgrest.APIError`` by its
+    ``code`` field instead of blanket-treating every APIError as
+    transient. The pre-fix behaviour burned the full 4-attempt ×
+    8.5s backoff budget on a schema-not-exposed misconfiguration
+    (HTTP 406 / PGRST106), per op, before each op's circuit
+    breaker tripped — ~60-120s of doomed retries per session
+    against a permanent server-side rejection.
+
+    Covers the classifier contract, the retry short-circuit for
+    permanent codes, and the run-global kill switch that disables
+    the entire billing_audit integration on a
+    ``_PGRST_GLOBAL_KILL_CODES`` error.
+    """
+
+    def setUp(self):
+        _reset_all()
+
+    def tearDown(self):
+        _reset_all()
+
+    def _make_api_error(self, code, message="", hint="", details=""):
+        """Build a real ``postgrest.APIError`` the same way postgrest-py
+        does when unwrapping the JSON response body. Skips the test
+        if postgrest isn't importable (CI-safety).
+        """
+        try:
+            from postgrest import APIError  # type: ignore
+        except Exception:
+            self.skipTest("postgrest not installed")
+        return APIError({
+            "code": code,
+            "message": message,
+            "hint": hint,
+            "details": details,
+        })
+
+    # ── Classifier contract ──────────────────────────────────────
+
+    def test_classifier_global_kill_for_schema_not_exposed(self):
+        """PGRST106 ("The schema must be one of the following: ...")
+        is the exact code PostgREST returns when the requested
+        ``Accept-Profile`` / ``Content-Profile`` schema is not in
+        the project's exposed-schemas list. This is a run-global
+        misconfiguration — every table + RPC in the schema will
+        fail the same way.
+        """
+        from billing_audit import client as ba_client
+        exc = self._make_api_error(
+            "PGRST106",
+            message="The schema must be one of the following: public",
+            hint="Only the following schemas are exposed: public",
+        )
+        is_transient, is_global_kill, reason = (
+            ba_client._classify_postgrest_error(exc)
+        )
+        self.assertFalse(is_transient)
+        self.assertTrue(is_global_kill)
+        self.assertEqual(reason, "PGRST106")
+
+    def test_classifier_global_kill_for_jwt_expired(self):
+        from billing_audit import client as ba_client
+        exc = self._make_api_error("PGRST301", message="JWT expired")
+        is_transient, is_global_kill, _ = (
+            ba_client._classify_postgrest_error(exc)
+        )
+        self.assertFalse(is_transient)
+        self.assertTrue(is_global_kill)
+
+    def test_classifier_permanent_but_not_global_kill_for_pgrst1xx(self):
+        """Generic PGRST1xx / PGRST2xx / PGRST3xx codes are permanent
+        but op-scoped — a malformed payload or single-endpoint
+        contract violation. Bail after one attempt; keep the per-op
+        circuit breaker behaviour but don't poison the whole run.
+        """
+        from billing_audit import client as ba_client
+        exc = self._make_api_error(
+            "PGRST100", message="Unrecognised operator"
+        )
+        is_transient, is_global_kill, _ = (
+            ba_client._classify_postgrest_error(exc)
+        )
+        self.assertFalse(is_transient)
+        self.assertFalse(is_global_kill)
+
+    def test_classifier_permanent_for_http_4xx_stringified(self):
+        """When PostgREST can't return JSON, postgrest-py synthesises
+        an APIError with ``code=str(r.status_code)`` via
+        ``generate_default_error_message``. HTTP 4xx → permanent.
+        """
+        from billing_audit import client as ba_client
+        for code in ("400", "401", "403", "404", "406", "422"):
+            with self.subTest(code=code):
+                exc = self._make_api_error(code, message=f"HTTP {code}")
+                is_transient, is_global_kill, _ = (
+                    ba_client._classify_postgrest_error(exc)
+                )
+                self.assertFalse(is_transient)
+                self.assertFalse(is_global_kill)
+
+    def test_classifier_transient_for_missing_code(self):
+        """An APIError whose dict carries no ``code`` field (exotic
+        shape from a body-parse failure) falls back to transient so
+        novel 5xx-style blips still retry — matches the pre-fix
+        behaviour for unclassified APIError bodies.
+        """
+        from billing_audit import client as ba_client
+        exc = self._make_api_error(None, message="no code")
+        is_transient, is_global_kill, reason = (
+            ba_client._classify_postgrest_error(exc)
+        )
+        self.assertTrue(is_transient)
+        self.assertFalse(is_global_kill)
+        self.assertIsNone(reason)
+
+    def test_classifier_transient_for_http_5xx_stringified(self):
+        from billing_audit import client as ba_client
+        for code in ("500", "502", "503", "504"):
+            with self.subTest(code=code):
+                exc = self._make_api_error(code, message=f"HTTP {code}")
+                is_transient, is_global_kill, _ = (
+                    ba_client._classify_postgrest_error(exc)
+                )
+                self.assertTrue(is_transient)
+                self.assertFalse(is_global_kill)
+
+    # ── with_retry short-circuit behaviour ───────────────────────
+
+    def test_with_retry_bails_after_one_attempt_on_permanent_api_error(self):
+        """Before the fix, any APIError burned all 4 attempts. After
+        the fix, a permanent PGRST1xx code fails fast.
+        """
+        from billing_audit import client as ba_client
+        calls = {"n": 0}
+
+        def failing():
+            calls["n"] += 1
+            raise self._make_api_error(
+                "PGRST100", message="Bad query"
+            )
+
+        with mock.patch("billing_audit.client.time.sleep") as msleep:
+            result = ba_client.with_retry(failing, op="feature_flag")
+
+        self.assertIsNone(result)
+        self.assertEqual(calls["n"], 1)
+        # time.sleep must NOT have been called — no retry backoff.
+        msleep.assert_not_called()
+
+    def test_with_retry_global_kill_fires_once_and_disables_client(self):
+        """PGRST106 on the first op must (a) short-circuit the retry
+        loop, (b) flip the global kill switch so ``get_client()``
+        returns None, and (c) emit exactly ONE operator-facing
+        WARNING pointing at the Supabase exposed-schemas setting.
+        """
+        from billing_audit import client as ba_client
+
+        # Pre-seed an initialized client so the kill switch, not
+        # missing credentials, is what drives ``get_client()`` to
+        # return None.
+        ba_client._client_cache = mock.Mock()
+        ba_client._client_initialized = True
+        self.assertIsNotNone(ba_client.get_client())
+
+        def failing():
+            raise self._make_api_error(
+                "PGRST106",
+                message="The schema must be one of the following: public",
+                hint="Only the following schemas are exposed: public",
+            )
+
+        with mock.patch(
+            "billing_audit.client.time.sleep"
+        ), self.assertLogs(level="WARNING") as cm:
+            result = ba_client.with_retry(failing, op="feature_flag")
+
+        self.assertIsNone(result)
+        # Global kill is set.
+        self.assertEqual(ba_client._global_disable_reason, "PGRST106")
+        # get_client now returns None even though the client cache
+        # object is still populated — the kill switch takes priority.
+        self.assertIsNone(ba_client.get_client())
+
+        # Operator-facing WARNING must mention the actionable fix
+        # path: 'Exposed schemas' in Supabase. The exact string
+        # appears in _disable_for_run.
+        disabled_lines = [
+            line for line in cm.output
+            if "disabled for this run" in line
+        ]
+        self.assertEqual(len(disabled_lines), 1, cm.output)
+        self.assertIn("Exposed schemas", disabled_lines[0])
+        self.assertIn("billing_audit", disabled_lines[0])
+
+    def test_with_retry_global_kill_is_logged_once(self):
+        """Multiple PGRST106 calls (e.g. because an op captured a
+        client reference before the kill switch tripped) must not
+        re-emit the operator-facing WARNING on every call — one
+        clear message per run is the contract.
+        """
+        from billing_audit import client as ba_client
+
+        def failing():
+            raise self._make_api_error(
+                "PGRST106", message="Schema not exposed"
+            )
+
+        with mock.patch(
+            "billing_audit.client.time.sleep"
+        ), self.assertLogs(level="WARNING") as cm:
+            # First call trips the kill switch and logs.
+            ba_client.with_retry(failing, op="feature_flag")
+            # Reset the client-cached short-circuit path: directly
+            # invoke with_retry again, simulating a captured-client
+            # caller bypassing get_client.
+            ba_client.with_retry(failing, op="feature_flag")
+            ba_client.with_retry(failing, op="freeze_attribution")
+
+        disabled_lines = [
+            line for line in cm.output
+            if "disabled for this run" in line
+        ]
+        self.assertEqual(len(disabled_lines), 1, cm.output)
+
+    def test_with_retry_short_circuits_other_ops_after_kill(self):
+        """After the kill switch trips on one op, every OTHER op
+        must short-circuit to None without making a network call.
+        Saves ~8.5s × (N-1) ops of doomed retry budget per run.
+        """
+        from billing_audit import client as ba_client
+
+        def trip():
+            raise self._make_api_error(
+                "PGRST106", message="Schema not exposed"
+            )
+
+        unrelated_calls = {"n": 0}
+
+        def unrelated():
+            unrelated_calls["n"] += 1
+            return mock.Mock(data=[{"something": True}])
+
+        with mock.patch("billing_audit.client.time.sleep"):
+            # Trip on feature_flag.
+            self.assertIsNone(
+                ba_client.with_retry(trip, op="feature_flag")
+            )
+            # Every other op now fast-fails to None without invoking fn.
+            for op in (
+                "freeze_attribution",
+                "pipeline_run_select",
+                "pipeline_run_upsert",
+            ):
+                with self.subTest(op=op):
+                    self.assertIsNone(
+                        ba_client.with_retry(unrelated, op=op)
+                    )
+            self.assertEqual(unrelated_calls["n"], 0)
+
+    def test_reset_cache_for_tests_clears_kill_switch(self):
+        """Test isolation: the kill switch must reset so one test's
+        tripped state can't leak into unrelated tests in the same
+        run.
+        """
+        from billing_audit import client as ba_client
+        ba_client._global_disable_reason = "PGRST106"
+        ba_client._global_disable_logged = True
+        ba_client.reset_cache_for_tests()
+        self.assertIsNone(ba_client._global_disable_reason)
+        self.assertFalse(ba_client._global_disable_logged)
+
+
 class BackfillCliDateValidationTests(unittest.TestCase):
     """_parse_week_mmddyy must reject invalid calendar dates with
     argparse.ArgumentTypeError so argparse surfaces a usage message


### PR DESCRIPTION
## Summary

Fix a production incident where permanent PostgREST errors (e.g., schema not exposed) caused the billing_audit integration to spam retry attempts across all operations. The fix adds error classification logic to distinguish transient errors (worth retrying) from permanent ones (fail fast), and implements a run-global kill switch to disable the entire integration when a misconfiguration is detected.

## Key Changes

- **Error Classification** (`_classify_postgrest_error`): New helper that inspects `postgrest.APIError.code` to determine if an error is transient or permanent:
  - Permanent: PGRST1xx/PGRST2xx/PGRST3xx codes, HTTP 4xx stringified codes → bail after first attempt
  - Global kill: PGRST106 (schema not exposed), PGRST301/PGRST302 (JWT invalid/expired) → disable entire integration
  - Transient: HTTP 5xx codes, missing code field → continue retrying
  
- **Run-Global Kill Switch** (`_global_disable_reason`, `_global_disable_logged`): When a global-kill error is detected:
  - `get_client()` returns `None` for the rest of the run, making all downstream operations silently no-op
  - Preserves the fail-safe contract: misconfigured billing_audit never breaks the billing pipeline
  - Prevents wasted retry budget across multiple operations hitting the same root cause

- **Operator-Facing Diagnostics** (`_disable_for_run`): Emits exactly one WARNING per run with:
  - The error code and server message
  - Concrete fix instructions (e.g., "Supabase: Project Settings → API → Data API Settings → 'Exposed schemas': add 'billing_audit'")
  - Sentry breadcrumb for observability

- **Retry Loop Integration**: Modified `with_retry` to:
  - Check the kill switch before attempting any operation
  - Classify APIErrors instead of treating all as transient
  - Short-circuit on permanent errors (no backoff sleep)
  - Break immediately on global-kill errors

- **Test Isolation**: Updated `reset_cache_for_tests` to clear the new global state variables

## Implementation Details

- The fix is additive and production-safe: unknown error codes default to transient behavior (matching pre-fix behavior)
- Per-operation circuit breakers are preserved for non-global permanent errors
- Comprehensive test coverage (11 new tests) validates classifier contract, retry short-circuiting, global kill behavior, and test isolation
- No changes to group processing, Excel generation, upload, or hash-history paths

https://claude.ai/code/session_01TqAYdUeuNjB8PP3atUvPfN