### PR TITLE
fix(P0): _resolve_row_price substring direction breaks abbreviated Work Types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,7 @@ portal/node_modules/
 # portal: un-ignore lib/ (overrides Python lib/ pattern above)
 !portal/lib/
 !portal/lib/**
+
+# Local artifact inspection (downloaded GHA artifacts for debugging — never committed)
+_inspect_artifact/
+artifact_inspection/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1783,3 +1783,77 @@ When proposing new workflows, dynamically evaluate the absolute best technology.
   (TestPppAttachmentPrefetchBudget). Total: ~55-65 new tests;
   ``pytest tests/`` continues to exit 0 at every
   plan-completion checkpoint.
+- [2026-05-16 23:45] **P0 production hotfix — ``_resolve_row_price``
+  substring-direction bug.** First post-merge scheduled GHA run
+  after Phase 01 shipped (run id 25975684465, 2026-05-16 23:23 UTC)
+  produced ``_AEPBillable`` and ``_ReducedSub`` Excel files that
+  were **byte-identical** for the same WR+week (verified via SHA256:
+  all 8 of 8 AEP+ReducedSub file pairs matched). Total Amount and
+  per-row Pricing values were identical across the two variants —
+  defeats the entire Phase 1 pricing-divergence contract.
+  **Root cause:** ``_resolve_row_price`` at the Work-Type-matching
+  block did ``if 'install' in work_type_raw``. This is a substring
+  containment check that succeeds when ``work_type_raw == 'install'``
+  (full canonical form) but FAILS when it equals ``'inst'`` (the
+  4-char abbreviation Smartsheet operators commonly enter) because
+  the search string ``'install'`` (7 chars) is NOT contained in the
+  shorter ``'inst'`` (4 chars). Same direction error on ``'remov'``
+  vs ``'rem'`` and ``'transfer'`` vs ``'trans'``. When all three
+  branches missed, the helper fell through to the safety floor:
+  ``return parse_price(row.get('Units Total Price'))``. The
+  fallback returns the SmartSheet-computed price unchanged, and
+  THAT price is the SAME value regardless of which variant called
+  the helper — hence byte-identical AEP and ReducedSub files. The
+  unique data_hash suffix in each filename (different per variant)
+  masked the bug from filename inspection; only byte-comparison or
+  content inspection caught it.
+  **Why tests missed it:**
+  ``TestResolveRowPriceCanonicalColumnNames`` (Plan 03) used
+  ``'Install'`` / ``'Removal'`` / ``'Transfer'`` (full canonical
+  forms) in every test row. The substring direction is correct for
+  the full form. The bug only manifests on abbreviations, which the
+  test corpus never exercised. Coverage gap: the test corpus did
+  not mirror the actual Smartsheet operator-entered values.
+  **Fix (additive, surgical):** in ``_resolve_row_price``, change
+  the three substring checks from ``'install'`` / ``'remov'`` /
+  ``'transfer'`` to the shorter forms ``'inst'`` / ``'rem'`` /
+  ``'tran'`` (with ``'xfr'`` as a second clause for the
+  transfer category, mirroring ``recalculate_row_price`` at
+  L1655's existing pattern: ``elif 'tran' in work_type_raw or
+  'xfr' in work_type_raw``). The shorter prefixes match BOTH the
+  abbreviated AND full canonical forms — operator drift in
+  either direction stays bug-free.
+  **New rule — Substring direction discipline for abbreviation-
+  tolerant matchers.** When a string matcher needs to accept BOTH
+  abbreviated and full forms of an operator-entered value, the
+  ``A in B`` substring check must use the SHORTEST UNAMBIGUOUS
+  PREFIX as ``A``. ``'install' in 'inst'`` is False (the search
+  string is longer than the haystack); ``'inst' in 'install'`` is
+  True. The matcher must search FOR the prefix WITHIN the
+  user-entered value, not the other way around. This rule
+  generalises across the codebase: any future categoriser that
+  needs to handle Smartsheet operator-entered abbreviations
+  (e.g., column-type detection, work-type categorisation, status
+  matching) MUST use the prefix-as-A direction. The existing
+  ``recalculate_row_price`` and
+  ``recalculate_row_price_using_original_rate_columns`` patterns
+  at L1655 and L1705 are the correct analogs — copy their shape.
+  **Corollary — test corpus must mirror production data shape.**
+  When adding regression tests for a parser/matcher that consumes
+  Smartsheet column data, the test rows MUST include the
+  abbreviated forms operators actually enter (``'Inst'``,
+  ``'Rem'``, ``'Trans'``, ``'Xfr'``), not just the canonical
+  full forms. Full-form-only test coverage on a substring matcher
+  is a silent-pass trap: the test corpus runs through the
+  matcher's happy path while real production data never does.
+  Regression test class
+  ``TestResolveRowPriceAbbreviatedWorkType`` in
+  ``tests/test_subcontractor_pricing.py`` (14 methods) covers
+  the abbreviated forms (``'Inst'``, ``'Rem'``, ``'Trans'``,
+  ``'Xfr'``) for both AEP and ReducedSub variants plus helper-
+  shadow variants, includes regression guards for the full forms,
+  AND has an explicit ``test_unknown_work_type_falls_through_to_smartsheet``
+  test that locks in the safety-floor behaviour for truly unknown
+  work types so the fix does not over-broaden. ``pytest tests/``
+  now reports **623 passed / 22 skipped / 58 subtests** (was
+  609 / 22 / 58 pre-fix; +14 net, zero regressions).

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -1489,12 +1489,25 @@ def _resolve_row_price(row: dict, variant: str, missing_cus) -> float:
         return parse_price(row.get('Units Total Price'))
 
     # Work-Type-keyed column selection (D-05). Canonical 'Work Type'.
+    # Production hotfix 2026-05-16: Smartsheet operators commonly enter
+    # the abbreviated forms 'Inst' / 'Rem' / 'Trans' / 'Xfr' rather
+    # than the canonical 'Install' / 'Removal' / 'Transfer'. The
+    # pre-fix matcher checked `'install' in work_type_raw` — a
+    # substring test that succeeds on the full form but FAILS on the
+    # abbreviation ('install' is 7 chars; 'inst' is 4 chars; the
+    # 7-char string is NOT contained in the 4-char string). Fall-
+    # through to the safety floor returned `Units Total Price` for
+    # BOTH variants, producing byte-identical AEP and ReducedSub
+    # workbooks (verified via SHA256 on 8 of 8 file pairs from GHA
+    # run 25975684465). Aligned with the existing
+    # ``recalculate_row_price`` pattern at L1655 — use the shortest
+    # unambiguous prefix so both abbreviated AND full forms match.
     work_type_raw = (row.get('Work Type') or '').strip().lower()
-    if 'install' in work_type_raw:
+    if 'inst' in work_type_raw:  # matches 'Inst', 'Install', 'Installation'
         wt = 'install'
-    elif 'remov' in work_type_raw:  # matches 'removal' / 'remove'
+    elif 'rem' in work_type_raw:  # matches 'Rem', 'Remov', 'Removal', 'Remove'
         wt = 'remove'
-    elif 'transfer' in work_type_raw:
+    elif 'tran' in work_type_raw or 'xfr' in work_type_raw:  # 'Tran'/'Trans'/'Transfer'/'Xfr'
         wt = 'transfer'
     else:
         # Unknown work type: keep SmartSheet pricing (safety floor).

--- a/tests/test_subcontractor_pricing.py
+++ b/tests/test_subcontractor_pricing.py
@@ -3678,5 +3678,153 @@ class TestPhase1GapClosureLedgerEntryPresent(unittest.TestCase):
                 )
 
 
+class TestResolveRowPriceAbbreviatedWorkType(unittest.TestCase):
+    """Production hotfix 2026-05-16 — P0 data-integrity bug.
+
+    Smartsheet operators commonly enter Work Type as the abbreviated
+    forms ``Inst`` / ``Rem`` / ``Trans``, not the canonical full
+    forms ``Install`` / ``Removal`` / ``Transfer``. The pre-fix
+    matcher used ``'install' in work_type_raw`` — a substring check
+    that succeeds for ``'install'`` (full) but FAILS for ``'inst'``
+    because the search string ``'install'`` (7 chars) is not contained
+    in the shorter ``'inst'`` (4 chars). Same direction error for
+    ``'remov'`` vs ``'rem'`` and ``'transfer'`` vs ``'trans'``.
+
+    When the matcher fell through to the ``else`` branch, the helper
+    returned ``parse_price(row.get('Units Total Price'))`` — the
+    safety-floor SmartSheet pricing. **The fallback returned the same
+    value for BOTH AEP and ReducedSub variants** so the generated
+    workbooks were byte-identical (verified via SHA256 on the
+    2026-05-16 23:23 UTC GHA artifact: 8 of 8 AEP+ReducedSub file
+    pairs had matching content hashes).
+
+    The fix aligns with the existing ``recalculate_row_price`` pattern
+    at L1655 (``'rem' in work_type_raw``) — uses the shortest
+    unambiguous substring so both abbreviated and full forms match.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls._orig_rates = dict(generate_weekly_pdfs._SUBCONTRACTOR_RATES)
+        # Different new_* vs reduced_* values so the test distinguishes
+        # which rate column was consulted.
+        generate_weekly_pdfs._SUBCONTRACTOR_RATES.clear()
+        generate_weekly_pdfs._SUBCONTRACTOR_RATES['ABC'] = {
+            'cu_code': 'ABC',
+            'cu_wbs': '999',
+            'compatible_unit_group': 'TestGroup',
+            'reduced_install_price': 10.00,
+            'reduced_remove_price': 5.00,
+            'reduced_transfer_price': 2.50,
+            'new_install_price': 20.00,
+            'new_remove_price': 12.00,
+            'new_transfer_price': 6.00,
+        }
+
+    @classmethod
+    def tearDownClass(cls):
+        generate_weekly_pdfs._SUBCONTRACTOR_RATES.clear()
+        generate_weekly_pdfs._SUBCONTRACTOR_RATES.update(cls._orig_rates)
+
+    def _resolve(self, work_type, variant, qty=5, units_total='$999.99'):
+        """``Units Total Price=$999.99`` is the safety-floor canary —
+        if it leaks into the return, the matcher fell through."""
+        from collections import Counter
+        row = {
+            'CU': 'ABC',
+            'Work Type': work_type,
+            'Quantity': qty,
+            'Units Total Price': units_total,
+        }
+        return generate_weekly_pdfs._resolve_row_price(
+            row, variant, Counter()
+        )
+
+    # ── Abbreviated forms — the production-realistic case ──────
+
+    def test_inst_abbrev_aep_billable_uses_new_install_price(self):
+        """``Work Type='Inst'`` + AEP → new_install_price × qty.
+
+        Pre-fix: 'install' in 'inst' is False → safety floor → 999.99.
+        Post-fix: 20.00 × 5 = 100.00.
+        """
+        self.assertEqual(self._resolve('Inst', 'aep_billable'), 100.00)
+
+    def test_inst_abbrev_reduced_sub_uses_reduced_install_price(self):
+        self.assertEqual(self._resolve('Inst', 'reduced_sub'), 50.00)
+
+    def test_rem_abbrev_aep_billable_uses_new_remove_price(self):
+        self.assertEqual(self._resolve('Rem', 'aep_billable'), 60.00)
+
+    def test_rem_abbrev_reduced_sub_uses_reduced_remove_price(self):
+        self.assertEqual(self._resolve('Rem', 'reduced_sub'), 25.00)
+
+    def test_trans_abbrev_aep_billable_uses_new_transfer_price(self):
+        self.assertEqual(self._resolve('Trans', 'aep_billable'), 30.00)
+
+    def test_trans_abbrev_reduced_sub_uses_reduced_transfer_price(self):
+        self.assertEqual(self._resolve('Trans', 'reduced_sub'), 12.50)
+
+    def test_xfr_abbrev_treated_as_transfer(self):
+        """``recalculate_row_price`` already handles 'xfr' as transfer
+        (L1657). The hotfix preserves that synonym."""
+        self.assertEqual(self._resolve('Xfr', 'aep_billable'), 30.00)
+
+    # ── Full forms — regression guard, MUST still work ─────────
+
+    def test_install_full_form_unchanged(self):
+        self.assertEqual(self._resolve('Install', 'aep_billable'), 100.00)
+
+    def test_removal_full_form_unchanged(self):
+        self.assertEqual(self._resolve('Removal', 'aep_billable'), 60.00)
+
+    def test_transfer_full_form_unchanged(self):
+        self.assertEqual(self._resolve('Transfer', 'aep_billable'), 30.00)
+
+    # ── AEP and ReducedSub MUST diverge on the same abbreviated row ──
+
+    def test_aep_and_reduced_diverge_on_abbreviated_inst(self):
+        """The hotfix's key invariant: with abbreviated Work Type,
+        the two variants must produce DIFFERENT prices (not the
+        same safety-floor fallback).
+        """
+        aep = self._resolve('Inst', 'aep_billable')
+        red = self._resolve('Inst', 'reduced_sub')
+        self.assertNotEqual(
+            aep, red,
+            'AEP and ReducedSub MUST diverge for abbreviated Work '
+            'Types — same-value response is the production bug.',
+        )
+        self.assertEqual(aep, 100.00)
+        self.assertEqual(red, 50.00)
+
+    def test_aep_and_reduced_diverge_on_abbreviated_rem(self):
+        aep = self._resolve('Rem', 'aep_billable')
+        red = self._resolve('Rem', 'reduced_sub')
+        self.assertNotEqual(aep, red)
+        self.assertEqual(aep, 60.00)
+        self.assertEqual(red, 25.00)
+
+    # ── Truly unknown work types still fall through ─────────────
+
+    def test_unknown_work_type_falls_through_to_smartsheet(self):
+        """Unknown work types (not inst/rem/trans/xfr prefix) MUST
+        still trigger the safety floor — the fix must not over-broaden.
+        """
+        self.assertEqual(self._resolve('Maintenance', 'aep_billable'), 999.99)
+        self.assertEqual(self._resolve('', 'aep_billable'), 999.99)
+        self.assertEqual(self._resolve('Unknown', 'reduced_sub'), 999.99)
+
+    def test_helper_shadow_variants_also_diverge(self):
+        """Both helper-shadow variants (Plan 02) MUST also pick the
+        correct rate column with abbreviated Work Type.
+        """
+        aep_h = self._resolve('Inst', 'aep_billable_helper')
+        red_h = self._resolve('Inst', 'reduced_sub_helper')
+        self.assertEqual(aep_h, 100.00)
+        self.assertEqual(red_h, 50.00)
+        self.assertNotEqual(aep_h, red_h)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

**P0 production data-integrity bug.** First post-merge scheduled GHA
run after Phase 01 shipped (run id `25975684465`, 2026-05-16 23:23 UTC)
produced **byte-identical `_AEPBillable` and `_ReducedSub` Excel files**
for all 8 of 8 paired WR+week groups (verified via SHA256 on the
downloaded artifact). Per-row Pricing values came from the SmartSheet
safety floor rather than `rate × qty`, defeating Phase 1's core
pricing-divergence contract.

## Root Cause

`_resolve_row_price` Work-Type matching used the wrong substring
direction:

```python
work_type_raw = (row.get('Work Type') or '').strip().lower()
if 'install' in work_type_raw:  # ❌ 'install' (7 chars) NOT in 'inst' (4 chars)
    wt = 'install'
elif 'remov' in work_type_raw:  # ❌ same direction error for 'rem'
    wt = 'remove'
elif 'transfer' in work_type_raw:  # ❌ same for 'trans'
    wt = 'transfer'
else:
    return parse_price(row.get('Units Total Price'))  # safety floor
```

Smartsheet operators commonly enter the **abbreviated forms** `Inst`,
`Rem`, `Trans` (verified in production data from the affected GHA
run). The 7-char search string `'install'` is NOT contained within
the 4-char haystack `'inst'`, so the matcher fell through to the
safety floor on every row. The safety floor returns the
SmartSheet-precomputed price unchanged, **identical for both AEP and
ReducedSub variants** → byte-identical files.

## Fix

Change the three substring searches to use the **shortest unambiguous
prefix** as the search string (mirrors the existing
`recalculate_row_price` pattern at L1655):

```python
if 'inst' in work_type_raw:    # matches 'Inst', 'Install', 'Installation'
    wt = 'install'
elif 'rem' in work_type_raw:    # matches 'Rem', 'Remov', 'Removal'
    wt = 'remove'
elif 'tran' in work_type_raw or 'xfr' in work_type_raw:  # 'Trans', 'Transfer', 'Xfr'
    wt = 'transfer'
```

The shorter prefixes match BOTH abbreviated and full canonical forms.

## Test Coverage

**New class `TestResolveRowPriceAbbreviatedWorkType`** (14 methods) in
`tests/test_subcontractor_pricing.py`:

- Abbreviated forms (`Inst`, `Rem`, `Trans`, `Xfr`) × both AEP and ReducedSub variants
- Helper-shadow variant coverage
- AEP-vs-Reduced divergence invariants
- Full-form regression guards
- Explicit safety-floor fallback for truly unknown Work Types

**Verified RED-then-GREEN:** 10/14 fail pre-fix, 14/14 pass post-fix.

**Full regression:** `pytest tests/` → **623 passed / 22 skipped / 58 subtests** (was 609/22/58 pre-fix; +14 net, **ZERO regressions**).

**End-to-end byte-divergence check** with abbreviated `Work Type='Inst'`:
- AEP file: **$1,106.19** = `new_install_price` × qty × 3 = 2.41 × 459 ✓
- ReducedSub: **$968.49** = `reduced_install_price` × qty × 3 = 2.11 × 459 ✓
- Different SHA256 ✓, different totals ✓

## Production Safety Check

- ✅ Surgical 4-line change to `_resolve_row_price` (plus comment block)
- ✅ Aligns with the existing `recalculate_row_price` pattern at L1655
- ✅ `python -m py_compile generate_weekly_pdfs.py` → exit 0
- ✅ `grep -c "@cell" generate_weekly_pdfs.py` → 0 (CLAUDE.md absolute ban preserved)
- ✅ Existing 609 tests still pass (full-form Work Type rows unchanged)
- ✅ Phase 1 byte-identical hash invariant for primary/helper/vac_crew/ORIG-folder still locked by `TestPhase1IntegrationRegression` (5/5 pass)
- ✅ Living Ledger entry `[2026-05-16 23:45]` documents the new "Substring direction discipline" operational rule with full root-cause attribution

## Operational Impact

- **Next scheduled GHA run after merge** will exercise the fix on real data
- **Existing byte-identical files** attached to TARGET_SHEET_ID + SUBCONTRACTOR_PPP_SHEET_ID from the 2026-05-16 runs will be **superseded** by correctly-priced files on the next run (the cleanup pass prunes prior attachments)
- **Kill switch** unchanged: `SUBCONTRACTOR_RATE_VARIANTS_ENABLED=0` still reverts to pre-Phase-1 behaviour
- **Operator action:** review the GHA run logs after merge for any new missing-CU warnings (none expected; pre-fix run reported only 1 missing CU)

## Test plan

- [x] Pytest full suite green (623 passed)
- [x] py_compile clean
- [x] @cell ban honored
- [x] Byte-divergence repro confirms different files per variant for abbreviated Work Type
- [ ] CI green on this PR (codecov + CodeQL + snyk-manifest)
- [ ] First scheduled GHA run after merge produces non-identical `_AEPBillable` and `_ReducedSub` files with correct rate-column attribution