### PR TITLE
Guard Python rate recalc on Smartsheet-native pricing folders

### DIFF
--- a/.github/workflows/weekly-excel-generation.yml
+++ b/.github/workflows/weekly-excel-generation.yml
@@ -257,11 +257,34 @@ jobs:
           # Helper/Resiliency Grouping Mode
           RES_GROUPING_MODE: ${{ github.event.inputs.res_grouping_mode || 'both' }}
           
-          # Rate Contract Versioning (set via repo Variables in Settings > Secrets and variables > Actions)
-          # RATE_CUTOFF_DATE: YYYY-MM-DD date when new rates take effect (empty = disabled)
-          RATE_CUTOFF_DATE: ${{ vars.RATE_CUTOFF_DATE || '' }}
-          NEW_RATES_CSV: ${{ vars.NEW_RATES_CSV || '' }}
-          OLD_RATES_CSV: ${{ vars.OLD_RATES_CSV || '' }}
+          # ─────────────────────────────────────────────────────────────
+          # LEGACY: Python CSV-side rate recalc — RETIRED 2026-04-24.
+          # ─────────────────────────────────────────────────────────────
+          # Smartsheet now emits the authoritative Units Total Price
+          # natively for sheets in ORIGINAL_CONTRACT_FOLDER_IDS
+          # (7644752003786628, 8815193070299012) on rows whose
+          # Snapshot Date >= 2026-04-12 and Units Completed? = true.
+          # Running the Python recalc on top of Smartsheet's
+          # authoritative price was a silent-corruption trap — see
+          # CLAUDE.md Living Ledger entry [2026-04-24] for the full
+          # incident write-up.
+          #
+          # These env vars are pinned to empty strings here so the
+          # production workflow CANNOT pass through a stray value
+          # from repo Variables. The Python code paths
+          # (recalculate_row_price, _resolve_rate_recalc_cutoff_date,
+          # build_cu_to_group_mapping, load_rate_versions) are
+          # retained intentionally so re-enablement is a one-line
+          # workflow revert, not a code rewrite.
+          #
+          # Revert path: replace each '' with the previous
+          # ${{ vars.<NAME> || '' }} form. The Python
+          # RATE_RECALC_SKIP_ORIGINAL_CONTRACT guard (default on)
+          # still protects the two folders even if cutoff is
+          # re-enabled, so a revert is safe by default.
+          RATE_CUTOFF_DATE: ''
+          NEW_RATES_CSV: ''
+          OLD_RATES_CSV: ''
 
           # Advanced Filters
           WR_FILTER: ${{ github.event.inputs.wr_filter || '' }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1367,3 +1367,69 @@ When proposing new workflows, dynamically evaluate the absolute best technology.
   itself is unchanged by the guard (callers invoking the helper
   directly still get the full recalc behaviour regardless of
   env vars).
+- [2026-04-24 14:30] Retired the Python CSV-side rate recalc
+  feature in production. Follow-up to the 11:30 entry above:
+  rather than rely solely on the per-sheet
+  ``RATE_RECALC_SKIP_ORIGINAL_CONTRACT`` guard to protect the
+  two original-contract folders, operators decided that since
+  Smartsheet's native pricing is now authoritative for those
+  folders, the entire CSV-side recalc path should be treated as
+  legacy across the production workflow — there is no remaining
+  production sheet that needs Python-side post-cutoff rate
+  recalculation. **Change:** ``.github/workflows/weekly-excel-
+  generation.yml`` now hardcodes ``RATE_CUTOFF_DATE: ''``,
+  ``NEW_RATES_CSV: ''``, ``OLD_RATES_CSV: ''`` (was
+  ``${{ vars.<NAME> || '' }}``) with a prominent LEGACY comment
+  block explaining the retirement and revert path. A repo
+  Variable that re-introduces a value is now ignored by the
+  workflow — pinning the value at the workflow layer makes the
+  decision code-reviewable through git history rather than
+  hidden in GitHub Actions UI. **Defense-in-depth on the Python
+  side:** ``generate_weekly_pdfs.py`` now emits a WARNING in the
+  startup banner whenever ``RATE_CUTOFF_DATE`` is detected,
+  pointing operators at this ledger entry. This catches local
+  dev shells, ad-hoc scripts, or future workflows that might
+  re-introduce the env var by accident. **What stays:** every
+  recalc helper (``recalculate_row_price``,
+  ``_resolve_rate_recalc_cutoff_date``,
+  ``build_cu_to_group_mapping``, ``load_rate_versions``), the
+  ``RATE_RECALC_SKIP_ORIGINAL_CONTRACT`` guard from the prior
+  commit on this branch, and every existing test. The code is
+  retained intentionally so re-enablement is a one-line workflow
+  revert (restore the three ``${{ vars.<NAME> || '' }}`` lines)
+  rather than a code rewrite. **Docs:** ``website/docs/reference/
+  environment.md`` "Rate contract versioning" section now leads
+  with a Docusaurus ``:::caution LEGACY`` admonition pointing
+  at this entry, and each row in the variable table is prefixed
+  with ``(LEGACY)``. **New rules:** (1) When an external system
+  takes over a column we used to compute locally AND there is no
+  remaining local consumer that benefits from the local
+  computation, retire the local feature in the workflow layer
+  — do NOT just leave it env-gated. Workflow pinning is
+  enforceable through git history; repo-Variable defaults are
+  not. (2) Retire vs. delete: keep the code paths intact behind
+  the workflow pin if the underlying business problem (post-
+  cutoff billing) could realistically come back (rate contract
+  renegotiation, new subcontractor, Smartsheet formula
+  regression). The marginal carrying cost of retained code +
+  tests is much lower than the cost of rewriting the recalc
+  pipeline from scratch under incident pressure. (3) When
+  retiring an env-var-gated feature, ALSO emit a runtime
+  WARNING when the env var is detected — silent retirement is
+  a footgun for any developer running locally with stale
+  ``.env`` files. The WARNING must point at the ledger entry
+  that explains why, not just say "deprecated". (4) Any future
+  un-retire of this feature MUST be paired with explicit
+  verification that the rows being re-priced are NOT already
+  Smartsheet-priced for the same column. The
+  ``RATE_RECALC_SKIP_ORIGINAL_CONTRACT`` guard remains the
+  default-on protection for the two folders documented in the
+  11:30 entry above; if a future engineer disables the guard
+  without confirming Smartsheet's formula has been removed
+  first, the same silent-corruption trap reopens. No new tests
+  are added for this retirement — existing tests in
+  ``tests/test_subcontractor_pricing.py``, ``tests/test_vac_crew.py``,
+  and ``tests/test_security_audit_followup.py`` already cover
+  the retained code paths because they explicitly set
+  ``RATE_CUTOFF_DATE`` in setUp/tearDown for isolation. Verified
+  via ``pytest tests/`` (393 passed / 17 skipped) post-change.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1274,3 +1274,96 @@ When proposing new workflows, dynamically evaluate the absolute best technology.
   Zero changes to group-processing, Excel-generation, upload,
   or hash-history paths — the billing pipeline itself is
   untouched by this fix.
+- [2026-04-24 11:30] Production over-pricing risk on the two
+  original-contract folders. Operators report Smartsheet has now
+  implemented the post-cutoff rates natively inside each sheet's
+  ``Units Total Price`` column for sheets in folders
+  ``7644752003786628`` and ``8815193070299012``
+  (``ORIGINAL_CONTRACT_FOLDER_IDS``) whenever ``Snapshot Date >=
+  2026-04-12`` and ``Units Completed? = true``. The Python-side
+  pre-acceptance rate recalc in ``_fetch_and_process_sheet`` was
+  still firing on those sheets (the existing gate only excluded
+  subcontractor sheets), so for every post-cutoff row the
+  Smartsheet-authoritative price was being overwritten in-place
+  by ``rate × qty`` from ``NEW_RATES_CSV`` via
+  ``recalculate_row_price``. Where the CSV and Smartsheet's
+  formula agreed this was a no-op; where they disagreed (CU
+  naming drift, work-type parsing edge cases, quantity
+  interpretation), the row shipped with an over- or under-billed
+  ``Units Total Price``. Root cause, not a symptom — running two
+  pricing systems sequentially on the same row is the bug;
+  fixing Smartsheet's formula or the CSV individually would not
+  have closed the hole. **Fix (additive, production-safe):**
+  (1) New env var ``RATE_RECALC_SKIP_ORIGINAL_CONTRACT``
+  (default ``'1'`` / True; accepts ``1``/``true``/``yes``/``on``)
+  wired into the startup banner alongside
+  ``RATE_RECALC_WEEKLY_FALLBACK`` so its resolved state is
+  visible on every run. (2) New per-sheet flag
+  ``is_original_contract_sheet = source['id'] in
+  _FOLDER_DISCOVERED_ORIG_IDS`` computed once alongside
+  ``is_subcontractor_sheet`` in ``_fetch_and_process_sheet``;
+  ``_FOLDER_DISCOVERED_ORIG_IDS`` is populated unconditionally
+  by ``discover_folder_sheets`` at the top of
+  ``discover_source_sheets`` on every run (before the
+  discovery-cache branch), so the membership test is reliable
+  even when the cache is served warm. (3) Composite
+  short-circuit ``_skip_recalc_original_contract`` fires only
+  when ``RATE_CUTOFF_DATE`` is set AND the env var is on AND
+  the sheet is in the ORIG folder AND the sheet is NOT a
+  subcontractor sheet — preserving the existing subcontractor
+  exclusion as primary (a sheet misconfigured into both sets
+  still skips via the subcontractor path and the ORIG skip log
+  never duplicates). (4) One ``🛡️`` info log per sheet when the
+  guard fires; the row-level gate adds ``and not
+  _skip_recalc_original_contract`` to short-circuit at zero
+  cost per row without spamming logs. (5) Per-sheet "Rate
+  recalc summary" is suppressed on skipped sheets (all counters
+  are zero by construction — the summary would be noise). The
+  single 🛡️ info log is the authoritative per-sheet signal.
+  (6) The "Dropped VAC/helper row" warning's fallback-disabled
+  ``_recalc_note`` branch gains ``and not
+  _skip_recalc_original_contract`` so operators are not told
+  to flip ``RATE_RECALC_WEEKLY_FALLBACK=1`` on sheets where
+  doing so would not change anything (recalc is skipped by
+  design). **What stays unchanged:** ``recalculate_row_price``,
+  ``_resolve_rate_recalc_cutoff_date``,
+  ``build_cu_to_group_mapping``, ``load_rate_versions``, the
+  Weekly-Ref-Date fallback, the snapshot-keyed primary cutoff
+  rule, subcontractor (Arrowhead) sheets' existing "keep
+  SmartSheet price" behaviour, and every test currently locking
+  in recalc behaviour for non-ORIG sheets. The fix is purely
+  additive. **New rules:** (1) When an external system
+  (Smartsheet here, any SaaS with server-side formulas) starts
+  emitting authoritative values for a column we also compute
+  locally, add a per-sheet / per-scope guard that short-circuits
+  the local computation rather than trying to reconcile two
+  independent sources row-by-row. Sequential double-writes on
+  the same field are a silent-corruption trap: where the two
+  systems agree, it's a no-op and no one notices; where they
+  disagree, the last write wins and the disagreement ships to
+  production unaudited. (2) Any such guard MUST be env-gated
+  with a default-ON kill switch
+  (``RATE_RECALC_SKIP_ORIGINAL_CONTRACT=0`` here) so operators
+  can restore pre-fix behaviour if the external system's
+  authoritative source breaks, without shipping a code change.
+  (3) Log the guard's active state in the startup banner and
+  emit one info log per sheet when it fires. Do NOT spam the
+  row-level gate with a log — use the per-sheet flag as the
+  single announcement surface. (4) Any follow-up operator note
+  that suggests an env-var flip (e.g. "set
+  ``RATE_RECALC_WEEKLY_FALLBACK=1`` to rescue this row") MUST
+  gate on whether the flip would actually change this sheet's
+  behaviour. On skipped sheets, tell the operator the correct
+  story (or stay silent) — a false lead wastes on-call time.
+  Regression tests:
+  ``tests/test_subcontractor_pricing.py::TestOriginalContractFolderSkipsRateRecalc``
+  (8 tests) covers the env-var wiring (exists + is ``bool``),
+  the default folder-ID list (contains ``7644752003786628`` and
+  ``8815193070299012``), the truth-table of the guard (fires on
+  ORIG + cutoff + env on; does NOT fire on non-ORIG; does NOT
+  fire with env off; does NOT fire without cutoff; does NOT
+  fire on subcontractor sheets — subcontractor exclusion stays
+  primary), and an isolation test that ``recalculate_row_price``
+  itself is unchanged by the guard (callers invoking the helper
+  directly still get the full recalc behaviour regardless of
+  env vars).

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -384,6 +384,22 @@ RATE_RECALC_WEEKLY_FALLBACK = os.getenv(
     'RATE_RECALC_WEEKLY_FALLBACK', '1'
 ).lower() in ('1', 'true', 'yes', 'on')
 
+# Smartsheet-native pricing guard for original-contract folders.
+# Default-ON: sheets discovered via ORIGINAL_CONTRACT_FOLDER_IDS (folders
+# whose Smartsheet formula already emits the correct post-cutoff
+# Units Total Price for rows with Snapshot Date >= RATE_CUTOFF_DATE
+# and Units Completed? = true) are excluded from Python-side recalc.
+# Running recalc on top of Smartsheet's already-correct price risked
+# overwriting the Smartsheet-authoritative value with a CSV-derived
+# rate × qty that did not always match, producing over/under-billed
+# rows. Set RATE_RECALC_SKIP_ORIGINAL_CONTRACT=0 (or false/no/off) to
+# restore the pre-fix behaviour (run recalc on these folders too).
+# Subcontractor sheets are excluded unconditionally regardless of this
+# flag (same as before this guard existed).
+RATE_RECALC_SKIP_ORIGINAL_CONTRACT = os.getenv(
+    'RATE_RECALC_SKIP_ORIGINAL_CONTRACT', '1'
+).lower() in ('1', 'true', 'yes', 'on')
+
 if RATE_CUTOFF_DATE:
     logging.info(f"📊 Rate contract versioning ENABLED: cutoff date = {RATE_CUTOFF_DATE.isoformat()}")
     if RATE_RECALC_WEEKLY_FALLBACK:
@@ -393,6 +409,18 @@ if RATE_CUTOFF_DATE:
         )
     else:
         logging.info("📊 Rate recalc Weekly-Ref-Date fallback DISABLED (RATE_RECALC_WEEKLY_FALLBACK=false)")
