### PR TITLE
fix(security): require primary-sheet WR membership before PPP upload routing

### DIFF
--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -5326,7 +5326,8 @@ def _build_upload_tasks_for_group(
     # reduced_sub / reduced_sub_helper. The primary leg always runs
     # first so a missing-WR warning consistently mentions
     # TARGET_SHEET_ID first.
-    if wr_num in target_map:
+    primary_present = wr_num in target_map
+    if primary_present:
         upload_tasks.append({
             'excel_path': excel_path,
             'filename': filename,
@@ -5354,7 +5355,7 @@ def _build_upload_tasks_for_group(
 
     # Second leg — only for reduced_sub variants per D-12 / SUB-03.
     if variant in ('reduced_sub', 'reduced_sub_helper'):
-        if wr_num in target_map_ppp:
+        if primary_present and wr_num in target_map_ppp:
             upload_tasks.append({
                 'excel_path': excel_path,
                 'filename': filename,
@@ -5368,7 +5369,7 @@ def _build_upload_tasks_for_group(
                 'week_raw': week_raw,
                 'group_key': group_key,
             })
-        else:
+        elif primary_present:
             # WR not on PPP sheet. Degrade gracefully — the primary
             # leg still runs (if it found the WR) and operators see
             # a sheet-specific WARNING with the PPP sheet id so they

--- a/tests/test_security_audit_followup.py
+++ b/tests/test_security_audit_followup.py
@@ -2100,6 +2100,22 @@ class TestDualTargetSheetRouting(unittest.TestCase):
             'distinguish which sheet is missing the WR',
         )
 
+    def test_reduced_sub_does_not_route_to_ppp_without_primary_membership(self):
+        """Security gate: PPP routing is allowed only when the WR is
+        present on TARGET_SHEET_ID. A WR present only on PPP must not
+        create any upload task."""
+        kwargs = self._make_kwargs(
+            'reduced_sub',
+            target_map={},
+            target_map_ppp={'90093002': 'row-PPP-90093002'},
+        )
+        tasks = generate_weekly_pdfs._build_upload_tasks_for_group(**kwargs)
+        self.assertEqual(
+            tasks, [],
+            'reduced_sub must not create PPP upload tasks when WR is '
+            'absent from TARGET_SHEET_ID',
+        )
+
     def test_helper_short_circuits_when_wr_num_blank(self):
         """Defensive: if ``wr_num`` is blank/None (degenerate row),
         the helper returns an empty list — no warning, no task."""


### PR DESCRIPTION
### Motivation
- A vulnerability allowed PPP (subcontractor) sheet contents to independently authorize uploads for `reduced_sub` variants, bypassing the primary-sheet allowlist/quarantine behavior.
- The change restores an explicit authorization gate so a WR must be present on the primary `TARGET_SHEET_ID` before any PPP-targeted upload is emitted.

### Description
- In `_build_upload_tasks_for_group` introduced `primary_present = wr_num in target_map` and use it to require primary membership before emitting the PPP upload leg for `reduced_sub` / `reduced_sub_helper` variants.
- Preserved the existing degraded-warning semantics for missing PPP rows when the primary leg exists, and preserved normal dual-routing when primary membership is present.
- Added a unit test `test_reduced_sub_does_not_route_to_ppp_without_primary_membership` in `tests/test_security_audit_followup.py` to assert that a WR present only in `target_map_ppp` does not produce upload tasks.

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_security_audit_followup.py -k 'DualTargetSheetRouting and (reduced_sub or missing_in_target_map)'` which passed: `5 passed, 140 deselected`.
- Verified the targeted helper behavior via the new unit test which ensures the PPP routing gate is enforced (test passed in the run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07753dbdbc8326af58edb0558d0069)