### PR TITLE
fix(security): require auth on all portal /api routes

### DIFF
--- a/docs/railway-to-render-transition-plan.md
+++ b/docs/railway-to-render-transition-plan.md
@@ -94,8 +94,7 @@ GITHUB_BRANCH
 SESSION_SECRET
 CORS_ORIGIN            # set to the Vercel production domain at cutover
 CORS_ORIGINS           # optional comma-separated preview + production Vercel domains
-API_AUTH_REQUIRED=true   # require legacy session or Supabase JWT for /api/*
-SUPABASE_JWT_SECRET      # verifies portal-v2 Supabase access tokens
+SUPABASE_JWT_SECRET      # verifies portal-v2 Supabase access tokens (required: /api/* always enforces session or Supabase JWT)
 PORT                   # Render injects its own; leave unset unless required
 NODE_ENV=production
 POLL_INTERVAL_MS

--- a/portal/.env.example
+++ b/portal/.env.example
@@ -4,8 +4,8 @@ NODE_ENV=production
 
 # Session secret (generate a strong random string)
 SESSION_SECRET=change-this-to-a-strong-random-string
-# Require either the legacy /auth session or a valid Supabase bearer token for /api/*
-API_AUTH_REQUIRED=true
+# All /api/* routes require either the legacy /auth session or a valid
+# Supabase bearer token. Authentication is enforced unconditionally.
 SUPABASE_URL=https://your-project.supabase.co
 SUPABASE_JWT_SECRET=your-supabase-jwt-secret
 

--- a/portal/config/default.js
+++ b/portal/config/default.js
@@ -61,12 +61,5 @@ module.exports = {
     enabled: process.env.POLLING_ENABLED !== 'false',
   },
 
-  auth: {
-    // Portal v2 uses Supabase auth on the frontend and calls this backend
-    // cross-origin from Vercel. Keep API auth optional so Render can serve
-    // artifact data without the legacy session login flow.
-    apiRequired: process.env.API_AUTH_REQUIRED === 'true',
-  },
-
   staticDir: path.join(__dirname, '..', 'public'),
 };

--- a/portal/routes/api.js
+++ b/portal/routes/api.js
@@ -18,20 +18,7 @@ function sanitizeFilename(name) {
   return normalized;
 }
 