+    if RATE_RECALC_SKIP_ORIGINAL_CONTRACT:
+        logging.info(
+            "📊 Rate recalc ORIGINAL_CONTRACT folder skip ENABLED "
+            "(sheets discovered via ORIGINAL_CONTRACT_FOLDER_IDS keep "
+            "Smartsheet-native Units Total Price, no CSV-side recalc)"
+        )
+    else:
+        logging.info(
+            "📊 Rate recalc ORIGINAL_CONTRACT folder skip DISABLED "
+            "(RATE_RECALC_SKIP_ORIGINAL_CONTRACT=false) — recalc will "
+            "run on original-contract folder sheets too"
+        )
 else:
     logging.info("📊 Rate contract versioning DISABLED (RATE_CUTOFF_DATE not set)")
 
@@ -2689,6 +2717,26 @@ def get_all_source_rows(client, source_sheets):
         try:
             logging.info(f"⚡ Processing: {source['name']} (ID: {source['id']})")
             is_subcontractor_sheet = source['id'] in SUBCONTRACTOR_SHEET_IDS
+            # Smartsheet-native pricing guard: sheets discovered via
+            # ORIGINAL_CONTRACT_FOLDER_IDS already produce their
+            # Units Total Price from Smartsheet's internal formula for
+            # post-cutoff rows with Units Completed? = true. The
+            # Python-side recalc must NOT overwrite that value.
+            # See RATE_RECALC_SKIP_ORIGINAL_CONTRACT env var declaration
+            # for the full rationale and the kill-switch.
+            is_original_contract_sheet = source['id'] in _FOLDER_DISCOVERED_ORIG_IDS
+            _skip_recalc_original_contract = (
+                RATE_CUTOFF_DATE is not None
+                and RATE_RECALC_SKIP_ORIGINAL_CONTRACT
+                and is_original_contract_sheet
+                and not is_subcontractor_sheet
+            )
+            if _skip_recalc_original_contract:
+                logging.info(
+                    f"🛡️ Skipping Python rate recalc for {source['name']} "
+                    f"(ID: {source['id']}) — sheet is in ORIGINAL_CONTRACT_FOLDER_IDS "
+                    f"and Smartsheet-native pricing is authoritative for post-cutoff rows"
+                )
 
             try:
                 # Fetch sheet once (no column history); include columns to support unmapped summary
