### PR TITLE
fix: harden subcontractor price resolution against malformed Work Type/Quantity

### DIFF
--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -1489,7 +1489,7 @@ def _resolve_row_price(row: dict, variant: str, missing_cus) -> float:
         return parse_price(row.get('Units Total Price'))
 
     # Work-Type-keyed column selection (D-05). Canonical 'Work Type'.
-    work_type_raw = (row.get('Work Type') or '').strip().lower()
+    work_type_raw = str(row.get('Work Type') or '').strip().lower()
     if 'install' in work_type_raw:
         wt = 'install'
     elif 'remov' in work_type_raw:  # matches 'removal' / 'remove'
@@ -1497,8 +1497,9 @@ def _resolve_row_price(row: dict, variant: str, missing_cus) -> float:
     elif 'transfer' in work_type_raw:
         wt = 'transfer'
     else:
-        # Unknown work type: keep SmartSheet pricing (safety floor).
-        return parse_price(row.get('Units Total Price'))
+        # Unknown work type on a known-CU subcontractor variant must not
+        # trust attacker-controlled SmartSheet pricing.
+        return 0.0
 
     if variant in ('aep_billable', 'aep_billable_helper'):
         rate = rate_row.get(f'new_{wt}_price', 0.0)
@@ -1520,10 +1521,9 @@ def _resolve_row_price(row: dict, variant: str, missing_cus) -> float:
         qty = 0.0
 
     if rate <= 0 or qty <= 0:
-        # Degenerate row: SmartSheet pricing as the safety floor,
-        # NEVER silently zero out (mirrors the recalc fall-through
-        # pattern in Living Ledger 2026-04-21 22:35).
-        return parse_price(row.get('Units Total Price'))
+        # Degenerate known-CU subcontractor rows must not fall through to
+        # attacker-controlled SmartSheet pricing.
+        return 0.0
     return rate * qty
 
 

--- a/tests/test_subcontractor_pricing.py
+++ b/tests/test_subcontractor_pricing.py
@@ -1945,13 +1945,27 @@ class TestResolveRowPriceCanonicalColumnNames(unittest.TestCase):
             'Work Type': 'Install',
             'Units Completed': 5,  # WRONG key name (a checkbox column in source data)
             # No 'Quantity' canonical key — helper must treat qty as 0
-            # and fall through.
+            # and resolve to 0.0 for known-CU subcontractor variants.
             'Units Total Price': '$33.33',
         }
         missing = Counter()
         price = generate_weekly_pdfs._resolve_row_price(row, 'aep_billable', missing)
-        # qty=0 → degenerate path → SmartSheet fallback
-        self.assertAlmostEqual(price, 33.33)
+        # qty=0 → degenerate path → secure 0.0 (no SmartSheet fallback)
+        self.assertAlmostEqual(price, 0.0)
+
+
+    def test_non_string_work_type_does_not_raise(self):
+        """Non-string Work Type values are coerced and do not crash."""
+        from collections import Counter
+        row = {
+            'CU': 'XYZ',
+            'Work Type': 123,
+            'Quantity': 2,
+            'Units Total Price': '$99.00',
+        }
+        missing = Counter()
+        price = generate_weekly_pdfs._resolve_row_price(row, 'aep_billable', missing)
+        self.assertEqual(price, 0.0)
 
     def test_helper_body_does_not_reference_forbidden_keys(self):
         """Negative invariant: executable body does NOT read non-canonical fallback keys.


### PR DESCRIPTION
### Motivation
- Prevent attacker-controlled Smartsheet fields or malformed input from causing CSV rate substitution to be bypassed or from crashing workbook generation.
- Ensure known-CU subcontractor rows do not silently fall back to untrusted `Units Total Price` when `Work Type` or `Quantity` are invalid.

### Description
- Coerce `Work Type` with `str(...).strip().lower()` before normalization to avoid `AttributeError` on non-string values and ensure safe handling. 
- For known-CU subcontractor variants, treat unknown work types as invalid and return `0.0` instead of falling back to Smartsheet `Units Total Price`.
- For known-CU rows where `rate` or `qty` is non-positive or unparseable, return `0.0` rather than trusting attacker-controlled pricing.
- Preserve existing behavior for missing CUs by recording them in `missing_cus` and falling back to the original Smartsheet price.
- Update tests in `tests/test_subcontractor_pricing.py` to assert secure outcomes for wrong-key quantity and non-string `Work Type` cases.

### Testing
- Ran `python -m unittest -q tests.test_subcontractor_pricing.TestResolveRowPriceCanonicalColumnNames` and the suite passed (10 tests OK).
- Attempted a targeted `pytest` selection which deselected tests (no tests executed) and therefore did not exercise additional cases.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0774e593308326a97fa2aae9751e6c)