-if (config.auth.apiRequired) {
-  router.use(requireAuth);
-} else {
-  router.use((req, res, next) => {
-    if (['GET', 'HEAD', 'OPTIONS'].includes(req.method)) {
-      return next();
-    }
-    return requireAuth(req, res, next);
-  });
-}
-
-const requireOperationalAuth = config.auth.apiRequired
-  ? (_req, _res, next) => next()
-  : requireAuth;
+router.use(requireAuth);
 
 router.get('/runs', async (req, res) => {
   try {
@@ -393,7 +380,7 @@ router.get('/search', async (req, res) => {
 /**
  * Force a search-index rebuild (admin / debugging).
  */
-router.post('/search/rebuild', requireOperationalAuth, async (req, res) => {
+router.post('/search/rebuild', async (req, res) => {
   try {
     await searchIndex.rebuild();
     return res.json({ status: 'ok', ...searchIndex.stats() });
@@ -403,7 +390,7 @@ router.post('/search/rebuild', requireOperationalAuth, async (req, res) => {
   }
 });
 
-router.get('/cache/stats', requireOperationalAuth, (req, res) => {
+router.get('/cache/stats', (req, res) => {
   return res.json({
     artifactCache: artifactCache.stats(),
     searchIndex: searchIndex.stats(),
@@ -500,7 +487,7 @@ router.get('/events', (req, res) => {
   });
 });
 
-router.get('/poller-status', requireOperationalAuth, (req, res) => {
+router.get('/poller-status', (req, res) => {
   return res.json(poller.getStatus());
 });
 

--- a/portal/tests/portal.test.js
+++ b/portal/tests/portal.test.js
@@ -211,10 +211,10 @@ describe('Auth endpoints', () => {
 });
 
 describe('API protection', () => {
-  it('allows unauthenticated read API access when API auth is optional', async () => {
+  it('blocks unauthenticated read API access', async () => {
     const res = await request('/api/runs');
-    expect(res.status).toBe(200);
-    expect(Array.isArray(res.body.runs)).toBe(true);
+    expect(res.status).toBe(401);
+    expect(res.body).toHaveProperty('error', 'Authentication required');
   });
 });
 
@@ -361,39 +361,22 @@ describe('sanitizeFilename', () => {
 });
 
 describe('New API endpoints protection', () => {
-  it('allows unauthenticated access to /api/latest when API auth is optional', async () => {
+  it('blocks unauthenticated access to /api/latest', async () => {
     const res = await request('/api/latest');
-    expect(res.status).toBe(200);
-    expect(res.headers['content-type']).toContain('application/json');
-    expect(res.body.run).toEqual(expect.objectContaining({
-      id: mockWorkflowRun.id,
-      runNumber: mockWorkflowRun.run_number,
-      status: mockWorkflowRun.status,
-      conclusion: mockWorkflowRun.conclusion,
-      createdAt: mockWorkflowRun.created_at,
-      updatedAt: mockWorkflowRun.updated_at,
-      event: mockWorkflowRun.event,
-      headBranch: mockWorkflowRun.head_branch,
-    }));
-    expect(Array.isArray(res.body.artifacts)).toBe(true);
+    expect(res.status).toBe(401);
+    expect(res.body).toHaveProperty('error', 'Authentication required');
   });
 
-  it('allows unauthenticated access to /api/poll when API auth is optional', async () => {
+  it('blocks unauthenticated access to /api/poll', async () => {
     const res = await request('/api/poll');
-    expect(res.status).toBe(200);
-    expect(res.body).toHaveProperty('hasNew', true);
-    expect(Array.isArray(res.body.runs)).toBe(true);
-    expect(res.body.runs[0]).toEqual(expect.objectContaining({
-      id: mockWorkflowRun.id,
-      runNumber: mockWorkflowRun.run_number,
-      status: mockWorkflowRun.status,
-    }));
+    expect(res.status).toBe(401);
+    expect(res.body).toHaveProperty('error', 'Authentication required');
   });
 
-  it('allows unauthenticated access to /api/events when API auth is optional', async () => {
+  it('blocks unauthenticated access to /api/events', async () => {
     const res = await request('/api/events', { resolveOnFirstChunk: true, timeoutMs: 1000 });
-    expect(res.status).toBe(200);
-    expect(res.headers['content-type']).toContain('text/event-stream');
+    expect(res.status).toBe(401);
+    expect(String(res.body)).toContain('Authentication required');
   });
 
   it('keeps unauthenticated access to /api/poller-status protected', async () => {
@@ -509,13 +492,10 @@ describe('Authenticated API endpoints', () => {
 });
 
 describe('New API routes: auth protection', () => {
-  it('allows unauthenticated GET /api/search when API auth is optional', async () => {
+  it('blocks unauthenticated GET /api/search', async () => {
     const res = await request('/api/search?q=test');
-    expect(res.status).toBe(200);
-    expect(res.body).toHaveProperty('hits');
-    expect(Array.isArray(res.body.hits)).toBe(true);
-    expect(res.body).toHaveProperty('total');
-    expect(typeof res.body.total).toBe('number');
+    expect(res.status).toBe(401);
+    expect(res.body).toHaveProperty('error', 'Authentication required');
   });
 
   it('blocks unauthenticated GET /api/cache/stats', async () => {
@@ -523,20 +503,22 @@ describe('New API routes: auth protection', () => {
     expect(res.status).toBe(401);
   });
 
-  it('allows unauthenticated GET /api/runs when API auth is optional', async () => {
+  it('blocks unauthenticated GET /api/runs', async () => {
     const res = await request('/api/runs');
-    expect(res.status).toBe(200);
-    expect(res.body.runs).toHaveLength(1);
+    expect(res.status).toBe(401);
+    expect(res.body).toHaveProperty('error', 'Authentication required');
   });
 
-  it('allows unauthenticated GET /api/artifacts/:id/file validation when API auth is optional', async () => {
+  it('blocks unauthenticated GET /api/artifacts/:id/file validation', async () => {
     const res = await request('/api/artifacts/1/file');
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(401);
+    expect(res.body).toHaveProperty('error', 'Authentication required');
   });
 
-  it('allows unauthenticated GET /api/artifacts/:id/preview validation when API auth is optional', async () => {
+  it('blocks unauthenticated GET /api/artifacts/:id/preview validation', async () => {
     const res = await request('/api/artifacts/1/preview');
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(401);
+    expect(res.body).toHaveProperty('error', 'Authentication required');
   });
 
   it('blocks unauthenticated POST /api/search/rebuild before rebuilding the index', async () => {

--- a/portal/tests/portal.test.js
+++ b/portal/tests/portal.test.js
@@ -9,7 +9,6 @@ const require = createRequire(import.meta.url);
 // Set test password hash before importing the app
 const bcrypt = require('bcryptjs');
 process.env.ADMIN_PASSWORD_HASH = bcrypt.hashSync('testpass', 4);
-process.env.API_AUTH_REQUIRED = 'false';
 process.env.SEARCH_INDEX_RUN_LIMIT = '0';
 
 const githubServicePath = require.resolve('../services/github');
@@ -663,9 +662,9 @@ describe('artifactCache service', () => {
   });
 });
 
-describe('API_AUTH_REQUIRED=true', () => {
+describe('API auth enforcement', () => {
   it('gates read API endpoints with the legacy session auth flow', async () => {
-    await withFreshApp({ API_AUTH_REQUIRED: 'true' }, async (freshRequest) => {
+    await withFreshApp({}, async (freshRequest) => {
       const res = await freshRequest('/api/latest');
       expect(res.status).toBe(401);
       expect(res.body).toHaveProperty('error', 'Authentication required');
@@ -682,7 +681,7 @@ describe('API_AUTH_REQUIRED=true', () => {
     });
 
     await withFreshApp(
-      { API_AUTH_REQUIRED: 'true', SUPABASE_JWT_SECRET: 'test-secret' },
+      { SUPABASE_JWT_SECRET: 'test-secret' },
       async (freshRequest) => {
         const res = await freshRequest('/api/search?q=test', {
           headers: { Authorization: `Bearer ${token}` },
@@ -705,7 +704,7 @@ describe('API_AUTH_REQUIRED=true', () => {
     const authHeaders = { Authorization: `Bearer ${token}` };
 
     await withFreshApp(
-      { API_AUTH_REQUIRED: 'true', SUPABASE_JWT_SECRET: 'test-secret' },
+      { SUPABASE_JWT_SECRET: 'test-secret' },
       async (freshRequest) => {
         const readRes = await freshRequest('/api/search?q=test', {
           headers: authHeaders,
@@ -733,7 +732,7 @@ describe('API_AUTH_REQUIRED=true', () => {
     });
 
     await withFreshApp(
-      { API_AUTH_REQUIRED: 'true', SUPABASE_JWT_SECRET: 'test-secret' },
+      { SUPABASE_JWT_SECRET: 'test-secret' },
       async (freshRequest) => {
         const res = await freshRequest('/api/events', {
           headers: { Authorization: `Bearer ${token}` },
@@ -767,7 +766,7 @@ describe('API_AUTH_REQUIRED=true', () => {
     });
 
     await withFreshApp(
-      { API_AUTH_REQUIRED: 'true', SUPABASE_JWT_SECRET: 'test-secret' },
+      { SUPABASE_JWT_SECRET: 'test-secret' },
       async (freshRequest) => {
         const missingSubjectRes = await freshRequest('/api/poller-status', {
           headers: { Authorization: `Bearer ${missingSubjectToken}` },

--- a/render.yaml
+++ b/render.yaml
@@ -52,8 +52,6 @@ services:
         sync: false                     # e.g. https://linetec-portal.vercel.app
       - key: CORS_ORIGINS
         sync: false                     # optional comma-separated preview + prod domains
-      - key: API_AUTH_REQUIRED
-        value: "true"                   # require session or Supabase JWT auth in production
       - key: SUPABASE_URL
         sync: false                     # e.g. https://your-project.supabase.co
       - key: SUPABASE_JWT_SECRET


### PR DESCRIPTION
### Motivation
- Close an access-control vulnerability where API authentication was gated by `API_AUTH_REQUIRED` and defaulted to false, allowing unauthenticated access to sensitive `/api` endpoints (artifact downloads, workflow lists, etc.).

### Description
- Enforce authentication unconditionally by applying `requireAuth` at the top of `portal/routes/api.js` so every `/api` route requires auth via the server-side check. 
- Remove the conditional / partial-auth middleware and the `requireOperationalAuth` fallback so operational endpoints rely on the global router-level auth. 
- Update tests in `portal/tests/portal.test.js` to assert unauthenticated requests to read/artifact/search/event endpoints return `401` with `Authentication required` rather than allowing anonymous access.

### Testing
- Ran the portal test suite with `npm test --prefix portal` and all automated tests passed: `59 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb390508c88326bde3e8241807e2a7)