@@ -2825,7 +2873,20 @@ def get_all_source_rows(client, source_sheets):
                         _rate_recalc_ran_for_row = False
                         _recalc_outcome = None
                         _recalc_via_fallback = False
-                        if RATE_CUTOFF_DATE and _rate_new_primary and not is_subcontractor_sheet:
+                        # ``_skip_recalc_original_contract`` is sheet-level
+                        # (computed once above, logged once per sheet) —
+                        # adding it to this row-level gate avoids per-row
+                        # log spam while still short-circuiting every row
+                        # on an original-contract folder sheet. Subcontractor
+                        # exclusion stays primary; the original-contract
+                        # skip only kicks in when Smartsheet-native pricing
+                        # is authoritative for the whole sheet.
+                        if (
+                            RATE_CUTOFF_DATE
+                            and _rate_new_primary
+                            and not is_subcontractor_sheet
+                            and not _skip_recalc_original_contract
+                        ):
                             # Primary gate is Snapshot Date; the helper
                             # transparently falls back to Weekly
                             # Reference Logged Date when Snapshot Date
@@ -3088,6 +3149,16 @@ def get_all_source_rows(client, source_sheets):
                                         not _rate_recalc_ran_for_row
                                         and RATE_CUTOFF_DATE
                                         and not RATE_RECALC_WEEKLY_FALLBACK
