### PR TITLE
fix: narrow subcontractor off-contract cleanup to legacy helper variant

### DIFF
--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -2691,10 +2691,9 @@ def cleanup_untracked_sheet_attachments(
 
     sub_offcontract_variants: Set of variant strings that are off-contract
         for WRs in ``sub_wr_scope`` on THIS sheet. For TARGET cleanup,
-        pass ``{'helper', 'primary'}`` (subcontractor non-helper rows
-        now emit only variant keys per Bug B1; subcontractor helper rows
-        now emit only shadow variants per Task 1 — so any bare 'primary'
-        or legacy 'helper' attachment for a sub WR is a pre-fix orphan).
+        pass ``{'helper'}`` so only legacy helper-labeled attachments are
+        treated as off-contract for subcontractor WR scope. Primary
+        attachments remain governed by identity-based pruning rules.
         When None and ``sub_wr_scope`` is provided, this gate is a no-op.
         Ignored when ``sub_wr_scope`` is None.
 
@@ -7975,7 +7974,7 @@ def main():  # pyright: ignore[reportGeneralTypeIssues]
                     client, TARGET_SHEET_ID, valid_wr_weeks, TEST_MODE,
                     attachment_cache=_cleanup_cache, target_sheet=_target_sheet_obj,
                     sub_wr_scope=_sub_scope,
-                    sub_offcontract_variants={'helper', 'primary'} if _sub_scope else None,
+                    sub_offcontract_variants={'helper'} if _sub_scope else None,
                 )
 
             # Phase 01 gap closure (REVIEW-WR-01): parallel cleanup pass


### PR DESCRIPTION
### Motivation
- The existing TARGET cleanup path could delete `primary` attachments for WRs in the subcontractor scope based only on WR membership and broad variant class, enabling unintended or attacker-influenced removals; the change limits the destructive scope while preserving the intended legacy-helper cleanup.

### Description
- Replace the TARGET cleanup call site to pass `sub_offcontract_variants={'helper'}` instead of `{'helper','primary'}` and update the `cleanup_untracked_sheet_attachments` docstring to reflect that only legacy helper-labeled attachments are treated as off-contract for subcontractor scope.

### Testing
- Ran `python -m py_compile generate_weekly_pdfs.py` and the file compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d4c1c6c588326b0bd0deef0ac34f0)