### PR TITLE
Skip billing-audit for unchanged groups and reduce GitHub Actions time budget

### DIFF
--- a/.github/workflows/weekly-excel-generation.yml
+++ b/.github/workflows/weekly-excel-generation.yml
@@ -172,6 +172,14 @@ jobs:
           restore-keys: |
             discovery-cache-${{ github.ref_name }}-
             discovery-cache-
+      - name: Restore billing-audit row cache
+        uses: actions/cache/restore@v4
+        with:
+          path: generated_docs/billing_audit_frozen_rows.json
+          key: billing-audit-rows-${{ github.ref_name }}-${{ github.run_id }}
+          restore-keys: |
+            billing-audit-rows-${{ github.ref_name }}-
+            billing-audit-rows-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -527,6 +535,13 @@ jobs:
         with:
           path: generated_docs/discovery_cache.json
           key: discovery-cache-${{ github.ref_name }}-${{ github.run_id }}
+
+      - name: Save billing-audit row cache
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: generated_docs/billing_audit_frozen_rows.json
+          key: billing-audit-rows-${{ github.ref_name }}-${{ github.run_id }}
       
       - name: Summary
         if: always()

--- a/.github/workflows/weekly-excel-generation.yml
+++ b/.github/workflows/weekly-excel-generation.yml
@@ -3,13 +3,13 @@ name: Weekly Excel Generation with Sentry Monitoring (Every 2 Hours + Weekly)
 permissions:
   contents: read
 
-# Serialize runs per-ref. With timeout-minutes: 195 and a cron every ~2h
+# Serialize runs per-ref. With timeout-minutes: 110 and a cron every ~2h
 # (120min), a slow run would otherwise overlap with the next fire,
 # doubling Smartsheet API pressure and increasing the chance of
 # cascading RemoteDisconnected stalls. cancel-in-progress: false
 # (queue mode) is the safer choice for billing: a near-complete run
 # must NEVER be cancelled right before hash_history.save / attachment
-# upload finishes. The 195min hard ceiling already bounds how long a
+# upload finishes. The 110min hard ceiling already bounds how long a
 # stuck run can hold the queue.
 concurrency:
   group: weekly-excel-${{ github.ref }}
@@ -122,10 +122,10 @@ jobs:
   core:
     runs-on: ubuntu-latest
     # Hard ceiling for the Actions runner. Must exceed TIME_BUDGET_MINUTES
-    # (currently 180 = 3h) so the Python process always exits gracefully
-    # before Actions kills it; the extra 15min is reserved for post-job
-    # cache-save and artifact-upload steps.
-    timeout-minutes: 195
+    # so the Python process exits gracefully before Actions kills it.
+    # User requirement (2026-04-25): keep total run time under 1h50m.
+    # Reserve ~15 minutes for post-job cache/artifact steps.
+    timeout-minutes: 110
     env:
       PYTHONUNBUFFERED: 1
       GITHUB_ACTIONS: 'true'
@@ -296,13 +296,10 @@ jobs:
           DEBUG_SAMPLE_ROWS: '1'
           DEBUG_ESSENTIAL_ROWS: '3'
           UNMAPPED_COLUMN_SAMPLE_LIMIT: '3'
-          # Graceful time budget: stop processing new groups before Actions hard-kills the job.
-          # Raised to 180min (3h) on 2026-04-22 to cover long pre-flight phases
-          # (discovery + target-row-attachment pre-fetch) that can occasionally stall on
-          # transient Smartsheet connection drops. timeout-minutes is set to 195 (180 budget
-          # + 15min cushion for post-job cache/artifact save steps) so the Python process
-          # always exits gracefully before Actions hard-kills it.
-          TIME_BUDGET_MINUTES: '400'
+          # Graceful Python budget: stop group processing before runner hard-kill.
+          # Keep Python execution within ~95 minutes, leaving ~15 minutes for
+          # artifact/cache save + summary steps so end-to-end stays under 1h50m.
+          TIME_BUDGET_MINUTES: '95'
         run: python generate_weekly_pdfs.py
       
       - name: Create Sentry release (optional)

--- a/.github/workflows/weekly-excel-generation.yml
+++ b/.github/workflows/weekly-excel-generation.yml
@@ -538,6 +538,7 @@ jobs:
 
       - name: Save billing-audit row cache
         if: always()
+        continue-on-error: true
         uses: actions/cache/save@v4
         with:
           path: generated_docs/billing_audit_frozen_rows.json

--- a/billing_audit/writer.py
+++ b/billing_audit/writer.py
@@ -360,7 +360,7 @@ def _sentry_capture_warning(tag_key: str, tag_value: Any,
 
 
 def freeze_row(row: dict, release: str | None,
-               run_id: str | None) -> None:
+               run_id: str | None) -> bool:
     """Upsert one row's personnel into ``attribution_snapshot``.
 
     First-write-wins via the ``billing_audit.freeze_attribution`` RPC.
@@ -371,7 +371,7 @@ def freeze_row(row: dict, release: str | None,
     """
     client = get_client()
     if client is None:
-        return
+        return False
     # Fail-open on indeterminate flag state — see
     # _flag_enabled_or_unknown for the rationale. A transient
     # feature_flag read blip must not be treated as definitive
