### PR TITLE
fix: exclude helper-completed rows from subcontractor primary files

### DIFF
--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -4853,39 +4853,69 @@ def group_source_rows(rows):
             # reads the SAME boolean — no behavioural change to the
             # variant emission contract.
             if is_subcontractor_row and SUBCONTRACTOR_RATE_VARIANTS_ENABLED:
-                # ReducedSub: unconditional per SUB-02 / D-08. Foreman
-                # is the primary ``effective_user`` (mirrors the
-                # existing primary key — the reduced-sub Excel is
-                # produced for the WR group as a whole).
-                reduced_key = f"{week_end_for_key}_{wr_key}_REDUCEDSUB"
-                keys_to_add.append(('reduced_sub', reduced_key, effective_user))
-                if reduced_key not in groups:
-                    logging.info(
-                        f"🔻 REDUCED SUB GROUP CREATED: WR={wr_key}, "
-                        f"Week={week_end_for_key}"
-                    )
-
-                # AEPBillable: snapshot-cutoff-gated per SUB-01 / D-08
-                # / Living Ledger 2026-04-21 22:35. Snapshot Date is
-                # authoritative — Weekly Reference Logged Date is
-                # NOT a valid fallback here (cutoff drift would
-                # silently re-price whole sheets; see the ledger
-                # entry). ``excel_serial_to_date`` returns ``None``
-                # for blank/unparseable values which naturally
-                # excludes the row from the AEPBillable branch
-                # without raising (D-16 fall-through safety).
+                # Snapshot cutoff is needed by BOTH the primary block
+                # here and the helper-shadow block below, so compute it
+                # once up front. ``excel_serial_to_date`` returns ``None``
+                # for blank/unparseable values (D-16 fall-through safety).
+                # Hoisted above the helper-completed guard so the
+                # helper-shadow block still sees it even when the primary
+                # emission is skipped.
                 _snap_for_cutoff = excel_serial_to_date(r.get('Snapshot Date'))
-                if (
-                    _snap_for_cutoff is not None
-                    and _snap_for_cutoff.date() >= _AEP_BILLABLE_CUTOFF
-                ):
-                    aep_key = f"{week_end_for_key}_{wr_key}_AEPBILLABLE"
-                    keys_to_add.append(('aep_billable', aep_key, effective_user))
-                    if aep_key not in groups:
+
+                # 2026-05-21 hotfix: a helper-COMPLETED subcontractor row
+                # (``Units Completed?`` AND ``Helping Foreman Completed
+                # Unit?`` both checked, with a valid ``Foreman Helping?``
+                # + helper dept) belongs SOLELY to the helper-shadow files
+                # below — the helper, not the primary foreman, earns the
+                # credit for that line item on Smartsheet. Emitting a
+                # primary ``_REDUCEDSUB`` / ``_AEPBILLABLE`` key here would
+                # double-count the row (it would appear in BOTH the
+                # primary and the helper file) and wrongly credit the
+                # primary. This mirrors the legacy main-file exclusion
+                # (the ``elif valid_helper_row:`` branch in the
+                # primary-vs-helper cascade above). Computed locally
+                # because ``valid_helper_row`` from the else-branch is out
+                # of scope for vac_crew rows; uses the same inputs as the
+                # helper-shadow recompute below.
+                _sub_is_valid_helper_row = (
+                    not is_vac_crew_row
+                    and RES_GROUPING_MODE in ('helper', 'both')
+                    and is_helper_row
+                    and bool(helper_foreman)
+                    and bool(r.get('__helper_dept', ''))
+                )
+
+                if not _sub_is_valid_helper_row:
+                    # ReducedSub: unconditional per SUB-02 / D-08 for
+                    # NON-helper subcontractor rows. Foreman is the
+                    # primary ``effective_user`` (mirrors the existing
+                    # primary key — the reduced-sub Excel is produced for
+                    # the WR group as a whole).
+                    reduced_key = f"{week_end_for_key}_{wr_key}_REDUCEDSUB"
+                    keys_to_add.append(('reduced_sub', reduced_key, effective_user))
+                    if reduced_key not in groups:
                         logging.info(
-                            f"💲 AEP BILLABLE GROUP CREATED: WR={wr_key}, "
+                            f"🔻 REDUCED SUB GROUP CREATED: WR={wr_key}, "
                             f"Week={week_end_for_key}"
                         )