+                                        # The Weekly-Ref-Date-fallback note
+                                        # is only valid when recalc was
+                                        # genuinely eligible to run on this
+                                        # sheet. Original-contract folder
+                                        # sheets skip recalc by design
+                                        # (Smartsheet-native pricing is
+                                        # authoritative), so enabling the
+                                        # fallback env var would not change
+                                        # anything on those sheets.
+                                        and not _skip_recalc_original_contract
                                         # Use the same parser the recalc
                                         # gate uses so an unparseable
                                         # Snapshot Date (treated as blank
@@ -3161,7 +3232,17 @@ def get_all_source_rows(client, source_sheets):
                 # signal operators need to investigate missing entries
                 # in NEW_RATES_CSV (common on VAC crew specialized work
                 # like vacuum switches, softswitches, switched banks).
-                if RATE_CUTOFF_DATE and _rate_new_primary:
+                # Suppress the summary entirely on sheets where the
+                # original-contract skip fired — every counter is zero by
+                # construction, so the summary would be noise. The
+                # single "🛡️ Skipping Python rate recalc…" info log
+                # emitted at the start of _fetch_and_process_sheet is
+                # the authoritative per-sheet signal here.
+                if (
+                    RATE_CUTOFF_DATE
+                    and _rate_new_primary
+                    and not _skip_recalc_original_contract
+                ):
                     skipped = sheet_rate_recalc_counts['skipped']
                     recalculated = sheet_rate_recalc_counts['recalculated']
                     fallback_applied = sheet_rate_recalc_counts['fallback_applied']

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -402,6 +402,25 @@ RATE_RECALC_SKIP_ORIGINAL_CONTRACT = os.getenv(
 
 if RATE_CUTOFF_DATE:
     logging.info(f"📊 Rate contract versioning ENABLED: cutoff date = {RATE_CUTOFF_DATE.isoformat()}")
+    # The CSV-side rate recalc was retired in production on
+    # 2026-04-24 because Smartsheet now emits the authoritative
+    # Units Total Price natively for ORIGINAL_CONTRACT_FOLDER_IDS
+    # post-cutoff rows. The production workflow pins
+    # RATE_CUTOFF_DATE='' so this branch should not fire on
+    # scheduled runs anymore. If it DOES fire, something has
+    # bypassed the workflow pinning (local dev shell, an ad-hoc
+    # script, a re-introduced repo Variable) — surface that loudly
+    # so operators can double-check the pricing source before
+    # trusting the output.
+    logging.warning(
+        "⚠️ RATE_CUTOFF_DATE is set, but the Python CSV-side rate "
+        "recalc feature has been retired — Smartsheet now emits "
+        "the authoritative Units Total Price natively on "
+        "ORIGINAL_CONTRACT_FOLDER_IDS sheets, and the production "
+        "workflow pins RATE_CUTOFF_DATE='' as of 2026-04-24. "
+        "Unset RATE_CUTOFF_DATE to silence this warning. See "
+        "CLAUDE.md Living Ledger entry [2026-04-24] for context."
+    )
     if RATE_RECALC_WEEKLY_FALLBACK:
         logging.info(
             "📊 Rate recalc Weekly-Ref-Date fallback ENABLED "

--- a/tests/test_subcontractor_pricing.py
+++ b/tests/test_subcontractor_pricing.py
@@ -1037,6 +1037,198 @@ class TestWeeklyRefDateFallbackCutoff(unittest.TestCase):
         self.assertEqual(row['Units Total Price'], 448.12)
 
 
+class TestOriginalContractFolderSkipsRateRecalc(unittest.TestCase):
+    """Regression tests for the Smartsheet-native pricing guard.
+
+    Production context: Smartsheet now emits the correct post-cutoff
+    ``Units Total Price`` natively for sheets discovered via the two
+    folders in ``ORIGINAL_CONTRACT_FOLDER_IDS``. Running Python-side
+    rate recalc on top of Smartsheet's authoritative price risked
+    overwriting it with a CSV-derived ``rate × qty`` value that did
+    not always agree — producing over/under-billed rows. The guard
+    introduced in this PR short-circuits the recalc gate for sheets
+    whose IDs are in ``_FOLDER_DISCOVERED_ORIG_IDS`` (populated by
+    ``discover_folder_sheets`` at every run start), behind a
+    default-ON env var so the behaviour is reversible by operators.
+    """
+
+    def setUp(self):
+        # Snapshot module state so individual tests can mutate
+        # _FOLDER_DISCOVERED_ORIG_IDS / SUBCONTRACTOR_SHEET_IDS /
+        # RATE_CUTOFF_DATE without leaking into other suites.
+        self._orig_folder_ids = set(generate_weekly_pdfs._FOLDER_DISCOVERED_ORIG_IDS)
+        self._orig_sub_ids = set(generate_weekly_pdfs.SUBCONTRACTOR_SHEET_IDS)
+        self._orig_cutoff = generate_weekly_pdfs.RATE_CUTOFF_DATE
+        self._orig_skip_flag = generate_weekly_pdfs.RATE_RECALC_SKIP_ORIGINAL_CONTRACT
+
+    def tearDown(self):
+        generate_weekly_pdfs._FOLDER_DISCOVERED_ORIG_IDS.clear()
+        generate_weekly_pdfs._FOLDER_DISCOVERED_ORIG_IDS.update(self._orig_folder_ids)
+        generate_weekly_pdfs.SUBCONTRACTOR_SHEET_IDS.clear()
+        generate_weekly_pdfs.SUBCONTRACTOR_SHEET_IDS.update(self._orig_sub_ids)
+        generate_weekly_pdfs.RATE_CUTOFF_DATE = self._orig_cutoff
+        generate_weekly_pdfs.RATE_RECALC_SKIP_ORIGINAL_CONTRACT = self._orig_skip_flag
+
+    def _evaluate_gate(self, sheet_id):
+        """Mirror the exact boolean used in ``_fetch_and_process_sheet``.
+
+        Keeping this tiny helper inline (vs. importing a production
+        helper) is intentional — if the production expression drifts,
+        these tests must be updated in the same PR so the invariant
+        stays locked.
+        """
+        is_subcontractor_sheet = sheet_id in generate_weekly_pdfs.SUBCONTRACTOR_SHEET_IDS
+        is_original_contract_sheet = (
+            sheet_id in generate_weekly_pdfs._FOLDER_DISCOVERED_ORIG_IDS
+        )
+        _skip_recalc_original_contract = (
+            generate_weekly_pdfs.RATE_CUTOFF_DATE is not None
+            and generate_weekly_pdfs.RATE_RECALC_SKIP_ORIGINAL_CONTRACT
+            and is_original_contract_sheet
+            and not is_subcontractor_sheet
+        )
+        recalc_would_run = (
+            generate_weekly_pdfs.RATE_CUTOFF_DATE is not None
+            and not is_subcontractor_sheet
+            and not _skip_recalc_original_contract
+        )
+        return recalc_would_run, _skip_recalc_original_contract
+
+    def test_env_var_exists_and_is_bool(self):
+        """``RATE_RECALC_SKIP_ORIGINAL_CONTRACT`` is wired into the module."""
+        self.assertTrue(
+            hasattr(generate_weekly_pdfs, 'RATE_RECALC_SKIP_ORIGINAL_CONTRACT')
+        )
+        self.assertIsInstance(
+            generate_weekly_pdfs.RATE_RECALC_SKIP_ORIGINAL_CONTRACT, bool
+        )
+
+    def test_default_folder_ids_include_smartsheet_priced_folders(self):
+        """Default ORIGINAL_CONTRACT_FOLDER_IDS covers the two Smartsheet-priced folders.
+
+        Incident: user reported Smartsheet natively prices rows in
+        folders 7644752003786628 and 8815193070299012 for post-cutoff
+        ``Units Completed?`` rows. If these IDs are ever removed from
+        the default list without also updating the env var wiring in
+        ``.github/workflows/weekly-excel-generation.yml``, the guard
+        becomes a no-op on CI runs that rely on the default.
+        """
+        defaults = generate_weekly_pdfs.ORIGINAL_CONTRACT_FOLDER_IDS
+        self.assertIn(7644752003786628, defaults)
+        self.assertIn(8815193070299012, defaults)
+
+    def test_guard_fires_for_original_contract_sheet(self):
+        """Sheet in ORIG folder + cutoff set + env on → recalc skipped."""
+        import datetime as dt
+        generate_weekly_pdfs.RATE_CUTOFF_DATE = dt.date(2026, 4, 12)
+        generate_weekly_pdfs.RATE_RECALC_SKIP_ORIGINAL_CONTRACT = True
+        generate_weekly_pdfs._FOLDER_DISCOVERED_ORIG_IDS.clear()
+        generate_weekly_pdfs._FOLDER_DISCOVERED_ORIG_IDS.add(111111)
+        generate_weekly_pdfs.SUBCONTRACTOR_SHEET_IDS.clear()
+
+        recalc_would_run, skip_fired = self._evaluate_gate(111111)
+        self.assertFalse(recalc_would_run)
+        self.assertTrue(skip_fired)
+
+    def test_guard_does_not_fire_for_non_original_contract_sheet(self):
+        """Sheet NOT in ORIG folder → recalc still runs (pre-fix behaviour)."""
+        import datetime as dt
+        generate_weekly_pdfs.RATE_CUTOFF_DATE = dt.date(2026, 4, 12)
+        generate_weekly_pdfs.RATE_RECALC_SKIP_ORIGINAL_CONTRACT = True
+        generate_weekly_pdfs._FOLDER_DISCOVERED_ORIG_IDS.clear()
+        generate_weekly_pdfs._FOLDER_DISCOVERED_ORIG_IDS.add(111111)
+        generate_weekly_pdfs.SUBCONTRACTOR_SHEET_IDS.clear()
+
+        recalc_would_run, skip_fired = self._evaluate_gate(222222)
+        self.assertTrue(recalc_would_run)
+        self.assertFalse(skip_fired)
+
+    def test_env_var_off_restores_legacy_behaviour(self):
+        """``RATE_RECALC_SKIP_ORIGINAL_CONTRACT=False`` → recalc runs on ORIG sheet too.
+
+        Proves the env-var kill switch works — operators can flip off
+        the guard if Smartsheet-native pricing ever breaks or needs
+        to be bypassed.
+        """
+        import datetime as dt
+        generate_weekly_pdfs.RATE_CUTOFF_DATE = dt.date(2026, 4, 12)
+        generate_weekly_pdfs.RATE_RECALC_SKIP_ORIGINAL_CONTRACT = False
+        generate_weekly_pdfs._FOLDER_DISCOVERED_ORIG_IDS.clear()
+        generate_weekly_pdfs._FOLDER_DISCOVERED_ORIG_IDS.add(111111)
+        generate_weekly_pdfs.SUBCONTRACTOR_SHEET_IDS.clear()
+
+        recalc_would_run, skip_fired = self._evaluate_gate(111111)
+        self.assertTrue(recalc_would_run)
+        self.assertFalse(skip_fired)
+
+    def test_no_cutoff_no_recalc_regardless_of_folder(self):
+        """Without ``RATE_CUTOFF_DATE``, recalc is disabled globally.
+
+        Confirms the original outer guard is preserved — the new
+        folder skip is additive, not a replacement.
+        """
+        generate_weekly_pdfs.RATE_CUTOFF_DATE = None
+        generate_weekly_pdfs.RATE_RECALC_SKIP_ORIGINAL_CONTRACT = True
+        generate_weekly_pdfs._FOLDER_DISCOVERED_ORIG_IDS.clear()
+        generate_weekly_pdfs._FOLDER_DISCOVERED_ORIG_IDS.add(111111)
+        generate_weekly_pdfs.SUBCONTRACTOR_SHEET_IDS.clear()
+
+        recalc_would_run, skip_fired = self._evaluate_gate(111111)
+        self.assertFalse(recalc_would_run)
+        # skip_fired must be False when cutoff is disabled: the skip
+        # flag only matters when recalc was otherwise eligible, and
+        # operators should not see the "🛡️ Skipping..." log on a
+        # cutoff-disabled deployment.
+        self.assertFalse(skip_fired)
+
+    def test_subcontractor_sheet_wins_over_original_contract(self):
+        """Sheet in BOTH sub and orig sets: subcontractor exclusion wins.
+
+        Pathological but possible (misconfiguration). The subcontractor
+        exclusion at the recalc gate is primary and unconditional, so
+        the sheet skips recalc via the subcontractor path and the
+        original-contract skip log never fires (avoiding duplicate
+        "skipping" messages for the same sheet).
+        """
+        import datetime as dt
+        generate_weekly_pdfs.RATE_CUTOFF_DATE = dt.date(2026, 4, 12)
+        generate_weekly_pdfs.RATE_RECALC_SKIP_ORIGINAL_CONTRACT = True
+        generate_weekly_pdfs._FOLDER_DISCOVERED_ORIG_IDS.clear()
+        generate_weekly_pdfs._FOLDER_DISCOVERED_ORIG_IDS.add(111111)
+        generate_weekly_pdfs.SUBCONTRACTOR_SHEET_IDS.clear()
+        generate_weekly_pdfs.SUBCONTRACTOR_SHEET_IDS.add(111111)
+
+        recalc_would_run, skip_fired = self._evaluate_gate(111111)
+        self.assertFalse(recalc_would_run)
+        # Subcontractor-exclusion path short-circuits first, so the
+        # original-contract skip must NOT fire for the same sheet.
+        self.assertFalse(skip_fired)
+
+    def test_guard_does_not_mutate_recalculate_row_price(self):
+        """``recalculate_row_price`` itself is unchanged by the guard.
+
+        The guard is a sheet-level gate; it does NOT modify
+        ``recalculate_row_price``'s behaviour. A caller that invokes
+        the function directly (e.g., a future one-off reprice script)
+        must still get the full recalc behaviour regardless of env
+        vars.
+        """
+        cu_to_group = {'ANC-DHM-10-84-D1': 'ANC-M'}
+        rates = {'ANC-M': {'install': 224.06, 'removal': 29.46, 'transfer': 0.0}}
+        row = {
+            'CU': 'ANC-DHM-10-84-D1',
+            'Work Type': 'Install',
+            'Quantity': '2',
+            'Units Total Price': 0,
+        }
+        # Flip the env flag off — helper should still recalc, proving
+        # the guard is at the caller (sheet-level gate), not here.
+        generate_weekly_pdfs.RATE_RECALC_SKIP_ORIGINAL_CONTRACT = True
+        new_price = generate_weekly_pdfs.recalculate_row_price(row, cu_to_group, rates)
+        self.assertAlmostEqual(new_price, 448.12)
+        self.assertEqual(row['Units Total Price'], 448.12)
+
+
 class TestExpandedHashCoverage(unittest.TestCase):
     """Tests for the expanded calculate_data_hash field coverage."""
 

--- a/tests/test_subcontractor_pricing.py
+++ b/tests/test_subcontractor_pricing.py
@@ -1070,12 +1070,24 @@ class TestOriginalContractFolderSkipsRateRecalc(unittest.TestCase):
         generate_weekly_pdfs.RATE_RECALC_SKIP_ORIGINAL_CONTRACT = self._orig_skip_flag
 
     def _evaluate_gate(self, sheet_id):
-        """Mirror the exact boolean used in ``_fetch_and_process_sheet``.
+        """Mirror the original-contract-skip portion of the production gate.
 
-        Keeping this tiny helper inline (vs. importing a production
-        helper) is intentional — if the production expression drifts,
-        these tests must be updated in the same PR so the invariant
-        stays locked.
+        The full row-level recalc gate in ``_fetch_and_process_sheet``
+        also requires ``_rate_new_primary`` to be populated (the new
+        rates dict, loaded by ``load_rate_versions()`` only when
+        ``RATE_CUTOFF_DATE`` is set). That branch is exercised by the
+        existing recalc-integration tests in
+        ``TestCutoffDateRecalculationIntegration`` and
+        ``TestWeeklyRefDateFallbackCutoff``. This helper deliberately
+        narrows the surface to the **original-contract skip
+        composite** so the truth-table tests below stay fast and don't
+        require seeding a CSV-loaded rates dict for what is purely a
+        boolean-gating concern.
+
+        Keeping the boolean inline (vs. importing a production helper)
+        is intentional — if the production ``_skip_recalc_original_contract``
+        expression drifts, these tests must be updated in the same PR
+        so the invariant stays locked.
         """
         is_subcontractor_sheet = sheet_id in generate_weekly_pdfs.SUBCONTRACTOR_SHEET_IDS
         is_original_contract_sheet = (
@@ -1221,7 +1233,7 @@ class TestOriginalContractFolderSkipsRateRecalc(unittest.TestCase):
             'Quantity': '2',
             'Units Total Price': 0,
         }
-        # Flip the env flag off — helper should still recalc, proving
+        # Flip the env flag on — helper should still recalc, proving
         # the guard is at the caller (sheet-level gate), not here.
         generate_weekly_pdfs.RATE_RECALC_SKIP_ORIGINAL_CONTRACT = True
         new_price = generate_weekly_pdfs.recalculate_row_price(row, cu_to_group, rates)

--- a/website/docs/reference/environment.md
+++ b/website/docs/reference/environment.md
@@ -61,11 +61,25 @@ workflow. Copy `.env.example` to `.env` for local dev.
 
 ## Rate contract versioning
 
+:::caution LEGACY — retired 2026-04-24
+The Python CSV-side rate recalc was retired on 2026-04-24.
+Smartsheet now emits the authoritative `Units Total Price`
+natively on `ORIGINAL_CONTRACT_FOLDER_IDS` sheets for rows whose
+`Snapshot Date >= 2026-04-12` and `Units Completed?` is checked.
+Running the Python recalc on top of Smartsheet's authoritative
+price was a silent-corruption trap. The production workflow
+(`.github/workflows/weekly-excel-generation.yml`) now pins all
+three variables below to empty strings; the env vars themselves
+are retained so re-enablement is a one-line workflow revert if
+ever needed. See the `[2026-04-24]` Living Ledger entry in
+`CLAUDE.md` for the full incident context and revert path.
+:::
+
 | Variable | Purpose |
 | --- | --- |
-| `RATE_CUTOFF_DATE` | `YYYY-MM-DD` switch date for new rates. |
-| `NEW_RATES_CSV` | Path to the new rate CSV. |
-| `OLD_RATES_CSV` | Path to the prior rate CSV. |
+| `RATE_CUTOFF_DATE` (LEGACY) | `YYYY-MM-DD` switch date for new rates. Production workflow pins this to `''`. |
+| `NEW_RATES_CSV` (LEGACY) | Path to the new rate CSV. Production workflow pins this to `''`. |
+| `OLD_RATES_CSV` (LEGACY) | Path to the prior rate CSV. Production workflow pins this to `''`. |
 
 ## Observability
 


### PR DESCRIPTION
## Summary

Adds a production-safe guard to prevent Python-side rate recalculation from overwriting Smartsheet's native post-cutoff pricing on the two original-contract folders (IDs: 7644752003786628, 8815193070299012). Smartsheet now emits the authoritative `Units Total Price` for these folders on rows with `Snapshot Date >= 2026-04-12` and `Units Completed? = true`, and running the Python recalc on top of that value was silently corrupting rows where the CSV-derived rate didn't match Smartsheet's formula.

## Key Changes

- **New env var `RATE_RECALC_SKIP_ORIGINAL_CONTRACT`** (default: `True`)
  - Wired into startup banner alongside existing rate-recalc flags for visibility
  - Accepts `1`/`true`/`yes`/`on` (case-insensitive)
  - Provides operator kill-switch to restore pre-fix behavior if needed

- **Sheet-level guard in `_fetch_and_process_sheet`**
  - Computes `is_original_contract_sheet` once per sheet by checking `_FOLDER_DISCOVERED_ORIG_IDS`
  - `_FOLDER_DISCOVERED_ORIG_IDS` is populated unconditionally by `discover_folder_sheets` at startup, so membership test is reliable even with warm cache
  - Composite condition: guard fires only when cutoff is set AND env var is on AND sheet is in ORIG folder AND sheet is NOT a subcontractor sheet
  - Subcontractor exclusion remains primary (pathological case of sheet in both sets still skips via subcontractor path)

- **Row-level short-circuit**
  - Adds `and not _skip_recalc_original_contract` to the recalc gate to skip every row on guarded sheets at zero cost per row
  - Per-sheet info log (`🛡️ Skipping Python rate recalc…`) emitted once instead of per-row spam

- **Suppressed noise on guarded sheets**
  - Rate recalc summary is suppressed entirely on sheets where the guard fired (all counters are zero by construction)
  - Weekly-Ref-Date fallback note is gated to not suggest enabling fallback on sheets where recalc is skipped by design

- **Workflow-layer retirement of CSV-side recalc**
  - `.github/workflows/weekly-excel-generation.yml` now hardcodes `RATE_CUTOFF_DATE: ''`, `NEW_RATES_CSV: ''`, `OLD_RATES_CSV: ''` with prominent LEGACY comment block
  - Pinning at workflow layer makes the decision code-reviewable through git history rather than hidden in GitHub Actions UI
  - Python code paths retained intentionally so re-enablement is a one-line workflow revert

- **Defense-in-depth warning**
  - `generate_weekly_pdfs.py` emits a WARNING in startup banner whenever `RATE_CUTOFF_DATE` is detected, pointing to CLAUDE.md ledger entry
  - Catches local dev shells, ad-hoc scripts, or future workflows that might re-introduce the env var by accident

- **Documentation updates**
  - `website/docs/reference/environment.md` "Rate contract versioning" section now leads with a Docusaurus `:::caution LEGACY` admonition
  - Each rate-recalc variable row prefixed with `(LEGACY)` and notes production workflow pins them to empty strings

## Implementation Details

- **Regression test suite** (`TestOriginalContractFolderSkipsRateRecalc`, 8 tests)
  - Verifies env var exists and is boolean
  - Confirms default folder IDs include the two Smartsheet-priced folders
  - Truth-table coverage: guard fires on ORIG + cutoff + env on; does NOT fire on non-ORIG; does NOT fire with env off; does NOT fire without cutoff; does NOT fire on subcontractor sheets
  - Isolation test confirms `recalculate_row_price` itself is unchanged (callers invoking directly still get full recalc behavior)

- **No changes to**

https://claude.ai/code/session_0153mLryMbARd3oqAFSaNirV