@@ -379,7 +379,7 @@ def freeze_row(row: dict, release: str | None,
     # permanently miss the first-write-wins freeze window for
     # completed rows.
     if not _flag_enabled_or_unknown(_FLAG_WRITE):
-        return
+        return False
 
     row_id = row.get("__row_id")
     if not isinstance(row_id, int):
@@ -387,15 +387,15 @@ def freeze_row(row: dict, release: str | None,
             "⚠️ billing_audit.freeze_row: skipping row with missing or "
             "non-integer __row_id"
         )
-        return
+        return False
 
     if not _is_checked(row.get("Units Completed?")):
-        return
+        return False
 
     wr = _sanitized_wr(row)
     week_ending = _coerce_week_ending(row.get("__week_ending_date"))
     if not wr or week_ending is None:
-        return
+        return False
 
     # Normalize release / run_id to empty-string sentinels so RPC
     # params stay valid even when the deployment applies NOT NULL
@@ -453,7 +453,7 @@ def freeze_row(row: dict, release: str | None,
     result = with_retry(_invoke, op="freeze_attribution")
     if result is None:
         _bump_counter("snapshots_errored")
-        return
+        return False
 
     data = getattr(result, "data", None)
     source_run_id: Any = None
@@ -470,6 +470,7 @@ def freeze_row(row: dict, release: str | None,
         _bump_counter("snapshots_written")
     else:
         _bump_counter("snapshots_already_frozen")
+    return True
 
 
 def emit_run_fingerprint(wr: str, week_ending: datetime.date,

--- a/billing_audit/writer.py
+++ b/billing_audit/writer.py
@@ -364,10 +364,20 @@ def freeze_row(row: dict, release: str | None,
     """Upsert one row's personnel into ``attribution_snapshot``.
 
     First-write-wins via the ``billing_audit.freeze_attribution`` RPC.
-    Silent no-op if the Supabase client is unavailable, the
-    ``write_attribution_snapshot`` flag is off, or the row does not
-    meet the freeze criteria. Failures are counted and logged in
-    aggregate only.
+
+    Returns:
+        ``True`` if an RPC was attempted and completed without error
+        (whether the row was newly written or was already frozen from
+        a prior run).  ``False`` in all other cases — client
+        unavailable, ``write_attribution_snapshot`` flag is
+        definitively off, row is ineligible (missing/non-integer
+        ``__row_id``, ``Units Completed?`` not checked, missing WR or
+        week-ending), or the RPC call itself failed after retries.
+
+    Silent no-op side-effects (returns ``False``) if the Supabase
+    client is unavailable, the ``write_attribution_snapshot`` flag is
+    off, or the row does not meet the freeze criteria.  Failures are
+    counted and logged in aggregate only.
     """
     client = get_client()
     if client is None:

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -2183,18 +2183,20 @@ def load_billing_audit_row_cache(path: str) -> set[str]:
 def save_billing_audit_row_cache(path: str, rows: set[str]) -> None:
     """Persist cached freeze-attribution row keys."""
     try:
-        values = list(rows)
+        # Always sort set-backed cache entries so serialized output is
+        # deterministic across runs; also produces smaller diffs.
+        values = sorted(rows)
         if len(values) > BILLING_AUDIT_ROW_CACHE_MAX_ENTRIES:
             # Deterministic truncation. Cache is opportunistic; precision
             # is not required as fallback is to re-call freeze_row.
-            values = sorted(values)[-BILLING_AUDIT_ROW_CACHE_MAX_ENTRIES:]
+            values = values[-BILLING_AUDIT_ROW_CACHE_MAX_ENTRIES:]
+            retained = len(values)
             logging.info(
-                "🧹 Pruned billing-audit row cache to "
-                f"{BILLING_AUDIT_ROW_CACHE_MAX_ENTRIES} entries"
+                f"🧹 Pruned billing-audit row cache to {retained} entries"
             )
         tmp_path = path + ".tmp"
         with open(tmp_path, "w") as f:
-            json.dump(values, f, indent=2)
+            json.dump(values, f, separators=(",", ":"))
         os.replace(tmp_path, path)
         logging.info(f"📝 Billing-audit row cache saved ({len(values)} entries)")
     except Exception as e:

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -2129,6 +2129,10 @@ def load_hash_history(path: str):
         return {}
 
 HASH_HISTORY_MAX_ENTRIES = 1000
+BILLING_AUDIT_ROW_CACHE_PATH = os.path.join(
+    OUTPUT_FOLDER, "billing_audit_frozen_rows.json"
+)
+BILLING_AUDIT_ROW_CACHE_MAX_ENTRIES = 200000
 
 def save_hash_history(path: str, history: dict):
     try:
@@ -2148,6 +2152,53 @@ def save_hash_history(path: str, history: dict):
         logging.info(f"📝 Hash history saved ({len(history)} entries)")
     except Exception as e:
         logging.warning(f"⚠️ Failed to save hash history: {e}")
+
+
+def load_billing_audit_row_cache(path: str) -> set[str]:
+    """Load cached freeze-attribution row keys.
+
+    Keys are ``{wr_sanitized}|{week_mmddyy}|{row_id}``. This local cache
+    is best-effort only — if missing/corrupt we simply fall back to
+    normal freeze-row behavior.
+    """
+    try:
+        with open(path, "r") as f:
+            data = json.load(f)
+        if isinstance(data, list):
+            return {str(x) for x in data if x is not None}
+        if isinstance(data, dict):
+            # Backward-compatible shape if we later add metadata.
+            rows = data.get("rows", [])
+            if isinstance(rows, list):
+                return {str(x) for x in rows if x is not None}
+        logging.warning("⚠️ Billing-audit row cache malformed; resetting")
+        return set()
+    except FileNotFoundError:
+        return set()
+    except Exception as e:
+        logging.warning(f"⚠️ Failed to load billing-audit row cache: {e}")
+        return set()
+
+
+def save_billing_audit_row_cache(path: str, rows: set[str]) -> None:
+    """Persist cached freeze-attribution row keys."""
+    try:
+        values = list(rows)
+        if len(values) > BILLING_AUDIT_ROW_CACHE_MAX_ENTRIES:
+            # Deterministic truncation. Cache is opportunistic; precision
+            # is not required as fallback is to re-call freeze_row.
+            values = sorted(values)[-BILLING_AUDIT_ROW_CACHE_MAX_ENTRIES:]
+            logging.info(
+                "🧹 Pruned billing-audit row cache to "
+                f"{BILLING_AUDIT_ROW_CACHE_MAX_ENTRIES} entries"
+            )
+        tmp_path = path + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(values, f, indent=2)
+        os.replace(tmp_path, path)
+        logging.info(f"📝 Billing-audit row cache saved ({len(values)} entries)")
+    except Exception as e:
+        logging.warning(f"⚠️ Failed to save billing-audit row cache: {e}")
 
 # --- DATA DISCOVERY AND PROCESSING ---
 
@@ -4655,6 +4706,12 @@ def main():
 
         # Load hash history AFTER optional purge so we don't rely on stale attachments
         hash_history = load_hash_history(HASH_HISTORY_PATH)
+        billing_audit_row_cache: set[str] = set()
+        billing_audit_row_cache_dirty = False
+        if BILLING_AUDIT_AVAILABLE and not TEST_MODE:
+            billing_audit_row_cache = load_billing_audit_row_cache(
+                BILLING_AUDIT_ROW_CACHE_PATH
+            )
         history_updates = 0
         _groups_skipped = 0
         _groups_generated = 0
@@ -4977,7 +5034,20 @@ def main():
                             name="billing_audit.freeze_attribution",
                         ) as _bas:
                             _bas.set_data("wr", wr_num)
-                            _bas.set_data("row_count", len(group_rows))
+                            _rows_to_freeze: list[dict] = []
+                            _freeze_row_keys: dict[int, str] = {}
+                            for _row in group_rows:
+                                _row_id = _row.get("__row_id")
+                                if not isinstance(_row_id, int):
+                                    continue
+                                if not is_checked(_row.get("Units Completed?")):
+                                    continue
+                                _cache_key = f"{wr_num}|{week_raw}|{_row_id}"
+                                if _cache_key in billing_audit_row_cache:
+                                    continue
+                                _rows_to_freeze.append(_row)
+                                _freeze_row_keys[id(_row)] = _cache_key
+                            _bas.set_data("row_count", len(_rows_to_freeze))
                             _week_snap = first_row.get('__week_ending_date')
                             if hasattr(_week_snap, 'date'):
                                 _week_snap = _week_snap.date()
@@ -5020,13 +5090,18 @@ def main():
                             # noisy in operational debugging.
                             # ``atexit`` handles shutdown when the
                             # interpreter exits.
-                            if len(group_rows) <= 1:
-                                for _row in group_rows:
-                                    _billing_audit_writer.freeze_row(
+                            if len(_rows_to_freeze) <= 1:
+                                for _row in _rows_to_freeze:
+                                    _ok = _billing_audit_writer.freeze_row(
                                         _row,
                                         release=_billing_audit_release_env,
                                         run_id=_billing_audit_run_id_env,
                                     )
+                                    if _ok:
+                                        _rk = _freeze_row_keys.get(id(_row))
+                                        if _rk:
+                                            billing_audit_row_cache.add(_rk)
+                                            billing_audit_row_cache_dirty = True
                             else:
                                 # Singleton executor sized once at
                                 # first use; subsequent calls share
@@ -5038,7 +5113,7 @@ def main():
                                     )
                                 )
                                 _bas.set_data(
-                                    "in_flight", len(group_rows)
+                                    "in_flight", len(_rows_to_freeze)
                                 )
                                 # Track future → row so an unexpected
                                 # raise can be pinpointed to the
@@ -5047,7 +5122,7 @@ def main():
                                 # row in a 100-row group has malformed
                                 # data the writer didn't anticipate.
                                 _bas_future_to_row: dict[Any, dict] = {}
-                                for _row in group_rows:
+                                for _row in _rows_to_freeze:
                                     _bas_f = _bas_ex.submit(
                                         _billing_audit_writer.freeze_row,
                                         _row,
@@ -5057,7 +5132,17 @@ def main():
                                     _bas_future_to_row[_bas_f] = _row
                                 for _bas_f in as_completed(_bas_future_to_row):
                                     try:
-                                        _bas_f.result()
+                                        _ok = _bas_f.result()
+                                        if _ok:
+                                            _good_row = _bas_future_to_row.get(
+                                                _bas_f, {}
+                                            )
+                                            _rk = _freeze_row_keys.get(
+                                                id(_good_row)
+                                            )
+                                            if _rk:
+                                                billing_audit_row_cache.add(_rk)
+                                                billing_audit_row_cache_dirty = True
                                     except Exception:
                                         # Sanitized row identifier:
                                         # ``__row_id`` is a Smartsheet
@@ -5166,6 +5251,7 @@ def main():
                                     run_id=_billing_audit_run_id_env,
                                 )
                             _bas.set_data("rows", len(group_rows))
+                            _bas.set_data("freeze_candidates", len(_rows_to_freeze))
                             _bas.set_data("variant", variant)
                     except Exception as _audit_err:
                         # Class name only — avoids leaking WR / foreman /
@@ -5507,6 +5593,15 @@ def main():
                         del hash_history[sk]
                     logging.info(f"🧹 Pruned {len(stale_keys)} stale hash history entries (groups no longer in source data)")
             save_hash_history(HASH_HISTORY_PATH, hash_history)
+        if (
+            BILLING_AUDIT_AVAILABLE
+            and not TEST_MODE
+            and billing_audit_row_cache_dirty
+        ):
+            save_billing_audit_row_cache(
+                BILLING_AUDIT_ROW_CACHE_PATH,
+                billing_audit_row_cache,
+            )
 
         # Write run summary JSON for downstream consumers (Notion sync, dashboards)
         _run_summary = {

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -4926,17 +4926,38 @@ def main():
                 # History key includes variant dimension to prevent collisions
                 history_key = f"{wr_num}|{week_raw}|{variant}|{identifier}"
 
+                # Pre-compute hash-change state before any optional side-effects.
+                # Billing audit RPCs are the single most expensive per-group operation
+                # in steady state, so we can safely skip them when the group hash is
+                # unchanged versus hash_history (no row-content drift to freeze or emit).
+                _history_eligible_for_skip = (
+                    HISTORY_SKIP_ENABLED
+                    and not (
+                        FORCE_GENERATION
+                        or week_raw in REGEN_WEEKS
+                        or RESET_HASH_HISTORY
+                        or RESET_WR_LIST
+                    )
+                )
+                _prev_history_entry = (
+                    hash_history.get(history_key)
+                    if _history_eligible_for_skip
+                    else None
+                )
+                _hash_unchanged = bool(
+                    _prev_history_entry
+                    and _prev_history_entry.get('hash') == data_hash
+                )
+
                 # ── Billing audit snapshot: freeze personnel + emit run fingerprint ──
-                # Runs BEFORE the skip check so stable rows get attribution frozen on
-                # subsequent runs (first-write-wins makes repeat calls cheap). Writes
-                # happen in shadow mode — no read path yet. Failures must never break
-                # Excel generation. Skipped in TEST_MODE to prevent polluting production
-                # Supabase with synthetic test data. ``any_flag_enabled()`` is a cheap
-                # cached probe — it skips fingerprint computation and the per-row
-                # freeze_row loop entirely when both writer flags are off.
+                # Only runs for groups with changed/new hashes. This keeps normal
+                # production runs from re-issuing identical freeze_attribution RPCs for
+                # every unchanged group while preserving full behavior when data changed.
+                # Failures must never break Excel generation.
                 if (
                     BILLING_AUDIT_AVAILABLE
                     and not TEST_MODE
+                    and not _hash_unchanged
                     and _billing_audit_writer.any_flag_enabled()
                 ):
                     try:
@@ -5161,9 +5182,8 @@ def main():
                         )
 
                 # Decide skip based on stored history BEFORE generating Excel (only if FORCE not set)
-                if HISTORY_SKIP_ENABLED and not (FORCE_GENERATION or week_raw in REGEN_WEEKS or RESET_HASH_HISTORY or RESET_WR_LIST):
-                    prev = hash_history.get(history_key)
-                    if prev and prev.get('hash') == data_hash:
+                if _history_eligible_for_skip:
+                    if _hash_unchanged:
                         # Only skip if attachment present OR policy allows skipping without attachment
                         can_skip = True
                         if ATTACHMENT_REQUIRED_FOR_SKIP and not TEST_MODE:

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -4714,6 +4714,17 @@ def main():
             billing_audit_row_cache = load_billing_audit_row_cache(
                 BILLING_AUDIT_ROW_CACHE_PATH
             )
+            # Ensure the cache file exists on disk even when no rows have been
+            # frozen yet. The GitHub Actions cache/save step will fail with
+            # "Path does not exist" when the file is absent, which can happen
+            # on the very first run or when all rows were already cached from a
+            # prior run (billing_audit_row_cache_dirty stays False, so the
+            # save at the end of the run is skipped).  Writing an empty list
+            # now is cheap and makes the CI step reliably no-op safe.
+            if not os.path.exists(BILLING_AUDIT_ROW_CACHE_PATH):
+                save_billing_audit_row_cache(
+                    BILLING_AUDIT_ROW_CACHE_PATH, billing_audit_row_cache
+                )
         history_updates = 0
         _groups_skipped = 0
         _groups_generated = 0
@@ -5008,15 +5019,39 @@ def main():
                     and _prev_history_entry.get('hash') == data_hash
                 )
 
+                # Pre-compute whether any eligible row in this group is absent
+                # from the freeze cache. When _hash_unchanged is True but some
+                # rows are uncached (e.g., freeze_attribution failed transiently
+                # in a prior run), we still need to attempt those rows so they
+                # are not permanently left unfrozen. This allows recovery without
+                # waiting for the group's content hash to change again.
+                #
+                # Use set-difference rather than an any()-generator so that for
+                # large groups (50-150 rows is typical) the membership test is
+                # O(len(eligible_keys)) via a single set operation instead of
+                # potentially scanning all rows in the worst case.
+                _has_uncached_freeze_candidates: bool = False
+                if BILLING_AUDIT_AVAILABLE and not TEST_MODE:
+                    _eligible_freeze_keys = {
+                        f"{wr_num}|{week_raw}|{_r.get('__row_id')}"
+                        for _r in group_rows
+                        if isinstance(_r.get("__row_id"), int)
+                        and is_checked(_r.get("Units Completed?"))
+                    }
+                    _has_uncached_freeze_candidates = bool(
+                        _eligible_freeze_keys - billing_audit_row_cache
+                    )
+
                 # ── Billing audit snapshot: freeze personnel + emit run fingerprint ──
-                # Only runs for groups with changed/new hashes. This keeps normal
-                # production runs from re-issuing identical freeze_attribution RPCs for
-                # every unchanged group while preserving full behavior when data changed.
+                # Runs when the group hash has changed/is new, OR when some rows
+                # were not successfully frozen in a prior run (transient failure
+                # recovery). Skipped only when hash is unchanged AND every
+                # eligible row is already in the freeze cache.
                 # Failures must never break Excel generation.
                 if (
                     BILLING_AUDIT_AVAILABLE
                     and not TEST_MODE
-                    and not _hash_unchanged
+                    and (not _hash_unchanged or _has_uncached_freeze_candidates)
                     and _billing_audit_writer.any_flag_enabled()
                 ):
                     try:

--- a/tests/test_billing_audit_shadow.py
+++ b/tests/test_billing_audit_shadow.py
@@ -540,11 +540,150 @@ class FreezeRowTests(unittest.TestCase):
             ba_client.reset_cache_for_tests()
 
 
+class FreezeRowBoolReturnTests(unittest.TestCase):
+    """Assert the documented bool return semantics of ``freeze_row``.
+
+    ``generate_weekly_pdfs.py`` uses the return value to maintain the
+    billing-audit row cache (skip rows already frozen). Regressions
+    here would silently break the skip logic.
+    """
+
+    def setUp(self):
+        _reset_all()
+
+    def tearDown(self):
+        _reset_all()
+
+    def _valid_row(self):
+        return {
+            "__row_id": 123456789,
+            "Work Request #": "WR-9001",
+            "__week_ending_date": datetime.date(2026, 4, 19),
+            "Units Completed?": True,
+            "Foreman": "Alice",
+            "__effective_user": "Alice",
+        }
+
+    def test_returns_false_when_client_none(self):
+        """client is None → False (no RPC possible)."""
+        from billing_audit import writer as ba_writer
+        with mock.patch("billing_audit.writer.get_client", return_value=None):
+            result = ba_writer.freeze_row(
+                self._valid_row(), release="r", run_id="x"
+            )
+        self.assertIs(result, False)
+
+    def test_returns_false_when_flag_definitively_off(self):
+        """flag is resolved-off → False."""
+        from billing_audit import writer as ba_writer
+        client = _make_fake_supabase_client()
+        with mock.patch(
+            "billing_audit.writer.get_client", return_value=client
+        ), mock.patch(
+            "billing_audit.writer.get_flag", return_value=False
+        ), mock.patch(
+            "billing_audit.writer.is_flag_resolved", return_value=True
+        ):
+            result = ba_writer.freeze_row(
+                self._valid_row(), release="r", run_id="x"
+            )
+        self.assertIs(result, False)
+
+    def test_returns_false_for_missing_row_id(self):
+        """Row without __row_id is ineligible → False."""
+        from billing_audit import writer as ba_writer
+        client = _make_fake_supabase_client()
+        row = self._valid_row()
+        del row["__row_id"]
+        with mock.patch(
+            "billing_audit.writer.get_client", return_value=client
+        ), mock.patch(
+            "billing_audit.writer.get_flag", return_value=True
+        ), self.assertLogs(level="WARNING"):
+            result = ba_writer.freeze_row(row, release="r", run_id="x")
+        self.assertIs(result, False)
+
+    def test_returns_false_when_units_completed_false(self):
+        """Row with Units Completed?=False is ineligible → False."""
+        from billing_audit import writer as ba_writer
+        client = _make_fake_supabase_client()
+        row = self._valid_row()
+        row["Units Completed?"] = False
+        with mock.patch(
+            "billing_audit.writer.get_client", return_value=client
+        ), mock.patch(
+            "billing_audit.writer.get_flag", return_value=True
+        ):
+            result = ba_writer.freeze_row(row, release="r", run_id="x")
+        self.assertIs(result, False)
+
+    def test_returns_false_when_rpc_returns_none(self):
+        """RPC exhausts retries (returns None) → False."""
+        from billing_audit import writer as ba_writer
+        client = _make_fake_supabase_client(
+            rpc_side_effect=[Exception("boom")] * 5
+        )
+        with mock.patch(
+            "billing_audit.writer.get_client", return_value=client
+        ), mock.patch(
+            "billing_audit.writer.get_flag", return_value=True
+        ), mock.patch("billing_audit.client.time.sleep"):
+            result = ba_writer.freeze_row(
+                self._valid_row(), release="r", run_id="x"
+            )
+        self.assertIs(result, False)
+        self.assertEqual(
+            ba_writer.get_counters()["snapshots_errored"], 1,
+            "errored counter must be bumped on RPC failure",
+        )
+
+    def test_returns_true_on_successful_new_write(self):
+        """RPC succeeds with source_run_id matching caller run_id → True
+        (snapshots_written incremented)."""
+        from billing_audit import writer as ba_writer
+        client = _make_fake_supabase_client()
+        client.schema.return_value.rpc.return_value.execute.return_value = (
+            _fake_rpc_response("run-1")
+        )
+        with mock.patch(
+            "billing_audit.writer.get_client", return_value=client
+        ), mock.patch(
+            "billing_audit.writer.get_flag", return_value=True
+        ):
+            result = ba_writer.freeze_row(
+                self._valid_row(), release="r", run_id="run-1"
+            )
+        self.assertIs(result, True)
+        self.assertEqual(ba_writer.get_counters()["snapshots_written"], 1)
+
+    def test_returns_true_on_already_frozen(self):
+        """RPC returns source_run_id differing from caller run_id → True
+        (snapshots_already_frozen incremented, not False)."""
+        from billing_audit import writer as ba_writer
+        client = _make_fake_supabase_client()
+        client.schema.return_value.rpc.return_value.execute.return_value = (
+            _fake_rpc_response("prior-run")
+        )
+        with mock.patch(
+            "billing_audit.writer.get_client", return_value=client
+        ), mock.patch(
+            "billing_audit.writer.get_flag", return_value=True
+        ):
+            result = ba_writer.freeze_row(
+                self._valid_row(), release="r", run_id="current-run"
+            )
+        self.assertIs(result, True)
+        self.assertEqual(
+            ba_writer.get_counters()["snapshots_already_frozen"], 1
+        )
+
+
+
 class FreezeRowConcurrencyTests(unittest.TestCase):
     """``freeze_row`` MUST be safe to invoke concurrently from a
     ThreadPoolExecutor. The main pipeline parallelizes the per-row
     freeze loop in ``generate_weekly_pdfs.py`` to convert
-    O(rows) × HTTP-latency serial cost into O(rows / PARALLEL_WORKERS)
+    O(rows) x HTTP-latency serial cost into O(rows / PARALLEL_WORKERS)
     parallel cost — without this property, a busy WR week with 100+
     rows would spend 12+ seconds per group purely on Supabase
     round-trips, compounding into hours across 1900+ groups (the

--- a/tests/test_billing_audit_shadow.py
+++ b/tests/test_billing_audit_shadow.py
@@ -53,6 +53,38 @@ def _reset_all():
     ba_writer._reset_counters_for_tests()
 
 
+def _ensure_smartsheet_mocked():
+    """Inject MagicMock stubs for smartsheet and its submodules into
+    sys.modules so that ``import generate_weekly_pdfs`` succeeds in
+    environments where the Smartsheet SDK is not installed.
+
+    ``generate_weekly_pdfs`` imports three names:
+        import smartsheet
+        import smartsheet.exceptions as ss_exc
+        import smartsheet.smartsheet as _ss_smartsheet_module
+
+    A bare ``MagicMock()`` registered as ``sys.modules['smartsheet']``
+    satisfies ``import smartsheet`` and attribute access, but the two
+    sub-imports fail because the Python import machinery looks up
+    ``sys.modules['smartsheet.exceptions']`` and
+    ``sys.modules['smartsheet.smartsheet']`` explicitly.  We register
+    both sub-stubs so all three import forms succeed.
+
+    The guard is idempotent: if the real SDK is already installed this
+    function is a no-op.
+    """
+    if "smartsheet" not in sys.modules:
+        _ss_stub = mock.MagicMock()
+        sys.modules["smartsheet"] = _ss_stub
+        sys.modules["smartsheet.exceptions"] = mock.MagicMock()
+        sys.modules["smartsheet.smartsheet"] = mock.MagicMock()
+    elif "smartsheet.exceptions" not in sys.modules:
+        # Real package present but sub-stubs missing — shouldn't happen,
+        # but guard anyway.
+        sys.modules["smartsheet.exceptions"] = mock.MagicMock()
+        sys.modules["smartsheet.smartsheet"] = mock.MagicMock()
+
+
 def _fake_rpc_response(source_run_id):
     resp = mock.Mock()
     resp.data = {"source_run_id": source_run_id}
@@ -3390,6 +3422,263 @@ class GetFlagCachingTests(unittest.TestCase):
         self.assertTrue(second)
         # Second call served from the cache — schema() called once.
         self.assertEqual(call_count["n"], 1)
+
+
+class BillingAuditRowCacheIOTests(unittest.TestCase):
+    """Unit tests for ``load_billing_audit_row_cache`` and
+    ``save_billing_audit_row_cache`` in ``generate_weekly_pdfs.py``.
+
+    These functions gate whether expensive ``freeze_attribution`` Supabase
+    RPCs run; they must be robust to missing/corrupt files and must
+    produce deterministic (sorted, compact) output for CI caching.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        # Ensure smartsheet stubs are in sys.modules so the import
+        # succeeds in environments without the Smartsheet SDK installed.
+        import importlib
+        import tempfile
+        _ensure_smartsheet_mocked()
+        with mock.patch.dict(os.environ, {"SENTRY_DSN": ""}, clear=False):
+            with mock.patch("sentry_sdk.init"):
+                cls._gwp = importlib.import_module("generate_weekly_pdfs")
+        # Class-level temp directory: unique per test run, cleaned up in
+        # tearDownClass, avoids the mkstemp+unlink race-condition window.
+        cls._tmp_dir = tempfile.mkdtemp(prefix="ba_cache_io_tests_")
+        cls._tmp_counter = 0
+
+    @classmethod
+    def tearDownClass(cls):
+        import shutil
+        shutil.rmtree(cls._tmp_dir, ignore_errors=True)
+
+    def _tmp_path(self, suffix: str = ".json") -> str:
+        """Return a path guaranteed not to exist inside the class temp dir."""
+        BillingAuditRowCacheIOTests._tmp_counter += 1
+        return os.path.join(
+            self._tmp_dir,
+            f"test_{BillingAuditRowCacheIOTests._tmp_counter}{suffix}",
+        )
+
+    # ── load_billing_audit_row_cache ────────────────────────────────────────
+
+    def test_load_missing_file_returns_empty_set(self):
+        path = self._tmp_path()
+        result = self._gwp.load_billing_audit_row_cache(path)
+        self.assertIsInstance(result, set)
+        self.assertEqual(len(result), 0)
+
+    def test_load_corrupt_file_returns_empty_set(self):
+        path = self._tmp_path()
+        with open(path, "w") as f:
+            f.write("not valid json {{{{")
+        result = self._gwp.load_billing_audit_row_cache(path)
+        self.assertIsInstance(result, set)
+        self.assertEqual(len(result), 0)
+
+    def test_load_valid_list_returns_set(self):
+        import json
+        path = self._tmp_path()
+        keys = ["WR-1|040126|111", "WR-2|040126|222"]
+        with open(path, "w") as f:
+            json.dump(keys, f)
+        result = self._gwp.load_billing_audit_row_cache(path)
+        self.assertEqual(result, set(keys))
+
+    def test_load_old_dict_shape_uses_rows_key(self):
+        """Backward-compatible dict shape ``{"rows": [...]}`` must load."""
+        import json
+        path = self._tmp_path()
+        keys = ["WR-A|040126|999"]
+        with open(path, "w") as f:
+            json.dump({"rows": keys, "meta": "ignored"}, f)
+        result = self._gwp.load_billing_audit_row_cache(path)
+        self.assertEqual(result, set(keys))
+
+    def test_load_empty_list_returns_empty_set(self):
+        import json
+        path = self._tmp_path()
+        with open(path, "w") as f:
+            json.dump([], f)
+        result = self._gwp.load_billing_audit_row_cache(path)
+        self.assertIsInstance(result, set)
+        self.assertEqual(len(result), 0)
+
+    # ── save_billing_audit_row_cache ────────────────────────────────────────
+
+    def test_save_produces_sorted_output(self):
+        """Serialized list must be sorted for deterministic diffs."""
+        import json
+        path = self._tmp_path()
+        keys = {"c|3", "a|1", "b|2"}
+        self._gwp.save_billing_audit_row_cache(path, keys)
+        with open(path) as fh:
+            data = json.load(fh)
+        self.assertEqual(data, sorted(keys))
+
+    def test_save_produces_compact_json(self):
+        """Output must NOT contain indentation whitespace (compact format)."""
+        path = self._tmp_path()
+        keys = {"k1", "k2"}
+        self._gwp.save_billing_audit_row_cache(path, keys)
+        with open(path) as fh:
+            raw = fh.read()
+        # Compact JSON has no newlines or spaces between elements
+        self.assertNotIn("\n", raw)
+        self.assertNotIn("  ", raw)
+
+    def test_save_max_entries_pruning(self):
+        """When entry count exceeds MAX, the tail (highest sorted keys)
+        is retained and the file reflects exactly MAX entries."""
+        import json
+        path = self._tmp_path()
+        small_cap = 5
+        keys = {f"key-{i:04d}" for i in range(small_cap + 3)}
+        with mock.patch.object(
+            self._gwp,
+            "BILLING_AUDIT_ROW_CACHE_MAX_ENTRIES",
+            small_cap,
+        ):
+            self._gwp.save_billing_audit_row_cache(path, keys)
+            with open(path) as fh:
+                data = json.load(fh)
+        self.assertEqual(len(data), small_cap)
+        # Retained entries must be the LAST ``small_cap`` in sorted order.
+        expected = sorted(keys)[-small_cap:]
+        self.assertEqual(data, expected)
+
+    def test_save_roundtrip(self):
+        """A set saved and then loaded must recover the original values."""
+        path = self._tmp_path()
+        keys = {f"WR-{i}|{i:06d}|{i * 7}" for i in range(20)}
+        self._gwp.save_billing_audit_row_cache(path, keys)
+        recovered = self._gwp.load_billing_audit_row_cache(path)
+        self.assertEqual(recovered, keys)
+
+
+class BillingAuditSkipRetryLogicTests(unittest.TestCase):
+    """Tests for the billing-audit snapshot skip / retry gate.
+
+    The main group-processing loop in ``generate_weekly_pdfs.py`` gates the
+    ``freeze_row`` block on ``not _hash_unchanged or _has_uncached_freeze_candidates``.
+
+    This class verifies two properties:
+      (a) When the group hash is unchanged AND all eligible rows are in the
+          freeze cache, the snapshot block is skipped entirely (no RPC).
+      (b) When the hash is unchanged but some rows are NOT in the cache
+          (transient failure in a prior run), the snapshot block still runs for
+          those rows so they are not permanently left unfrozen.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        import importlib
+        _ensure_smartsheet_mocked()
+        with mock.patch.dict(os.environ, {"SENTRY_DSN": ""}, clear=False):
+            with mock.patch("sentry_sdk.init"):
+                cls._gwp = importlib.import_module("generate_weekly_pdfs")
+
+    def setUp(self):
+        _reset_all()
+
+    def tearDown(self):
+        _reset_all()
+
+    def _make_eligible_row(self, row_id: int = 1001) -> dict:
+        return {
+            "__row_id": row_id,
+            "Work Request #": "WR-9001",
+            "__week_ending_date": "040126",
+            "Units Completed?": True,
+        }
+
+    def test_skip_flag_true_when_hash_unchanged_and_all_cached(self):
+        """``_hash_unchanged=True`` + all rows in cache → skip (no uncached candidates)."""
+        row = self._make_eligible_row(row_id=42)
+        wr_num = "WR-9001"
+        week_raw = "040126"
+        cache_key = f"{wr_num}|{week_raw}|42"
+        cache = {cache_key}
+
+        # Simulate the pre-compute logic from the main loop:
+        # _hash_unchanged=True, all rows cached → _has_uncached_freeze_candidates=False
+        _has_uncached_freeze_candidates = any(
+            isinstance(r.get("__row_id"), int)
+            and self._gwp.is_checked(r.get("Units Completed?"))
+            and f"{wr_num}|{week_raw}|{r.get('__row_id')}" not in cache
+            for r in [row]
+        )
+        _hash_unchanged = True
+        _should_run = not _hash_unchanged or _has_uncached_freeze_candidates
+        self.assertFalse(
+            _should_run,
+            "Snapshot block must be skipped when hash unchanged and all rows cached",
+        )
+
+    def test_retry_flag_true_when_hash_unchanged_but_row_uncached(self):
+        """``_hash_unchanged=True`` + uncached row → retry path fires."""
+        row = self._make_eligible_row(row_id=99)
+        wr_num = "WR-9001"
+        week_raw = "040126"
+        # Row 99 is NOT in the cache (simulates a prior transient failure)
+        cache: set[str] = set()
+
+        _has_uncached_freeze_candidates = any(
+            isinstance(r.get("__row_id"), int)
+            and self._gwp.is_checked(r.get("Units Completed?"))
+            and f"{wr_num}|{week_raw}|{r.get('__row_id')}" not in cache
+            for r in [row]
+        )
+        _hash_unchanged = True
+        _should_run = not _hash_unchanged or _has_uncached_freeze_candidates
+        self.assertTrue(
+            _should_run,
+            "Snapshot block must run when hash unchanged but some rows are uncached "
+            "(transient failure recovery)",
+        )
+
+    def test_unchecked_units_not_counted_as_uncached_candidate(self):
+        """Rows with ``Units Completed?=False`` must not count as uncached
+        candidates even if they are absent from the cache."""
+        row = self._make_eligible_row(row_id=55)
+        row["Units Completed?"] = False
+        wr_num = "WR-9001"
+        week_raw = "040126"
+        cache: set[str] = set()  # Nothing cached
+
+        _has_uncached_freeze_candidates = any(
+            isinstance(r.get("__row_id"), int)
+            and self._gwp.is_checked(r.get("Units Completed?"))
+            and f"{wr_num}|{week_raw}|{r.get('__row_id')}" not in cache
+            for r in [row]
+        )
+        self.assertFalse(
+            _has_uncached_freeze_candidates,
+            "Units-Completed?=False rows must not trigger the uncached-candidate flag",
+        )
+
+    def test_hash_changed_always_runs_regardless_of_cache(self):
+        """When ``_hash_unchanged=False`` the snapshot block runs even if
+        every row is already in the cache."""
+        row = self._make_eligible_row(row_id=77)
+        wr_num = "WR-9001"
+        week_raw = "040126"
+        cache_key = f"{wr_num}|{week_raw}|77"
+        cache = {cache_key}  # Row already cached
+
+        _has_uncached_freeze_candidates = any(
+            isinstance(r.get("__row_id"), int)
+            and self._gwp.is_checked(r.get("Units Completed?"))
+            and f"{wr_num}|{week_raw}|{r.get('__row_id')}" not in cache
+            for r in [row]
+        )
+        _hash_unchanged = False  # Data changed this run
+        _should_run = not _hash_unchanged or _has_uncached_freeze_candidates
+        self.assertTrue(
+            _should_run,
+            "Snapshot block must run when hash has changed, regardless of cache",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation

- Reduce runner hard-timeouts to meet the user requirement of keeping end-to-end runs under ~1h50m.
- Avoid issuing expensive billing-audit RPCs when group data has not changed to reduce Smartsheet/DB pressure and duplicate records.
- Ensure helper variant attachments regenerate correctly when helper rows change by making helper identity fully unique.

### Description

- Update GitHub Actions workflow `weekly-excel-generation.yml` to lower job `timeout-minutes` from `195` to `110` and change the Python `TIME_BUDGET_MINUTES` env from `'400'` to `'95'` with updated explanatory comments.
- In `generate_weekly_pdfs.py` include `__helper_dept` and `__helper_job` in the helper `identifier` to produce unique hash keys for helper files and keep `file_identifier` aligned with the filename-safe value.
- Pre-compute history-skip eligibility (`_history_eligible_for_skip`), previous history entry (`_prev_history_entry`), and whether the content hash is unchanged (`_hash_unchanged`) before side-effects, and use `_hash_unchanged` to skip billing-audit snapshot work for unchanged groups.
- Use the precomputed flags for the existing history-skip/attachment checks and preserve safe fallbacks (e.g., regenerate when attachment presence cannot be verified).

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec526c04388326913817323c31c1f5)