+
+                    # AEPBillable: snapshot-cutoff-gated per SUB-01 / D-08
+                    # / Living Ledger 2026-04-21 22:35. Snapshot Date is
+                    # authoritative — Weekly Reference Logged Date is
+                    # NOT a valid fallback here (cutoff drift would
+                    # silently re-price whole sheets; see the ledger
+                    # entry).
+                    if (
+                        _snap_for_cutoff is not None
+                        and _snap_for_cutoff.date() >= _AEP_BILLABLE_CUTOFF
+                    ):
+                        aep_key = f"{week_end_for_key}_{wr_key}_AEPBILLABLE"
+                        keys_to_add.append(('aep_billable', aep_key, effective_user))
+                        if aep_key not in groups:
+                            logging.info(
+                                f"💲 AEP BILLABLE GROUP CREATED: WR={wr_key}, "
+                                f"Week={week_end_for_key}"
+                            )
 
                 # Helper-shadow variants: piggyback on the EXISTING
                 # helper detection. The two gates that already

--- a/tests/test_subcontractor_helper_shadow_rescue.py
+++ b/tests/test_subcontractor_helper_shadow_rescue.py
@@ -331,6 +331,65 @@ class TestEndToEndPipeline(unittest.TestCase):
             f"SUB-09 pre-cutoff: legacy _HELPER_ must NOT be emitted; got: {keys}",
         )
 
+    # ─── Helper-completed primary exclusion (2026-05-21 hotfix) ──
+
+    def test_subcontractor_helper_row_excluded_from_primary_variant_files(self):
+        """Production bug (2026-05-21): a helper-completed subcontractor
+        row (both ``Units Completed?`` and ``Helping Foreman Completed
+        Unit?`` checked, with a valid ``Foreman Helping?`` + helper dept)
+        must NOT be credited to the PRIMARY ``_ReducedSub`` /
+        ``_AEPBillable`` files. The helper completed the line item, so it
+        belongs SOLELY to the helper-shadow files — otherwise the primary
+        foreman is wrongly credited and the line item is double-counted
+        (it would appear in both the primary and the helper file). Mirrors
+        the legacy main-file ``valid_helper_row`` exclusion.
+
+        Snapshot 2026-04-19 is post-AEP-cutoff so BOTH primary variants
+        would be at risk; the assertion proves neither bare primary key
+        is emitted while both helper-shadow keys remain.
+        """
+        with mock.patch(
+            'billing_audit.writer.lookup_attribution',
+            return_value=None,  # no_history → falls back to current helper
+        ):
+            row = self._make_synth_helper_row(
+                helper_foreman='Chris_Lopez',
+                snapshot='2026-04-19',  # post-cutoff
+            )
+            groups = generate_weekly_pdfs.group_source_rows([row])
+        keys = list(groups.keys())
+        # NO primary (non-helper) _REDUCEDSUB key for a helper-completed row.
+        self.assertFalse(
+            any('REDUCEDSUB' in k and 'HELPER' not in k for k in keys),
+            f"helper-completed row must NOT emit a primary _REDUCEDSUB "
+            f"key (belongs solely to the helper); got: {keys}",
+        )
+        # NO primary (non-helper) _AEPBILLABLE key for a helper-completed row.
+        self.assertFalse(
+            any('AEPBILLABLE' in k and 'HELPER' not in k for k in keys),
+            f"helper-completed row must NOT emit a primary _AEPBILLABLE "
+            f"key (belongs solely to the helper); got: {keys}",
+        )
+        # Confirm no group carries variant 'reduced_sub' / 'aep_billable'
+        # (the primary variants) for this helper row — only the *_helper
+        # shadow variants.
+        for k in keys:
+            variant = groups[k][0].get('__variant', '')
+            self.assertNotIn(
+                variant, ('reduced_sub', 'aep_billable'),
+                f"helper-completed row must not produce a primary variant "
+                f"group; offending key={k!r} variant={variant!r}; got: {keys}",
+            )
+        # The helper-shadow files MUST still be present (helper credit intact).
+        self.assertTrue(
+            any('REDUCEDSUB_HELPER_Chris_Lopez' in k for k in keys),
+            f"helper-shadow _REDUCEDSUB_HELPER_ must still be present; got: {keys}",
+        )
+        self.assertTrue(
+            any('AEPBILLABLE_HELPER_Chris_Lopez' in k for k in keys),
+            f"helper-shadow _AEPBILLABLE_HELPER_ must still be present; got: {keys}",
+        )
+
     # ─── Bug C attribution ───────────────────────────────────────
 
     def test_bug_c_attribution_partitions_row_to_frozen_helper(self):


### PR DESCRIPTION
## Objective

Fix a production billing-accuracy bug in the subcontractor workflow. When a helper claims a line item they check **both** "Units Completed?" and "Helping Foreman Completed Unit?" (with "Foreman Helping?" set). That row should be credited **solely** to the helper-shadow files (`_ReducedSub_Helper_<helper>` / `_AEPBillable_Helper_<helper>`) — the helper, not the primary foreman, earns it on Smartsheet. Instead, the row was **also** emitted to the PRIMARY `_ReducedSub` / `_AEPBillable` files, so the line item was **double-counted** and the primary foreman was **wrongly credited**.

Pre-existing since Phase 1; `SUBCONTRACTOR_RATE_VARIANTS_ENABLED` is pinned on in production, so master is actively affected. Helper files themselves were already correct.

## Changes Made

- **`generate_weekly_pdfs.py`** (`group_source_rows`): gate the subcontractor primary variant emission (`_REDUCEDSUB` / `_AEPBILLABLE`) on `not _sub_is_valid_helper_row`, mirroring the legacy main-file `valid_helper_row` exclusion. Hoisted the `_snap_for_cutoff` computation above the guard so the **unchanged** helper-shadow block still sees it.
- **`tests/test_subcontractor_helper_shadow_rescue.py`**: added `TestEndToEndPipeline::test_subcontractor_helper_row_excluded_from_primary_variant_files` — drives `group_source_rows` with a valid helper row and asserts no bare primary `_REDUCEDSUB`/`_AEPBILLABLE` key is emitted while both `_HELPER_` shadow keys remain. (This is the coverage gap that let the bug ship: prior helper tests checked the shadow keys but never the primary-key absence.)

## Production Safety Check

- **Root cause confirmed via failing test first** (TDD): the red test reproduced all four keys (`_REDUCEDSUB`, `_AEPBILLABLE`, `_REDUCEDSUB_HELPER_*`, `_AEPBILLABLE_HELPER_*`) for one helper row; after the fix only the two `_HELPER_` keys remain.
- **Non-helper subcontractor rows are unchanged** — they still emit the primary `_REDUCEDSUB`/`_AEPBILLABLE` keys (verified by the existing `test_subcontractor_non_helper_row_only_emits_variant_keys`, still green). No over-exclusion.
- **Helper-shadow + Bug C attribution paths are byte-identical** — the helper-shadow block was not touched; only `_snap_for_cutoff` was hoisted (a pure computation move).
- **Surgical, additive guard.** No change to discovery, row fetch, pricing, upload, hash history, or any non-subcontractor flow.
- `pytest tests/` → **712 passed / 26 skipped / 58 subtests** (zero failures).

## Test Plan

- [x] Failing test reproduces the bug, passes after the fix
- [x] `python -m py_compile generate_weekly_pdfs.py`
- [x] `pytest tests/` green (712 passed)
- [ ] Operator spot-check: after merge, confirm a helper-completed line item appears only in the `_ReducedSub_Helper_*` / `_AEPBillable_Helper_*` files and NOT in the primary `_ReducedSub` / `_AEPBillable` files

> Note: PR #215 (Subproject B) rewrote this same emission block; it will be rebased onto this fix and carry the equivalent guard for its `_USER_<claimer>` partitioned keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)