### PR TITLE
feat: VAC crew claim attribution (Subproject C)

### DIFF
--- a/.github/workflows/weekly-excel-generation.yml
+++ b/.github/workflows/weekly-excel-generation.yml
@@ -378,6 +378,20 @@ jobs:
           # [2026-05-20].
           SUBCONTRACTOR_LEGACY_PRIMARY_CLEANUP_ENABLED: '1'
 
+          # Sub-project C (2026-05-21): kill switch for per-claimer
+          # partitioning of _VacCrew Excel files by frozen vac-crew
+          # claimer from billing_audit.attribution_snapshot. Set to
+          # '0' to preserve legacy one-file-per-WR _VacCrew behavior.
+          VAC_CREW_CLAIM_ATTRIBUTION_ENABLED: '1'
+          # Sub-project C (2026-05-21): kill switch for the one-time
+          # removal of legacy UNPARTITIONED _VacCrew attachments (no
+          # _User_ token) on TARGET_SHEET_ID for vac-crew WRs. Set to
+          # '0' to skip the destructive cleanup (legacy duplicates
+          # persist until removed manually). Separate from
+          # VAC_CREW_CLAIM_ATTRIBUTION_ENABLED (which gates attribution
+          # resolution, NOT this cleanup). Living Ledger [2026-05-21].
+          VAC_CREW_LEGACY_CLEANUP_ENABLED: '1'
+
           # AEP_BILLABLE_CUTOFF is intentionally UNSET in the
           # workflow — the Python default (datetime.date(2026,
           # 4, 12), the contract award date) is the source of

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2609,3 +2609,146 @@ When proposing new workflows, dynamically evaluate the absolute best technology.
   ``TestSubprojectBHashPrune`` +4 (prune return-value contract +
   migration-dirty save-gate source guard). ``pytest tests/`` → **766
   passed / 26 skipped / 60 subtests** (was 757; +9, zero regressions).
+- [2026-05-21 14:15] **Sub-project C (VAC crew claim attribution)
+  shipped** — third consumer of Foundation A's ``resolve_claimer`` +
+  HOLD contract ([2026-05-20 13:45]), mirroring Subproject B
+  ([2026-05-21 09:21]). VAC crew Excel files are now re-partitioned
+  by the FROZEN vac-crew claimer (``frozen_vac_crew`` from
+  ``billing_audit.attribution_snapshot``) rather than shipping one
+  bare ``_VacCrew`` file per WR+week. Each file holds only one
+  claimer's completed line items and is named ``_VacCrew_<name>``
+  (e.g. ``WR_90773033_WeekEnding_051226_VacCrew_Jane_Smith_<hash>.xlsx``).
+  Hash-in-filename retained (E does the strip). ``billing_audit/``
+  NOT modified — everything C needs shipped in Foundation A.
+  Spec: ``docs/superpowers/specs/2026-05-21-subproject-c-vac-crew-
+  claim-attribution-design.md``; plan: ``docs/superpowers/plans/
+  2026-05-21-subproject-c-vac-crew-claim-attribution.md``.
+  **Operator-approved decisions:** (1) **ALL-sheets scope** — vac_crew
+  rows span both subcontractor-folder sheets AND original-contract-
+  folder sheets; C uses its own dedicated kill switches
+  (``VAC_CREW_CLAIM_ATTRIBUTION_ENABLED`` + ``VAC_CREW_LEGACY_CLEANUP_ENABLED``)
+  rather than reusing ``SUBCONTRACTOR_HELPER_CLAIM_ATTRIBUTION_ENABLED``,
+  enabling independent rollback. (2) **Filename** ``_VacCrew_<name>``
+  (the reserved ``_VacCrew_`` prefix is parser-unambiguous vs.
+  ``_Helper_`` and ``_User_``). (3) **Fallback-to-current on
+  ``no_history``** — rows with no frozen claimer yet fall back to the
+  current Smartsheet vac-crew name; this run's ``freeze_row`` call is
+  what writes the first freeze. (4) **Two new default-on
+  workflow-pinned kill switches** (``VAC_CREW_CLAIM_ATTRIBUTION_ENABLED``
+  + ``VAC_CREW_LEGACY_CLEANUP_ENABLED``) following the
+  [2026-05-19 22:00] destructive-cleanup-needs-its-own-switch rule.
+  (5) **HOLD on ``resolve_claimer`` ``fetch_failure``** (correctness
+  over availability) — ``record_attribution_hold('vac_crew')`` per
+  row, end-of-run ``summarize_attribution_holds()`` WARNING reports
+  the count.
+  **Wiring — Approach A parallel pre-pass.** ``group_source_rows``
+  resolves every completed vac-crew row's claimer into a
+  ``_vac_crew_claimer_map`` via a bounded
+  ``ThreadPoolExecutor(max_workers=min(PARALLEL_WORKERS, n))`` BEFORE
+  the grouping loop — no per-row Supabase I/O in the hot loop (per
+  the [2026-04-25 14:00] per-row-latency rule). Single-row groups
+  skip the executor to avoid setup overhead. The emission partitions
+  the legacy flat key ``{week}_{wr}_VACCREW`` into per-claimer keys
+  ``{week}_{wr}_VACCREW_{sanitized_claimer}``. A row absent from the
+  map (attribution disabled, pre-pass skipped, missing
+  ``__row_id``, unexpected per-row error) resolves to use-current —
+  NEVER HOLD — so a plumbing fault cannot silently suppress a billing
+  file.
+  **CR-01 lockstep — the key lesson from this sub-project.** The vac
+  claimer identifier must be carried IDENTICALLY at FOUR sites that
+  must agree byte-for-byte or attachments churn / hash-skip breaks:
+  (1) the main-loop ``identifier`` / ``file_identifier`` /
+  ``history_key`` construction immediately before the group-emit
+  block, (2) the ``valid_wr_weeks.add(...)`` cleanup-tuple builder,
+  (3) the ``current_keys`` set construction inside the
+  hash-history-prune block, AND (4) the ``build_group_identity``
+  parser — which was reordered so ``VacCrew`` is checked BEFORE
+  ``Helper`` in the token scan, preventing a vac-crew claimer whose
+  name contains the string ``Helper`` from being misparsed as a
+  helper-shadow variant (the [2026-05-21 09:21] reserved-token
+  parse-order rule). All four are gated on
+  ``VAC_CREW_CLAIM_ATTRIBUTION_ENABLED`` so the kill-switch-OFF path
+  reproduces the EXACT legacy ``''``-identifier / bare ``_VacCrew``
+  shape — otherwise disabling the flag would itself cause attachment
+  churn.
+  **Two bugs the two-stage code review caught.** (a) The plan
+  initially missed the main-loop Site 1 ``identifier`` /
+  ``history_key`` construction (distinct from the
+  ``group_source_rows`` emission group-key). Had this shipped, the
+  main loop would write ``...|vac_crew|`` (blank identifier) to
+  ``hash_history`` while ``current_keys`` held the claimer name →
+  the hash-history pruner would have marked every vac-crew entry
+  stale on each run → permanent regeneration churn with no operator-
+  visible signal. (b) The disabled-mode (kill-switch OFF) path
+  initially still resolved the claimer and produced
+  ``_VacCrew_<name>`` filenames + non-empty identifiers in
+  ``valid_wr_weeks`` / ``current_keys``, violating the "exact legacy
+  behavior" contract — the OFF path would have generated files the
+  old cleanup code couldn't match and itself caused churn. Fixed by
+  gating all four identity surfaces on the flag so OFF literally
+  reproduces the pre-C state.
+  **Migration plumbing.** TARGET-only legacy ``_VacCrew``
+  (empty-identifier) cleanup via a new
+  ``_build_vac_crew_wr_scope(groups)`` shared helper (referenced by
+  both ``cleanup_untracked_sheet_attachments`` and
+  ``_run_vac_crew_hash_prune`` — the [2026-05-19 22:00] shared-scope-
+  builder rule). The deletion gate carries the ``valid_wr_weeks``
+  live-identity exemption per [2026-05-19 23:45] (scope-set
+  granularity must match the routing key). A one-time idempotent
+  hash prune ``_run_vac_crew_hash_prune`` with a DISTINCT
+  ``VAC_CREW_HASH_PRUNE_VERSION`` / ``_vac_crew_prune_version``
+  sentinel (separate from ``_phase_prune_version`` and
+  ``_subproject_b_prune_version``) drops blank-identifier
+  ``vac_crew`` hash orphans; returns a ``bool`` ORed into
+  ``_hash_history_migration_dirty`` so the prune persists even on a
+  no-update run (per the [2026-05-21 10:30] one-time-migration rule).
+  PII marker ``"Vac crew hash-history prune"`` registered in
+  ``_PII_LOG_MARKERS``.
+  **New rule:** Any new variant whose group key embeds a claimer
+  identifier MUST carry that identifier identically at all four CR-01
+  sites AND gate every one of them on the variant's kill switch so
+  the OFF path reproduces exact legacy behavior. The main-loop
+  ``identifier`` / ``history_key`` site (Site 1) is EASY TO MISS
+  because it is distinct from the ``group_source_rows`` emission
+  group-key — the two live in different scopes and both construct the
+  identity tuple from the same logical fields. Sub-project C's
+  two-stage code review caught exactly this omission; future
+  sub-project implementers MUST explicitly cross-reference all four
+  sites before marking a task complete. Additionally, when adding a
+  new reserved filename token to the ``build_group_identity`` parser,
+  the new token MUST be checked BEFORE any free-text substring scan
+  for other tokens — free-text identifier content can contain any
+  token string and will false-positive the scan (e.g. a vac-crew
+  member named ``Pat Helper`` contains the ``Helper`` substring).
+  Regression tests: new file
+  ``tests/test_vac_crew_claim_attribution.py`` —
+  ``TestVacCrewConfigFlags`` (env-var wiring + default values),
+  ``TestVacCrewSuffixAndParser`` (filename suffix helper + 4-site
+  identity round-trip including ``_VacCrew_<name>`` parse-before-
+  helper ordering), ``TestVacCrewPrePassConcurrency`` (50 concurrent
+  pre-pass calls preserve counter accuracy, no silent drops),
+  ``TestVacCrewEmission`` (group-key emission with attribution on/off
+  + HOLD propagation), ``TestVacCrewIdentitySitesAndDisplay``
+  (all four CR-01 sites carry the claimer; OFF path produces legacy
+  empty-identifier shape at all four sites),
+  ``TestVacCrewLegacyCleanup`` (empty-identifier files deleted;
+  live per-claimer files exempted via ``valid_wr_weeks``; non-vac WRs
+  untouched), ``TestVacCrewHashPrune`` (idempotency, version-sentinel
+  persistence, returns-bool contract wired into migration-dirty path),
+  ``TestVacCrewEndToEnd`` (full ``group_source_rows`` → grouping →
+  key-shape assertion with mocked pre-pass),
+  ``TestVacCrewProductionInvariants`` (source-grep guards for all
+  four CR-01 sites, kill-switch pins, PII marker, parser token
+  order). Two legacy contract-override rewrites in existing files:
+  ``tests/test_vac_crew.py::test_vac_crew_key_format`` + sibling
+  (rewritten in-place per [2026-05-20 00:26] rule 2 citing this
+  entry), ``tests/test_subcontractor_primary_claim_attribution.py::
+  test_vac_crew_row_unaffected`` (updated to reflect partitioned
+  emission keys). ``pytest tests/`` → **807 passed / 26 skipped /
+  60 subtests** (was 766 at Subproject B review-fixes close; +41
+  net). After this branch lands, Foundation A + Subproject B +
+  Sub-project C together cover subcontractor-primary, sub-helper,
+  and vac-crew claim attribution; the primary-workflow primary
+  foreman partitioning remains Sub-project D (highest blast radius —
+  changes core primary grouping across all sheets, deliberately last
+  before E).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2752,3 +2752,52 @@ When proposing new workflows, dynamically evaluate the absolute best technology.
   foreman partitioning remains Sub-project D (highest blast radius —
   changes core primary grouping across all sheets, deliberately last
   before E).
+- [2026-05-25 12:40] PR #219 (Sub-project C) pre-merge AI code-review
+  pass (Copilot + Codex) surfaced 3 real bugs + 3 doc nits; all fixed
+  TDD red→green before merge. **(Codex P1 — WR matchers blind to the
+  per-claimer key.)** ``_key_matches_wr`` (WR_FILTER) and
+  ``_key_matches_excluded_wr`` (EXCLUDE_WRS) matched vac_crew via
+  ``suffix == f"{wr}_VACCREW"`` (exact), so C's new
+  ``{wr}_VACCREW_<claimer>`` keys (attribution on, the default) slipped
+  past both — an EXCLUDE_WRS'd WR would still produce/upload vac files
+  and a WR_FILTER run would drop them. This is the exact CR-02/CR-03
+  mirror-matcher rule the matcher comments themselves cite: a new
+  variant key shape MUST extend BOTH matchers. Fix: added
+  ``or suffix.startswith(f"{wr}_VACCREW_")`` to both (legacy bare +
+  per-claimer both covered). **(Codex P2 — prune deletes valid history
+  when the kill switch is off.)** ``_run_vac_crew_hash_prune`` drops
+  blank-identifier ``wr|week|vac_crew|`` keys, but blank-identifier is
+  the ACTIVE legacy format when ``VAC_CREW_CLAIM_ATTRIBUTION_ENABLED=0``
+  — so the first disabled-mode run would delete valid current history
+  and force regeneration churn, breaking the exact-legacy contract. Fix:
+  early-return ``False`` from the prune when the flag is off, WITHOUT
+  advancing the sentinel (so the one-time migration still runs if
+  attribution is later enabled). **(Copilot — vac_crew row double-emits
+  on subcontractor sheets.)** ``__is_vac_crew`` is set by column
+  presence, not sheet membership, so a vac_crew row can come from a
+  subcontractor-folder sheet; the subcontractor variant block was gated
+  only on ``is_subcontractor_row and SUBCONTRACTOR_RATE_VARIANTS_ENABLED``
+  (not ``not is_vac_crew_row``) and the vac block doesn't ``continue``,
+  so such a row emitted VACCREW **and** REDUCEDSUB/AEPBILLABLE and a vac
+  ``hold`` was bypassed. Pre-existing since Phase 1; fixed by adding
+  ``not is_vac_crew_row`` to the subcontractor block gate (a ``continue``
+  would skip the ``keys_to_add`` processing that actually creates the
+  vac group, so the gate — not a short-circuit — is the correct fix).
+  Doc nits: env.md filename example now includes the ``<timestamp>``
+  token; the "exact legacy" note clarifies the PARSER is read-only /
+  not flag-gated (only the three identity-CONSTRUCTION sites revert);
+  the ``group_source_rows`` docstring now documents both vac key shapes.
+  **New rule:** the [2026-05-15] mirror-matcher rule (EXCLUDE_WRS /
+  WR_FILTER) and the variant-vs-vac double-emit guard both extend to
+  EVERY new variant key shape — when a sub-project adds a
+  ``{wr}_<VARIANT>[_<id>]`` group key, it MUST (a) extend BOTH WR
+  matchers (prefix-match the id form), (b) ensure the row's other
+  applicable emission blocks are mutually exclusive with the new variant
+  (gate on ``not is_<other>_row``), and (c) gate any one-time hash-prune
+  on the variant's kill switch so the OFF path doesn't delete the
+  now-active legacy keys. Regression tests:
+  ``tests/test_vac_crew_claim_attribution.py::TestVacCrewReviewFixes``
+  (EXCLUDE_WRS drops the per-claimer key, WR_FILTER retains it, prune
+  skipped when disabled / runs when enabled, vac-on-sub row emits only
+  VACCREW). ``pytest tests/`` → **814 passed / 26 skipped / 60
+  subtests** (was 809; +5).

--- a/docs/superpowers/plans/2026-05-21-subproject-c-vac-crew-claim-attribution.md
+++ b/docs/superpowers/plans/2026-05-21-subproject-c-vac-crew-claim-attribution.md
@@ -1,0 +1,939 @@
+# Sub-project C — VAC Crew Claim Attribution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Re-partition `vac_crew` Excel files by the frozen vac-crew claimer (`frozen_vac_crew` via Foundation A `resolve_claimer`), naming each file `_VacCrew_<name>`, with HOLD-on-outage and one-time legacy migration — mirroring Sub-project B.
+
+**Architecture:** A bounded `ThreadPoolExecutor` pre-pass resolves each completed vac_crew row's frozen claimer into a `{__row_id: ResolveOutcome}` map before `group_source_rows`' grouping loop (no per-row Supabase I/O in the hot loop). The vac_crew emission then partitions the single `{week}_{wr}_VACCREW` group into per-claimer `{week}_{wr}_VACCREW_{claimer}` groups. Identity is kept consistent across the four CR-01 sites (group key, `valid_wr_weeks`, `current_keys`, `build_group_identity`). A default-on kill switch reverts to exact legacy behavior; a separate default-on switch gates the destructive legacy-attachment cleanup. `billing_audit/` is NOT modified.
+
+**Tech Stack:** Python 3.10+, `openpyxl`, Smartsheet SDK, `concurrent.futures.ThreadPoolExecutor`, `unittest`/`pytest`, Supabase (via the existing `billing_audit` package). Spec: `docs/superpowers/specs/2026-05-21-subproject-c-vac-crew-claim-attribution-design.md`.
+
+**Reference implementation (real, in-repo):** Sub-project B's now-merged code is the closest analog for nearly every task. Concrete templates to read while implementing:
+- `_subcontractor_primary_variant_suffix` (filename suffix helper, raises on empty claimer)
+- the `_sub_primary_claimer_map` pre-pass + the `reduced_sub`/`aep_billable` emission block in `group_source_rows`
+- the `reduced_sub`/`aep_billable` branches in `build_group_identity` (reserved-token-first, span-join)
+- `_run_subproject_b_hash_prune` + `_build_subcontractor_wr_scope` + the `_hash_history_migration_dirty` save path
+- the `sub_legacy_primary_variants` gate in `cleanup_untracked_sheet_attachments`
+
+---
+
+## File Structure
+
+- **Modify `generate_weekly_pdfs.py`** (the engine — all logic):
+  - Config constants near the other attribution flags (search `SUBCONTRACTOR_HELPER_CLAIM_ATTRIBUTION_ENABLED`).
+  - Startup banner block (search the banner that prints `RATE_RECALC_WEEKLY_FALLBACK` / attribution-flag state).
+  - `build_group_identity` — `VacCrew` parse branch (currently ~line 2650).
+  - New module-level `_vac_crew_variant_suffix(...)` helper near `_subcontractor_primary_variant_suffix`.
+  - `group_source_rows` — new vac_crew pre-pass + the `if is_vac_crew_row:` emission block (currently ~line 4943) + the `valid_wr_weeks` builder + the `current_keys` builder.
+  - `generate_excel` — vac_crew filename `variant_suffix` (~line 5855) + the vac_crew display branch (~line 6029).
+  - `_build_vac_crew_wr_scope(groups)` near `_build_subcontractor_wr_scope`.
+  - `cleanup_untracked_sheet_attachments` — new vac_crew legacy-cleanup gate.
+  - `_run_vac_crew_hash_prune(...)` + `VAC_CREW_HASH_PRUNE_VERSION` constant + `_vac_crew_prune_version` sentinel; call site near the B prune call (~line 7262); `_hash_history_migration_dirty` wiring.
+  - `_PII_LOG_MARKERS` — add the prune marker.
+- **Create `tests/test_vac_crew_claim_attribution.py`** — all C tests (true end-to-end).
+- **Modify `.github/workflows/weekly-excel-generation.yml`** — pin the two new env vars.
+- **Modify `website/docs/reference/environment.md`** — document the two new env vars.
+- **Modify `CLAUDE.md`** — Living Ledger entry.
+
+**Test imports note:** mirror the B test file header. `tests/test_subcontractor_primary_claim_attribution.py` imports `_ensure_smartsheet_mocked, _reset_all` from `tests.test_billing_audit_shadow`, calls `_ensure_smartsheet_mocked()` before `import generate_weekly_pdfs`, and imports `ResolveOutcome` from `billing_audit.writer`. Reuse that exact pattern.
+
+---
+
+## Task 1: Config — kill switches + startup banner + workflow pin
+
+**Files:**
+- Modify: `generate_weekly_pdfs.py` (config block + startup banner)
+- Modify: `.github/workflows/weekly-excel-generation.yml`
+- Test: `tests/test_vac_crew_claim_attribution.py`
+
+- [ ] **Step 1: Write the failing test** (create the file with the B-style header)
+
+```python
+"""Sub-project C — VAC Crew claim attribution tests.
+
+Drives real production code paths (parser, group_source_rows pre-pass +
+emission, generate_excel, migration cleanup, hash prune, HOLD wiring) per
+the [2026-05-20 00:26] rule 4: row-flow changes require TRUE end-to-end
+tests, not static mirrors.
+"""
+from __future__ import annotations
+
+import inspect
+import pathlib
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from tests.test_billing_audit_shadow import _ensure_smartsheet_mocked, _reset_all
+
+_ensure_smartsheet_mocked()
+import generate_weekly_pdfs  # noqa: E402
+from billing_audit.writer import ResolveOutcome  # noqa: E402
+
+
+class TestVacCrewConfigFlags(unittest.TestCase):
+    def test_attribution_flag_exists_and_is_bool_default_on(self):
+        self.assertIsInstance(
+            generate_weekly_pdfs.VAC_CREW_CLAIM_ATTRIBUTION_ENABLED, bool
+        )
+
+    def test_legacy_cleanup_flag_exists_and_is_bool(self):
+        self.assertIsInstance(
+            generate_weekly_pdfs.VAC_CREW_LEGACY_CLEANUP_ENABLED, bool
+        )
+
+    def test_flags_pinned_in_workflow(self):
+        wf = (_REPO_ROOT / ".github/workflows/weekly-excel-generation.yml").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("VAC_CREW_CLAIM_ATTRIBUTION_ENABLED", wf)
+        self.assertIn("VAC_CREW_LEGACY_CLEANUP_ENABLED", wf)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_vac_crew_claim_attribution.py::TestVacCrewConfigFlags -v`
+Expected: FAIL — `AttributeError: module 'generate_weekly_pdfs' has no attribute 'VAC_CREW_CLAIM_ATTRIBUTION_ENABLED'`.
+
+- [ ] **Step 3: Add the constants** (next to `SUBCONTRACTOR_HELPER_CLAIM_ATTRIBUTION_ENABLED`; reuse the same truthy parse)
+
+```python
+VAC_CREW_CLAIM_ATTRIBUTION_ENABLED = os.getenv(
+    'VAC_CREW_CLAIM_ATTRIBUTION_ENABLED', '1'
+).strip().lower() in ('1', 'true', 'yes', 'on')
+
+VAC_CREW_LEGACY_CLEANUP_ENABLED = os.getenv(
+    'VAC_CREW_LEGACY_CLEANUP_ENABLED', '1'
+).strip().lower() in ('1', 'true', 'yes', 'on')
+```
+
+- [ ] **Step 4: Surface in the startup banner** (in the same block that logs the other attribution/recalc flag states)
+
+```python
+logging.info(
+    f"🚐 VAC Crew claim attribution: "
+    f"{'ENABLED' if VAC_CREW_CLAIM_ATTRIBUTION_ENABLED else 'DISABLED'}; "
+    f"legacy cleanup: "
+    f"{'ENABLED' if VAC_CREW_LEGACY_CLEANUP_ENABLED else 'DISABLED'}"
+)
+```
+
+- [ ] **Step 5: Pin in the workflow** (`.github/workflows/weekly-excel-generation.yml`, in the `env:` block of the `core` job alongside `SUBCONTRACTOR_*`)
+
+```yaml
+      VAC_CREW_CLAIM_ATTRIBUTION_ENABLED: '1'
+      VAC_CREW_LEGACY_CLEANUP_ENABLED: '1'
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_vac_crew_claim_attribution.py::TestVacCrewConfigFlags -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add generate_weekly_pdfs.py tests/test_vac_crew_claim_attribution.py .github/workflows/weekly-excel-generation.yml
+git commit -m "feat(vac-crew): add VAC_CREW_* kill switches + banner + workflow pin"
+```
+
+---
+
+## Task 2: Filename suffix helper + parser (`build_group_identity`)
+
+**Files:**
+- Modify: `generate_weekly_pdfs.py` (new `_vac_crew_variant_suffix`; `build_group_identity` VacCrew branch)
+- Test: `tests/test_vac_crew_claim_attribution.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+class TestVacCrewSuffixAndParser(unittest.TestCase):
+    def test_suffix_embeds_name(self):
+        self.assertEqual(
+            generate_weekly_pdfs._vac_crew_variant_suffix('John Smith', '91467680', '041926'),
+            '_VacCrew_John_Smith',
+        )
+
+    def test_suffix_empty_claimer_raises(self):
+        with self.assertRaises(ValueError):
+            generate_weekly_pdfs._vac_crew_variant_suffix('', '91467680', '041926')
+
+    def test_parser_vaccrew_name_round_trips(self):
+        fname = 'WR_91467680_WeekEnding_041926_120000_VacCrew_John_Smith_abc123.xlsx'
+        self.assertEqual(
+            generate_weekly_pdfs.build_group_identity(fname),
+            ('91467680', '041926', 'vac_crew', 'John_Smith'),
+        )
+
+    def test_parser_name_containing_helper_token_stays_vac_crew(self):
+        # A crew member whose name contains 'Helper' must NOT misparse as a
+        # helper variant — VacCrew is checked before the Helper scan.
+        fname = 'WR_91467680_WeekEnding_041926_120000_VacCrew_Pat_Helper_abc123.xlsx'
+        self.assertEqual(
+            generate_weekly_pdfs.build_group_identity(fname),
+            ('91467680', '041926', 'vac_crew', 'Pat_Helper'),
+        )
+
+    def test_parser_legacy_vaccrew_no_name(self):
+        fname = 'WR_91467680_WeekEnding_041926_120000_VacCrew_abc123.xlsx'
+        self.assertEqual(
+            generate_weekly_pdfs.build_group_identity(fname),
+            ('91467680', '041926', 'vac_crew', ''),
+        )
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `python -m pytest tests/test_vac_crew_claim_attribution.py::TestVacCrewSuffixAndParser -v`
+Expected: FAIL — `_vac_crew_variant_suffix` missing; `test_parser_name_containing_helper_token_stays_vac_crew` returns `('91467680','041926','helper','Pat')` (current Helper-first order); `test_parser_vaccrew_name_round_trips` returns identifier `''`.
+
+- [ ] **Step 3: Add the suffix helper** (near `_subcontractor_primary_variant_suffix`)
+
+```python
+def _vac_crew_variant_suffix(claimer: str, wr_num: str, week_end_raw: str) -> str:
+    """Build the filename suffix for a per-claimer VAC crew file.
+
+    Sub-project C (2026-05-21): vac_crew files are partitioned by frozen
+    vac-crew claimer and named ``_VacCrew_<sanitized name>``. Raises on an
+    empty claimer (production never hits this — the emission falls back to
+    'Unknown'); the raise surfaces data drift instead of an ambiguous name.
+    """
+    if not claimer:
+        logging.error(
+            f"⚠️ vac_crew variant row missing claimer for WR {wr_num} "
+            f"week {week_end_raw}; filename would be ambiguous — raising."
+        )
+        raise ValueError(
+            f"vac_crew requires a non-empty claimer; got empty for "
+            f"WR={wr_num} week={week_end_raw}"
+        )
+    return f"_VacCrew_{_RE_SANITIZE_IDENTIFIER.sub('_', claimer)[:50]}"
+```
+
+- [ ] **Step 4: Reorder + extend the parser** — in `build_group_identity`, MOVE the `elif 'VacCrew' in tail:` branch ABOVE the `elif 'Helper' in tail:` branch and extract the name via span-join:
+
+```python
+    elif 'VacCrew' in tail:
+        # Sub-project C: _VacCrew_<name>_<hash>. Checked BEFORE the 'Helper'
+        # scan so a crew name containing the 'Helper' token isn't
+        # misclassified as a helper variant (B round-7 lesson). Span-join so
+        # an underscored name survives. Legacy _VacCrew (no name) → ''.
+        variant = 'vac_crew'
+        vac_idx_rel = tail.index('VacCrew')
+        identifier = '_'.join(tail[vac_idx_rel + 1:-1])
+```
+
+(Delete the old `elif 'VacCrew' in tail: variant='vac_crew'; identifier=''` block at its previous position. Leave the `Helper` and `User` branches intact.)
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `python -m pytest tests/test_vac_crew_claim_attribution.py::TestVacCrewSuffixAndParser -v`
+Expected: PASS (5 tests).
+
+- [ ] **Step 6: Run the full build_group_identity regression set** (ensure no other variant regressed)
+
+Run: `python -m pytest tests/test_subcontractor_primary_claim_attribution.py tests/test_security_audit_followup.py -q`
+Expected: PASS (no regressions in helper/primary/aep/reduced parsing).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add generate_weekly_pdfs.py tests/test_vac_crew_claim_attribution.py
+git commit -m "feat(vac-crew): _VacCrew_<name> suffix + parser (VacCrew before Helper)"
+```
+
+---
+
+## Task 3: Pre-pass — resolve frozen claimers into a map
+
+**Files:**
+- Modify: `generate_weekly_pdfs.py` (`group_source_rows`, before the grouping loop)
+- Test: `tests/test_vac_crew_claim_attribution.py`
+
+Read the B pre-pass (`_sub_primary_claimer_map`) as the exact template. The vac_crew pre-pass resolves only completed vac_crew rows.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def _make_vac_row(row_id=6001, wr='91467680', name='CurrentCrew', snapshot='2026-04-19'):
+    return {
+        '__row_id': row_id,
+        'Work Request #': wr,
+        'Weekly Reference Logged Date': '2026-04-19',
+        'Snapshot Date': snapshot,
+        'Units Completed?': True,
+        'Units Total Price': '$100.00',
+        'CU': 'ANC-M', 'Work Type': 'Inst', 'Quantity': 2,
+        '__effective_user': 'PrimaryForeman',
+        '__is_helper_row': False, '__helper_foreman': '', '__helper_dept': '', '__helper_job': '',
+        '__is_vac_crew': True,
+        '__vac_crew_name': name, '__vac_crew_dept': '700', '__vac_crew_job': 'VJ-1',
+        '__source_sheet_id': 8162920222379908,
+    }
+
+
+class TestVacCrewPrePassConcurrency(unittest.TestCase):
+    def setUp(self):
+        _reset_all()
+        self._orig = generate_weekly_pdfs.VAC_CREW_CLAIM_ATTRIBUTION_ENABLED
+        generate_weekly_pdfs.VAC_CREW_CLAIM_ATTRIBUTION_ENABLED = True
+
+    def tearDown(self):
+        generate_weekly_pdfs.VAC_CREW_CLAIM_ATTRIBUTION_ENABLED = self._orig
+        _reset_all()
+
+    def test_fifty_rows_each_partition_to_their_own_claimer(self):
+        def _resolve(variant, current, *, wr, week_ending, row_id, enabled):
+            return ResolveOutcome('use', f'Crew{row_id}', 'frozen', 'success')
+        rows = [_make_vac_row(row_id=7000 + i) for i in range(50)]
+        with mock.patch('billing_audit.writer.resolve_claimer', side_effect=_resolve):
+            groups = generate_weekly_pdfs.group_source_rows(rows)
+        keys = list(groups.keys())
+        for i in range(50):
+            self.assertTrue(
+                any(f'VACCREW_Crew{7000 + i}' in k for k in keys),
+                f"row {7000+i} must partition to its own claimer; got {keys[:5]}…",
+            )
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `python -m pytest tests/test_vac_crew_claim_attribution.py::TestVacCrewPrePassConcurrency -v`
+Expected: FAIL — keys are the single legacy `…_VACCREW` (no per-claimer suffix) because emission isn't wired yet. (This test goes green at the end of Task 4; it is RED now to lock the contract.)
+
+- [ ] **Step 3: Add the pre-pass** — in `group_source_rows`, BEFORE the per-row grouping loop (mirror the B `_sub_primary_claimer_map` block exactly, swapping the predicate and variant):
+
+```python
+    # Sub-project C: resolve frozen vac-crew claimers for completed vac_crew
+    # rows in a bounded pre-pass (NO Supabase I/O inside the grouping loop —
+    # [2026-05-21 09:21] rule 2). Map: {__row_id: ResolveOutcome}. Only runs
+    # when attribution is enabled; otherwise the emission uses the legacy key.
+    _vac_crew_claimer_map: dict = {}
+    if VAC_CREW_CLAIM_ATTRIBUTION_ENABLED:
+        _vac_rows = [
+            r for r in source_rows
+            if r.get('__is_vac_crew')
+            and r.get('__row_id') is not None
+        ]
+        if _vac_rows:
+            from billing_audit.writer import resolve_claimer
+
+            def _resolve_one(_r):
+                _we = _r.get('__week_ending_date')
+                _we = _we.date() if isinstance(_we, datetime.datetime) else _we
+                return _r.get('__row_id'), resolve_claimer(
+                    'vac_crew',
+                    _r.get('__vac_crew_name') or '',
+                    wr=str(_r.get('Work Request #', '')).split('.')[0],
+                    week_ending=_we,
+                    row_id=_r.get('__row_id'),
+                    enabled=VAC_CREW_CLAIM_ATTRIBUTION_ENABLED,
+                )
+
+            if len(_vac_rows) <= 1:
+                for _r in _vac_rows:
+                    try:
+                        _rid, _out = _resolve_one(_r)
+                        _vac_crew_claimer_map[_rid] = _out
+                    except Exception:
+                        logging.exception("⚠️ Sub-project C: vac claimer pre-pass row failed")
+            else:
+                from concurrent.futures import ThreadPoolExecutor, as_completed
+                _workers = min(PARALLEL_WORKERS, len(_vac_rows))
+                with ThreadPoolExecutor(max_workers=_workers) as _ex:
+                    _futs = [_ex.submit(_resolve_one, _r) for _r in _vac_rows]
+                    for _f in as_completed(_futs):
+                        try:
+                            _rid, _out = _f.result()
+                            _vac_crew_claimer_map[_rid] = _out
+                        except Exception:
+                            logging.exception("⚠️ Sub-project C: vac claimer pre-pass row failed")
+```
+
+> Note: confirm the source-rows parameter name in `group_source_rows` (the B pre-pass iterates the same input list — match it). Confirm `__week_ending_date` is present on rows at this point (it is set during fetch and used downstream); if the per-row week is derived differently in this function, mirror exactly how the B pre-pass obtained `week_ending`.
+
+- [ ] **Step 4: (no standalone run yet)** — the pre-pass populates the map but emission (Task 4) consumes it. Proceed to Task 4; this test is verified green at Task 4 Step 6.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add generate_weekly_pdfs.py tests/test_vac_crew_claim_attribution.py
+git commit -m "feat(vac-crew): parallel pre-pass resolving frozen vac claimers"
+```
+
+---
+
+## Task 4: Emission — partition by claimer (Site 1) with kill-switch + HOLD
+
+**Files:**
+- Modify: `generate_weekly_pdfs.py` (`group_source_rows`, the `if is_vac_crew_row:` block, currently ~4943)
+- Test: `tests/test_vac_crew_claim_attribution.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+class TestVacCrewEmission(unittest.TestCase):
+    def setUp(self):
+        _reset_all()
+        self._orig = generate_weekly_pdfs.VAC_CREW_CLAIM_ATTRIBUTION_ENABLED
+        generate_weekly_pdfs.VAC_CREW_CLAIM_ATTRIBUTION_ENABLED = True
+
+    def tearDown(self):
+        generate_weekly_pdfs.VAC_CREW_CLAIM_ATTRIBUTION_ENABLED = self._orig
+        _reset_all()
+
+    def test_frozen_claimer_partitions(self):
+        with mock.patch('billing_audit.writer.resolve_claimer',
+                        return_value=ResolveOutcome('use', 'FrozenCrew', 'frozen', 'success')):
+            groups = generate_weekly_pdfs.group_source_rows([_make_vac_row()])
+        self.assertTrue(any('VACCREW_FrozenCrew' in k for k in groups))
+
+    def test_no_history_falls_back_to_current_name(self):
+        with mock.patch('billing_audit.writer.resolve_claimer',
+                        return_value=ResolveOutcome('use', 'CurrentCrew', 'current', 'no_history')):
+            groups = generate_weekly_pdfs.group_source_rows([_make_vac_row(name='CurrentCrew')])
+        self.assertTrue(any('VACCREW_CurrentCrew' in k for k in groups))
+
+    def test_hold_suppresses_and_records(self):
+        from billing_audit.writer import get_counters
+        with mock.patch('billing_audit.writer.resolve_claimer',
+                        return_value=ResolveOutcome('hold', None, None, 'fetch_failure')):
+            groups = generate_weekly_pdfs.group_source_rows([_make_vac_row()])
+        self.assertFalse(any('VACCREW' in k for k in groups))
+        self.assertEqual(get_counters()['attribution_rows_held'], 1)
+
+    def test_disabled_emits_exact_legacy_key(self):
+        generate_weekly_pdfs.VAC_CREW_CLAIM_ATTRIBUTION_ENABLED = False
+        with mock.patch('billing_audit.writer.resolve_claimer') as m:
+            groups = generate_weekly_pdfs.group_source_rows([_make_vac_row(name='CurrentCrew')])
+            m.assert_not_called()
+        self.assertIn('041926_91467680_VACCREW', groups)
+        self.assertFalse(any('VACCREW_' in k for k in groups))  # no claimer suffix
+
+    def test_map_miss_uses_current_name_not_hold(self):
+        # __row_id absent → not in map → use current, never HOLD.
+        from billing_audit.writer import get_counters
+        row = _make_vac_row()
+        del row['__row_id']
+        with mock.patch('billing_audit.writer.resolve_claimer',
+                        return_value=ResolveOutcome('use', 'X', 'frozen', 'success')):
+            groups = generate_weekly_pdfs.group_source_rows([row])
+        self.assertTrue(any('VACCREW_CurrentCrew' in k for k in groups))
+        self.assertEqual(get_counters()['attribution_rows_held'], 0)
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `python -m pytest tests/test_vac_crew_claim_attribution.py::TestVacCrewEmission -v`
+Expected: FAIL — current emission always produces the single `…_VACCREW` key; no partitioning, no HOLD.
+
+- [ ] **Step 3: Replace the `if is_vac_crew_row:` block** with the kill-switch-gated, map-consuming version:
+
+```python
+            if is_vac_crew_row:
+                if not VAC_CREW_CLAIM_ATTRIBUTION_ENABLED:
+                    # Kill switch OFF → exact legacy behavior: one group per
+                    # WR+week, no per-claimer partition.
+                    vac_crew_key = f"{week_end_for_key}_{wr_key}_VACCREW"
+                    vac_crew_foreman = r.get('__vac_crew_name') or effective_user
+                    keys_to_add.append(('vac_crew', vac_crew_key, vac_crew_foreman))
+                    if vac_crew_key not in groups:
+                        logging.info(f"🏗️ VAC CREW GROUP CREATED: WR={wr_key}, Week={week_end_for_key}")
+                else:
+                    # Sub-project C: partition by frozen vac-crew claimer.
+                    _vac_current = r.get('__vac_crew_name') or effective_user
+                    _c_vac_claimer = None
+                    _vac_outcome = _vac_crew_claimer_map.get(r.get('__row_id'))
+                    if _vac_outcome is not None and _vac_outcome.action == 'hold':
+                        _c_vac_claimer = None  # defer — correctness over availability
+                        try:
+                            from billing_audit.writer import record_attribution_hold
+                            record_attribution_hold(
+                                wr_key,
+                                week_ending_date.date()
+                                if isinstance(week_ending_date, datetime.datetime)
+                                else week_ending_date,
+                                'vac_crew',
+                            )
+                        except Exception:
+                            logging.exception("⚠️ Sub-project C: record_attribution_hold failed")
+                    elif _vac_outcome is not None and _vac_outcome.action == 'use':
+                        _c_vac_claimer = _vac_outcome.name or _vac_current or 'Unknown'
+                    else:
+                        # map-miss / disabled / no_history default → use current
+                        _c_vac_claimer = _vac_current or 'Unknown'
+
+                    if _c_vac_claimer is not None:
+                        _c_vac_sanitized = _RE_SANITIZE_IDENTIFIER.sub('_', _c_vac_claimer)[:50]
+                        vac_crew_key = f"{week_end_for_key}_{wr_key}_VACCREW_{_c_vac_sanitized}"
+                        keys_to_add.append(('vac_crew', vac_crew_key, _c_vac_claimer))
+                        if vac_crew_key not in groups:
+                            logging.info(f"🏗️ VAC CREW GROUP CREATED: WR={wr_key}, Week={week_end_for_key}")
+```
+
+> `week_ending_date` must be in scope here exactly as it is at the B HOLD call site; if this block uses `week_end_for_key`/another local for the week, obtain the `datetime`/`date` the same way B's vac-adjacent emission does. Keep `('vac_crew', ...)` as the variant tag so `r_copy['__variant']` stays `'vac_crew'` and `__current_foreman` becomes the claimer.
+
+- [ ] **Step 4: Run the emission tests**
+
+Run: `python -m pytest tests/test_vac_crew_claim_attribution.py::TestVacCrewEmission -v`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Run the pre-pass test (now green)**
+
+Run: `python -m pytest tests/test_vac_crew_claim_attribution.py::TestVacCrewPrePassConcurrency -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add generate_weekly_pdfs.py tests/test_vac_crew_claim_attribution.py
+git commit -m "feat(vac-crew): partition emission by frozen claimer + HOLD + legacy switch"
+```
+
+---
+
+## Task 5: Sites 2 & 3 (valid_wr_weeks + current_keys) + generate_excel display/filename
+
+**Files:**
+- Modify: `generate_weekly_pdfs.py` (`valid_wr_weeks` builder; `current_keys` builder; `generate_excel` filename suffix + display branch)
+- Test: `tests/test_vac_crew_claim_attribution.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+class TestVacCrewIdentitySitesAndDisplay(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._src = pathlib.Path(
+            inspect.getsourcefile(generate_weekly_pdfs)
+        ).read_text(encoding='utf-8')
+
+    def test_current_keys_site_carries_vac_claimer(self):
+        # Site 3: the hash-prune current_keys reconstruction must derive the
+        # vac_crew identifier from __current_foreman, not hard-code ''.
+        self.assertNotRegex(
+            self._src,
+            r"_variant == 'vac_crew':\s*\n\s*_ident = ''",
+            "current_keys must derive vac_crew identifier from the claimer",
+        )
+
+    def test_generate_excel_vac_crew_file_named_by_claimer(self):
+        import datetime as dt, tempfile, os, openpyxl
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        orig = generate_weekly_pdfs.OUTPUT_FOLDER
+        generate_weekly_pdfs.OUTPUT_FOLDER = tmp.name
+        self.addCleanup(lambda: setattr(generate_weekly_pdfs, 'OUTPUT_FOLDER', orig))
+        row = {
+            'Work Request #': '91467680', 'Units Completed?': True,
+            'Units Total Price': '$100.00', 'Customer Name': 'Cust',
+            'Dept #': '500', 'Job #': 'J-1', 'CU': 'ANC-M', 'Work Type': 'Inst', 'Quantity': 2,
+            '__variant': 'vac_crew', '__current_foreman': 'FrozenCrew',
+            '__vac_crew_name': 'CurrentCrew', '__vac_crew_dept': '700', '__vac_crew_job': 'VJ-1',
+            '__week_ending_date': dt.datetime(2026, 4, 19),
+        }
+        result = generate_weekly_pdfs.generate_excel(
+            '041926_91467680_VACCREW_FrozenCrew', [row], dt.datetime(2026, 4, 19),
+            data_hash='deadbeefcafe0c01',
+        )
+        excel_path, filename = result[0], result[1]
+        self.assertIn('_VacCrew_FrozenCrew', filename)
+        wb = openpyxl.load_workbook(excel_path)
+        ws = wb.active
+        foreman = next(
+            (ws.cell(row=r, column=7).value for r in range(1, ws.max_row + 1)
+             if ws.cell(row=r, column=6).value == 'Foreman:'),
+            None,
+        )
+        self.assertEqual(foreman, 'FrozenCrew')  # display = attributed claimer
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `python -m pytest tests/test_vac_crew_claim_attribution.py::TestVacCrewIdentitySitesAndDisplay -v`
+Expected: FAIL — `current_keys` still hard-codes `_ident=''` for vac_crew; `generate_excel` filename is `_VacCrew` (no name) and display foreman uses `__vac_crew_name` (`'CurrentCrew'`).
+
+- [ ] **Step 3: Fix Site 2 (`valid_wr_weeks` builder).** Find where `valid_wr_weeks.add((...))` is built per variant. For vac_crew it currently contributes identifier `''`. Change it to the sanitized claimer:
+
+```python
+                elif _variant == 'vac_crew':
+                    _vc = group_rows[0].get('__current_foreman', '')
+                    _ident = _RE_SANITIZE_IDENTIFIER.sub('_', _vc)[:50] if _vc else ''
+```
+
+(Match the exact surrounding shape of the existing per-variant `if/elif` in the `valid_wr_weeks` builder.)
+
+- [ ] **Step 4: Fix Site 3 (`current_keys` builder).** In the hash-prune `current_keys` block, the `elif _variant == 'vac_crew': _ident = ''` becomes:
+
+```python
+                        elif _variant == 'vac_crew':
+                            # Subproject C identity site (Site 3). Must match
+                            # the history_key written at Site 1 (sanitized
+                            # claimer) or the fresh entry is treated as stale.
+                            _vc = group_rows[0].get('__current_foreman', '')
+                            _ident = (
+                                _RE_SANITIZE_IDENTIFIER.sub('_', _vc)[:50]
+                                if _vc else ''
+                            )
+```
+
+- [ ] **Step 5: Fix `generate_excel` filename suffix** (the `variant_suffix = '_VacCrew'` line):
+
+```python
+        variant_suffix = _vac_crew_variant_suffix(
+            first_row.get('__current_foreman') or first_row.get('__vac_crew_name', ''),
+            wr_num, week_end_raw,
+        )
+```
+
+- [ ] **Step 6: Fix `generate_excel` vac_crew display branch** — foreman = the claimer (`__current_foreman`), dept/job stay from vac fields:
+
+```python
+    elif variant == 'vac_crew':
+        # Per-claimer (Sub-project C): show the ATTRIBUTED claimer
+        # (__current_foreman, the partition key), with VAC-specific dept/job.
+        display_foreman = first_row.get('__current_foreman') or first_row.get('__vac_crew_name', 'Unknown VAC Crew')
+        display_dept = first_row.get('__vac_crew_dept', '')
+        display_job = first_row.get('__vac_crew_job', '')
+```
+
+- [ ] **Step 7: Run to verify pass**
+
+Run: `python -m pytest tests/test_vac_crew_claim_attribution.py::TestVacCrewIdentitySitesAndDisplay -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add generate_weekly_pdfs.py tests/test_vac_crew_claim_attribution.py
+git commit -m "feat(vac-crew): carry claimer through valid_wr_weeks/current_keys + generate_excel"
+```
+
+---
+
+## Task 6: Migration — `_build_vac_crew_wr_scope` + TARGET legacy cleanup
+
+**Files:**
+- Modify: `generate_weekly_pdfs.py` (`_build_vac_crew_wr_scope`; `cleanup_untracked_sheet_attachments`; the TARGET cleanup call site)
+- Test: `tests/test_vac_crew_claim_attribution.py`
+
+Read `_build_subcontractor_wr_scope` and the `sub_legacy_primary_variants` gate in `cleanup_untracked_sheet_attachments` as the template.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+class TestVacCrewLegacyCleanup(unittest.TestCase):
+    def setUp(self):
+        _ensure_smartsheet_mocked()
+
+    def test_scope_builder_collects_vac_wrs(self):
+        groups = {
+            '041926_91467680_VACCREW_John': [{'Work Request #': '91467680'}],
+            '041926_55555_REDUCEDSUB_USER_X': [{'Work Request #': '55555'}],
+        }
+        scope = generate_weekly_pdfs._build_vac_crew_wr_scope(groups)
+        self.assertIn('91467680', scope)
+        self.assertNotIn('55555', scope)
+
+    def test_legacy_vaccrew_deleted_live_claimer_exempt(self):
+        # Build a fake client recording deletes; an in-scope WR has a stale
+        # legacy _VacCrew (no name → identity NOT in valid_wr_weeks → deleted)
+        # AND a live _VacCrew_John (identity in valid_wr_weeks → exempt).
+        # Assert only the legacy one is deleted.
+        ...  # mirror TestLegacyHelperTargetCleanupE2E from the sub-helper rescue tests
+```
+
+> Implement the second test by mirroring `TestLegacyHelperTargetCleanupE2E::test_target_cleanup_exempts_live_helper_for_overlapping_sub_wr` in `tests/test_subcontractor_helper_shadow_rescue.py`: construct attachments named `WR_..._VacCrew_<hash>` (legacy) and `WR_..._VacCrew_John_<hash>` (live), put the live identity tuple in `valid_wr_weeks`, drive `cleanup_untracked_sheet_attachments(...)` with the new vac params, and assert `delete_attachment` is called only for the legacy one.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `python -m pytest tests/test_vac_crew_claim_attribution.py::TestVacCrewLegacyCleanup -v`
+Expected: FAIL — `_build_vac_crew_wr_scope` missing; cleanup has no vac gate.
+
+- [ ] **Step 3: Add `_build_vac_crew_wr_scope`** (near `_build_subcontractor_wr_scope`):
+
+```python
+def _build_vac_crew_wr_scope(groups: dict) -> set:
+    """WRs that have any vac_crew group this run (for legacy-_VacCrew cleanup
+    + hash prune). Shared by both call sites so scopes never drift."""
+    scope = set()
+    for key, rows in groups.items():
+        if '_VACCREW' in key and rows:
+            wr = str(rows[0].get('Work Request #', '')).split('.')[0]
+            wr = _RE_SANITIZE_HELPER_NAME.sub('_', wr)[:50]
+            if wr:
+                scope.add(wr)
+    return scope
+```
+
+- [ ] **Step 4: Add the vac gate to `cleanup_untracked_sheet_attachments`** — add a kwarg `vac_legacy_wr_scope: set | None = None` and, inside the per-attachment loop, mirror the `sub_legacy_primary_variants` off-contract gate: when `vac_legacy_wr_scope` is provided and the parsed identity is `(wr in scope, variant == 'vac_crew', identifier == '')` AND `ident not in valid_wr_weeks`, unconditionally delete (regardless of `KEEP_HISTORICAL_WEEKS`). Match B's exact gate shape including the `valid_wr_weeks` live-identity exemption.
+
+- [ ] **Step 5: Wire the TARGET call site** — where `cleanup_untracked_sheet_attachments` is called for `TARGET_SHEET_ID`, pass `vac_legacy_wr_scope=_build_vac_crew_wr_scope(groups) if VAC_CREW_LEGACY_CLEANUP_ENABLED else None`.
+
+- [ ] **Step 6: Run to verify pass**
+
+Run: `python -m pytest tests/test_vac_crew_claim_attribution.py::TestVacCrewLegacyCleanup -v`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add generate_weekly_pdfs.py tests/test_vac_crew_claim_attribution.py
+git commit -m "feat(vac-crew): legacy _VacCrew TARGET cleanup with live-identity exemption"
+```
+
+---
+
+## Task 7: One-time hash prune
+
+**Files:**
+- Modify: `generate_weekly_pdfs.py` (`VAC_CREW_HASH_PRUNE_VERSION`; `_run_vac_crew_hash_prune`; call site; `_hash_history_migration_dirty` wiring; `_PII_LOG_MARKERS`)
+- Test: `tests/test_vac_crew_claim_attribution.py`
+
+Read `_run_subproject_b_hash_prune` (returns `bool`) as the exact template.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+class TestVacCrewHashPrune(unittest.TestCase):
+    def setUp(self):
+        _ensure_smartsheet_mocked()
+
+    def _groups(self, wrs):
+        return {f"041926_{wr}_VACCREW_John": [{'Work Request #': wr}] for wr in wrs}
+
+    def test_drops_legacy_vaccrew_orphans_returns_true(self):
+        hist = {
+            '91467680|041926|vac_crew|': {'hash': 'h1'},
+            '91467680|041926|vac_crew|John': {'hash': 'h2'},  # new — survives
+            '55555|041926|vac_crew|': {'hash': 'h3'},          # non-scope — survives
+        }
+        changed = generate_weekly_pdfs._run_vac_crew_hash_prune(hist, self._groups(['91467680']))
+        self.assertIs(changed, True)
+        self.assertNotIn('91467680|041926|vac_crew|', hist)
+        self.assertIn('91467680|041926|vac_crew|John', hist)
+        self.assertIn('55555|041926|vac_crew|', hist)
+        self.assertEqual(hist['_vac_crew_prune_version'],
+                         generate_weekly_pdfs.VAC_CREW_HASH_PRUNE_VERSION)
+
+    def test_idempotent_returns_false(self):
+        hist = {'_vac_crew_prune_version': generate_weekly_pdfs.VAC_CREW_HASH_PRUNE_VERSION}
+        self.assertIs(
+            generate_weekly_pdfs._run_vac_crew_hash_prune(hist, self._groups(['91467680'])),
+            False,
+        )
+
+    def test_pii_marker_registered(self):
+        self.assertIn('Vac crew hash-history prune', generate_weekly_pdfs._PII_LOG_MARKERS)
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `python -m pytest tests/test_vac_crew_claim_attribution.py::TestVacCrewHashPrune -v`
+Expected: FAIL — function + constant + marker missing.
+
+- [ ] **Step 3: Add the constant** (near `SUBPROJECT_B_HASH_PRUNE_VERSION`):
+
+```python
+VAC_CREW_HASH_PRUNE_VERSION = 1
+```
+
+- [ ] **Step 4: Add the prune** (mirror `_run_subproject_b_hash_prune`, returning `bool`):
+
+```python
+def _run_vac_crew_hash_prune(hash_history: dict, groups: dict) -> bool:
+    """Sub-project C: idempotent one-time prune of legacy blank-identifier
+    vac_crew orphans (``wr|week|vac_crew|``) for WRs that are vac_crew in this
+    run. Returns True if it mutated hash_history (so the caller persists it
+    even on a no-update run). Distinct sentinel ``_vac_crew_prune_version``."""
+    _persisted = hash_history.pop('_vac_crew_prune_version', 0)
+    if isinstance(_persisted, int) and _persisted >= VAC_CREW_HASH_PRUNE_VERSION:
+        hash_history['_vac_crew_prune_version'] = _persisted
+        return False
+    _scope = _build_vac_crew_wr_scope(groups)
+    _orphans = []
+    for _hk in list(hash_history.keys()):
+        if isinstance(_hk, str) and _hk.startswith('_'):
+            continue
+        _parts = str(_hk).split('|')
+        if len(_parts) != 4:
+            continue
+        _wr, _wk, _var, _id = _parts
+        if _wr in _scope and _var == 'vac_crew' and _id == '':
+            _orphans.append(_hk)
+    for _ok in _orphans:
+        del hash_history[_ok]
+    hash_history['_vac_crew_prune_version'] = VAC_CREW_HASH_PRUNE_VERSION
+    if _orphans:
+        logging.info(
+            f"🧹 Vac crew hash-history prune: dropped {len(_orphans)} legacy "
+            f"unpartitioned vac_crew orphan(s) "
+            f"(WRs first 20: {sorted({k.split('|')[0] for k in _orphans})[:20]})"
+        )
+    else:
+        logging.info("🧹 Vac crew hash-history prune: no legacy vac_crew orphans to drop")
+    return True
+```
+
+- [ ] **Step 5: Register the PII marker** — add `"Vac crew hash-history prune"` to the `_PII_LOG_MARKERS` collection.
+
+- [ ] **Step 6: Wire the call site + migration-dirty flag** — next to the B prune call (`if _run_subproject_b_hash_prune(...)`), add:
+
+```python
+        try:
+            if _run_vac_crew_hash_prune(hash_history, groups):
+                _hash_history_migration_dirty = True
+        except Exception as _vc_prune_exc:
+            logging.warning(
+                f"⚠️ Vac crew hash-history prune failed; continuing "
+                f"with existing history: {_vc_prune_exc!r}"
+            )
+```
+
+- [ ] **Step 7: Run to verify pass**
+
+Run: `python -m pytest tests/test_vac_crew_claim_attribution.py::TestVacCrewHashPrune -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add generate_weekly_pdfs.py tests/test_vac_crew_claim_attribution.py
+git commit -m "feat(vac-crew): one-time legacy hash prune wired into migration-dirty save"
+```
+
+---
+
+## Task 8: End-to-end coexistence, non-vac preservation, production-site invariants
+
+**Files:**
+- Test: `tests/test_vac_crew_claim_attribution.py`
+- (No production change expected; if a test reveals a gap, fix it under TDD.)
+
+- [ ] **Step 1: Write the tests**
+
+```python
+class TestVacCrewEndToEnd(unittest.TestCase):
+    def setUp(self):
+        _reset_all()
+        self._orig = generate_weekly_pdfs.VAC_CREW_CLAIM_ATTRIBUTION_ENABLED
+        generate_weekly_pdfs.VAC_CREW_CLAIM_ATTRIBUTION_ENABLED = True
+
+    def tearDown(self):
+        generate_weekly_pdfs.VAC_CREW_CLAIM_ATTRIBUTION_ENABLED = self._orig
+        _reset_all()
+
+    def test_two_claimers_same_wr_week_coexist(self):
+        def _resolve(variant, current, *, wr, week_ending, row_id, enabled):
+            return ResolveOutcome('use', 'CrewA' if row_id == 6001 else 'CrewB', 'frozen', 'success')
+        with mock.patch('billing_audit.writer.resolve_claimer', side_effect=_resolve):
+            groups = generate_weekly_pdfs.group_source_rows(
+                [_make_vac_row(row_id=6001), _make_vac_row(row_id=6002)]
+            )
+        self.assertTrue(any('VACCREW_CrewA' in k for k in groups))
+        self.assertTrue(any('VACCREW_CrewB' in k for k in groups))
+
+    def test_non_vac_primary_row_unaffected(self):
+        # A non-vac, non-helper primary row still groups exactly as before.
+        row = {
+            'Work Request #': '91467680', 'Weekly Reference Logged Date': '2026-04-19',
+            'Snapshot Date': '2026-04-19', 'Units Completed?': True, 'Units Total Price': '$10.00',
+            'CU': 'X', 'Work Type': 'Inst', 'Quantity': 1,
+            '__effective_user': 'Boss', '__is_helper_row': False, '__is_vac_crew': False,
+            '__helper_foreman': '', '__helper_dept': '', '__helper_job': '',
+            '__source_sheet_id': 99999999, '__row_id': 1,
+        }
+        groups = generate_weekly_pdfs.group_source_rows([row])
+        self.assertTrue(any(k.startswith('041926_91467680') and 'VACCREW' not in k for k in groups))
+
+
+class TestVacCrewProductionInvariants(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._src = pathlib.Path(inspect.getsourcefile(generate_weekly_pdfs)).read_text(encoding='utf-8')
+
+    def test_prepass_present(self):
+        self.assertIn('_vac_crew_claimer_map', self._src)
+
+    def test_emission_uses_claimer_key(self):
+        self.assertIn('_VACCREW_{_c_vac_sanitized}', self._src)
+
+    def test_prune_version_constant(self):
+        self.assertRegex(self._src, r'(?m)^VAC_CREW_HASH_PRUNE_VERSION = 1$')
+
+    def test_prune_call_site_present(self):
+        self.assertIn('_run_vac_crew_hash_prune(hash_history, groups)', self._src)
+```
+
+- [ ] **Step 2: Run to verify** (these should pass if Tasks 3–7 are correct; if any fail, fix the production gap under TDD)
+
+Run: `python -m pytest tests/test_vac_crew_claim_attribution.py::TestVacCrewEndToEnd tests/test_vac_crew_claim_attribution.py::TestVacCrewProductionInvariants -v`
+Expected: PASS.
+
+- [ ] **Step 3: Run the FULL suite (zero regressions gate)**
+
+Run: `python -m pytest tests/ -q`
+Expected: PASS — all prior tests green, plus the new vac_crew tests. No vac_crew test in `tests/test_vac_crew.py` (the legacy detection/hash tests) regresses; if one does, it is asserting the legacy single-group key — update it in place with a docstring citing this plan (per the [2026-05-20 00:26] rule-2 contract-override discipline) and add a sibling test asserting the new per-claimer invariant.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/test_vac_crew_claim_attribution.py
+git commit -m "test(vac-crew): end-to-end coexistence + non-vac preservation + invariants"
+```
+
+---
+
+## Task 9: Docs + Living Ledger
+
+**Files:**
+- Modify: `website/docs/reference/environment.md`
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Document the env vars** — add `VAC_CREW_CLAIM_ATTRIBUTION_ENABLED` and `VAC_CREW_LEGACY_CLEANUP_ENABLED` to `environment.md` (default `'1'`, what they gate, and that OFF reverts to the legacy single `_VacCrew` file). Follow the format of the `SUBCONTRACTOR_*` entries.
+
+- [ ] **Step 2: Append the Living Ledger entry** to `CLAUDE.md` (prepend `[2026-05-21 HH:MM]`), covering: what shipped (vac_crew per-frozen-claimer partition), the all-sheets scope + new `VAC_CREW_*` flags, the kill-switch-OFF=exact-legacy contract, the parser reorder (VacCrew before Helper), TARGET-only migration + distinct prune sentinel, the preemptive B-lessons applied, and the final `pytest tests/` count.
+
+- [ ] **Step 3: Validate docs build** (if touched beyond the table)
+
+Run: `cd website && npm run build` (only if structural doc changes were made; a table-row addition needs no build).
+
+- [ ] **Step 4: Final full-suite confirmation**
+
+Run: `python -m pytest tests/ -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add website/docs/reference/environment.md CLAUDE.md
+git commit -m "docs(vac-crew): env vars + Living Ledger for Sub-project C"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Decision 1 (all-sheets scope) → Task 3 pre-pass predicate is sheet-agnostic (`__is_vac_crew`); Task 6/7 scope by `_VACCREW` group key (any sheet). ✓
+- Decision 2 (`_VacCrew_<name>`) → Task 2 (suffix + parser), Task 5 (filename). ✓
+- Decision 3 (fallback-to-current) → Task 4 emission (`use`/`no_history`/map-miss → current). ✓
+- Decision 4 (two new flags) → Task 1; OFF=legacy → Task 4 disabled branch + test. ✓
+- Decision 5 (HOLD on outage) → Task 4 (`hold` → defer + `record_attribution_hold`); summary already wired from B. ✓
+- CR-01 four sites → Task 4 (Site 1), Task 5 (Sites 2 & 3), Task 2 (parser). ✓
+- Migration (cleanup + prune, distinct sentinel, live-identity exemption, migration-dirty save) → Tasks 6 & 7. ✓
+- Preemptive B-lessons (empty-claimer sentinel, `.date()`, defensive raise) → Task 4 (`or 'Unknown'`, `.date()`), Task 2 (suffix raise). ✓
+- Hash retained / `billing_audit` untouched → no task modifies the hash content algorithm or `billing_audit/`. ✓
+- Testing (true e2e) → Tasks 3–8 drive real `group_source_rows`/`generate_excel`/cleanup/prune. ✓
+
+**Placeholder scan:** Task 6 Step 1 second test and Step 4 reference the B analog rather than re-pasting (`TestLegacyHelperTargetCleanupE2E`, the `sub_legacy_primary_variants` gate) — these are REAL in-repo code the implementer reads, not forward task references; the adaptation (vac variant, `'vac_crew'`, empty-identifier) is spelled out. Acceptable.
+
+**Type consistency:** `_vac_crew_variant_suffix(claimer, wr_num, week_end_raw)`, `_build_vac_crew_wr_scope(groups)`, `_run_vac_crew_hash_prune(hash_history, groups) -> bool`, `_vac_crew_claimer_map`, `_vac_crew_prune_version`, `VAC_CREW_HASH_PRUNE_VERSION`, `VAC_CREW_CLAIM_ATTRIBUTION_ENABLED`, `VAC_CREW_LEGACY_CLEANUP_ENABLED` — names consistent across tasks. `ResolveOutcome(action, name, source, status)` matches B test usage. ✓
+
+**Two implementation notes flagged for the executor** (verify against the live code, do not guess): (a) the exact parameter name of the row list in `group_source_rows` for the pre-pass loop; (b) the exact local holding the week `datetime`/`date` in scope at the vac_crew emission block (mirror B's HOLD-call site precisely).

--- a/docs/superpowers/specs/2026-05-21-subproject-c-vac-crew-claim-attribution-design.md
+++ b/docs/superpowers/specs/2026-05-21-subproject-c-vac-crew-claim-attribution-design.md
@@ -1,0 +1,191 @@
+# Sub-project C — VAC Crew Claim Attribution (Design)
+
+- **Status:** approved (design), pending implementation plan
+- **Date:** 2026-05-21
+- **Depends on:** Foundation A (`billing_audit.writer.resolve_claimer` +
+  HOLD contract, [2026-05-20 13:45]); Sub-project B (the per-frozen-claimer
+  partition pattern, [2026-05-21 09:21])
+- **Sequencing:** A → B → **C** → D → E. C is the third consumer of
+  Foundation A. E (Supabase hash-store migration + stripping
+  `_<hash>`/`_<timestamp>` filename tokens) remains **last**; C therefore
+  **retains** the existing hash-in-filename + `hash_history.json`
+  change-detection mechanism unchanged.
+
+## 1. Goal
+
+Re-partition the `vac_crew` Excel files so each file holds only **one
+frozen vac-crew claimer's** completed line items, named
+`_VacCrew_<name>`, mirroring how B partitions subcontractor primary
+files. Attribution is **frozen first-write-wins per row** via
+`billing_audit.attribution_snapshot.frozen_vac_crew` (already captured by
+`freeze_row`; C only *consumes* it).
+
+**Why:** today a WR+week produces ONE `{week}_{wr}_VACCREW` group holding
+every crew member → a single `_VacCrew` file. If two crew members work the
+same WR+week, their line items are commingled in one file and a member who
+switches mid-week can be re-credited. Partitioning by the frozen claimer
+fixes both.
+
+## 2. Operator-approved decisions
+
+1. **Scope = ALL vac_crew rows, every sheet** (subcontractor *and*
+   original-contract). vac_crew is a cross-sheet concept and `freeze_row`
+   captures `frozen_vac_crew` for all of them. (Unlike B, which was
+   subcontractor-only.)
+2. **Filename token = `_VacCrew_<name>`** (mirrors the helper-shadow
+   `_Helper_<name>` convention; the legacy unpartitioned `_VacCrew` — no
+   name — must still parse for migration cleanup).
+3. **Partition model = fallback-to-current.** Rows with a frozen claimer
+   group under that claimer; rows with no frozen claimer yet
+   (`no_history`) fall back to the current `__vac_crew_name`. (Every row
+   reaching the vac_crew block is `Vac Crew Completed Unit?` +
+   `Units Completed?` checked.)
+4. **Kill switches (new, default-on, workflow-pinned):**
+   `VAC_CREW_CLAIM_ATTRIBUTION_ENABLED` (gates partitioning) and
+   `VAC_CREW_LEGACY_CLEANUP_ENABLED` (gates destructive legacy cleanup).
+   A vac_crew-scoped flag is correct because the subcontractor flag's name
+   would mislead for original-contract vac crew. (A universal
+   `CLAIM_ATTRIBUTION_ENABLED` flag was considered and deferred to an
+   E-era consolidation to avoid re-scoping B's already-shipped flag.)
+5. **Outage = HOLD.** On `resolve_claimer` `fetch_failure` the row is
+   deferred (`record_attribution_hold`), no vac_crew file is emitted that
+   run, and `summarize_attribution_holds()` fires once at end-of-run.
+   Correctness over availability — a possibly mis-attributed billing file
+   is worse than a late one. Mirrors B.
+
+## 3. Architecture & data flow
+
+```
+completed vac_crew rows
+   ↓  PRE-PASS (Approach A — bounded ThreadPoolExecutor,
+   ↓  max_workers = min(PARALLEL_WORKERS, n); single-row groups skip the executor)
+   resolve_claimer(variant="vac_crew", current=__vac_crew_name, *,
+                   wr, week_ending=week.date(), row_id=__row_id,
+                   enabled=VAC_CREW_CLAIM_ATTRIBUTION_ENABLED)
+   → {__row_id: ResolveOutcome}      # NO Supabase I/O inside the grouping loop
+   ↓  group_source_rows vac_crew block
+   'use'        → claimer = frozen_vac_crew (or current on empty) → {week}_{wr}_VACCREW_{sanitized claimer}
+   'no_history' → claimer = current __vac_crew_name              → same shape
+   'hold'       → DEFER row + record_attribution_hold(wr, week.date(), 'vac_crew'); emit nothing
+   map-miss / disabled → use current __vac_crew_name (NEVER hold)
+```
+
+The pre-pass placement and the "no per-row attribution I/O in the hot
+loop" rule come from Foundation A / B ([2026-05-21 09:21] rule 2). A row
+absent from the map (attribution disabled, pre-pass skipped, missing
+`__row_id`, unexpected per-row error) resolves to use-current at
+emission — **never** HOLD; only `resolve_claimer`'s own `fetch_failure`
+HOLDs (so a plumbing fault can never silently suppress a billing file).
+
+## 4. Touch points — CR-01 four-site lockstep + display + hash
+
+The claimer identifier MUST be built identically at all four sites; drift
+breaks attachment-identity matching or hash-history persistence
+([2026-05-15] CR-01, extended by B).
+
+| Site | Today (vac_crew) | Sub-project C |
+|---|---|---|
+| Group key / `__current_foreman` (emission) | `{week}_{wr}_VACCREW`; foreman unused | `{week}_{wr}_VACCREW_{sanitized claimer}`; `__current_foreman = claimer` |
+| `valid_wr_weeks` cleanup tuple builder | identifier `''` | sanitized claimer |
+| `current_keys` hash-prune set | `{wr}|{week}|vac_crew|''` | `{wr}|{week}|vac_crew|{sanitized claimer}` |
+| `build_group_identity` parser | `VacCrew` → `vac_crew`, identifier `''` | extract claimer via span-join; **reorder the `VacCrew` branch ahead of the `Helper` scan** so a crew name containing the `Helper` token cannot misparse (B round-7 Codex lesson); legacy `_VacCrew` (no name) still yields identifier `''` |
+
+`generate_excel`:
+- filename `variant_suffix = '_VacCrew'` → `_VacCrew_{sanitized claimer}`
+  (sourced from `__current_foreman`, set by the pre-pass).
+- display **foreman = the attributed claimer (`__current_foreman`)**;
+  `display_dept` / `display_job` stay from `__vac_crew_dept` /
+  `__vac_crew_job`. (Do NOT regress to a row's current name — the
+  [2026-05-21 12:35] dept-#/Job-# display-source lesson.)
+
+Hash: the vac_crew **history-key** gains the claimer
+(`{wr}|{week}|vac_crew|{sanitized claimer}`); the per-row **content** hash
+keeps `__vac_crew_name` as-is (it is the change-detection content, not the
+identity key).
+
+Identifier sanitization reuses `_RE_SANITIZE_IDENTIFIER` (the same
+sanitizer B uses), `[:50]`.
+
+## 5. Configuration
+
+| Var | Default | Effect |
+|---|---|---|
+| `VAC_CREW_CLAIM_ATTRIBUTION_ENABLED` | `'1'` | On ⇒ pre-pass + per-claimer partitioning. Off ⇒ today's single `_VacCrew` group (exact legacy behavior). |
+| `VAC_CREW_LEGACY_CLEANUP_ENABLED` | `'1'` | On ⇒ destructive legacy-`_VacCrew` TARGET cleanup runs. Off ⇒ reverts to pre-C cleanup behavior. |
+
+Both pinned in `.github/workflows/weekly-excel-generation.yml`, documented
+in `website/docs/reference/environment.md`, and their resolved state
+printed in the startup banner.
+
+## 6. Migration (one-time, idempotent)
+
+- **TARGET-only cleanup** (vac_crew never routes to PPP — confirmed in the
+  upload-routing function): `cleanup_untracked_sheet_attachments` gains a
+  vac_crew off-contract gate that deletes empty-identifier `_VacCrew`
+  attachments for in-scope vac WRs, **with the `valid_wr_weeks`
+  live-identity exemption** so a current per-claimer file is never deleted
+  ([2026-05-19 23:45] data-loss lesson). In-scope WRs come from a shared
+  `_build_vac_crew_wr_scope(groups)` (WRs with any `_VACCREW` group key) —
+  one implementation used by both the cleanup call site and the prune (no
+  drift, mirroring B's `_build_subcontractor_wr_scope`).
+- **One-time hash prune** `_run_vac_crew_hash_prune` with a NEW
+  `VAC_CREW_HASH_PRUNE_VERSION` constant + `_vac_crew_prune_version`
+  sentinel (DISTINCT from B's `_subproject_b_prune_version` and Phase
+  1.1's `_phase_prune_version`), dropping legacy `{wr}|{week}|vac_crew|''`
+  orphans for in-scope vac WRs. It **returns the mutated-bool** and wires
+  into the existing `_hash_history_migration_dirty` save path so it
+  persists even on no-update runs ([2026-05-21 13:20] Codex P2 fix). New
+  PII marker `"Vac crew hash-history prune"` registered in
+  `_PII_LOG_MARKERS`. The prune is benign (drops a hash key → at most one
+  regeneration, never data loss), so it carries no live-identity exemption.
+
+## 7. Error handling & preemptive B-lessons
+
+Apply the fixes already learned in B from the start (do not re-introduce
+the bugs):
+- **Empty-claimer → `'Unknown'` sentinel** before any `_VacCrew_<name>`
+  key/filename is built (B Codex P1). `__vac_crew_name` is required for
+  vac_crew detection so it is normally non-empty, but the fallback chain
+  (`frozen or current or 'Unknown'`) guards the edge.
+- **`.date()` normalization** on the `record_attribution_hold` call
+  (Copilot #1).
+- **Defensive raise** on the vac_crew suffix helper if it ever receives an
+  unexpected variant (Copilot #2 convention for new variant-identity
+  helpers).
+
+`billing_audit/` is **NOT modified** — Foundation A already provides
+`resolve_claimer`, `ROLE_BY_VARIANT["vac_crew"] = "vac_crew"`,
+`record_attribution_hold`, and `summarize_attribution_holds`.
+
+## 8. Out of scope
+
+- Hash/timestamp filename-token stripping and the Supabase
+  change-detection cutover — that is **Sub-project E**.
+- Primary-workflow primary partitioning — **Sub-project D**.
+- Any change to legacy `primary` / `helper` / subcontractor
+  (`reduced_sub` / `aep_billable` / `*_helper`) variants, the upload
+  routing, or the hash content algorithm.
+
+## 9. Testing (TDD, true end-to-end)
+
+New `tests/test_vac_crew_claim_attribution.py`, driving real production
+code paths (per the [2026-05-20 00:26] rule 4 — static mirror classes do
+NOT count):
+- `group_source_rows` partitioning: frozen / no_history / hold / disabled
+  / map-miss outcomes.
+- `build_group_identity`: `_VacCrew_<name>` round-trip, a claimer name
+  containing the `Helper` token parsing as `vac_crew`, legacy `_VacCrew`
+  (no name) → identifier `''`.
+- Two claimers on the same WR+week produce two coexisting files (no
+  cross-delete).
+- TARGET cleanup: in-scope empty-identifier `_VacCrew` deleted; a live
+  per-claimer identity exempt; non-vac WRs preserved.
+- Prune: return-value contract (mutated → True, idempotent → False) +
+  idempotency + PII marker registered.
+- HOLD records exactly one hold with a date-only week key.
+- Non-vac variants unaffected (byte-identical grouping for
+  primary/helper/subcontractor).
+- Production-code-site invariants: source-level grep guards that the
+  four identity sites carry the vac_crew claimer.
+
+Full `pytest tests/` must remain green at every plan-completion checkpoint.

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -6030,13 +6030,21 @@ def generate_excel(group_key, group_rows, snapshot_date, ai_analysis_results=Non
             helper_sanitized = _RE_SANITIZE_HELPER_NAME.sub('_', helper_foreman)[:50]
             variant_suffix = f"_Helper_{helper_sanitized}"
     elif variant == 'vac_crew':
-        # Subproject C: per-claimer suffix so each foreman gets their own file.
-        # Falls back to __vac_crew_name when __current_foreman is absent (legacy
-        # disabled-attribution path) so the suffix is never empty.
-        variant_suffix = _vac_crew_variant_suffix(
-            first_row.get('__current_foreman') or first_row.get('__vac_crew_name', ''),
-            wr_num, week_end_raw,
-        )
+        # Subproject C: suffix is GATED on the kill switch.
+        # Enabled mode: per-claimer _VacCrew_<name> so each foreman's file is
+        # distinct and matches the Sites 1/2/3 identity tuple.
+        # Disabled mode: exact legacy bare '_VacCrew' suffix — no claimer name
+        # embedded, preserving byte-identical filenames with pre-C attachments.
+        # NOTE: __vac_crew_name is intentionally NOT used as a fallback in
+        # disabled mode; the legacy contract is a bare '_VacCrew' token, and
+        # falling back to __vac_crew_name would produce _VacCrew_<name> in
+        # disabled mode, which violates the disabled=legacy invariant.
+        _vc_name = first_row.get('__current_foreman', '')
+        if VAC_CREW_CLAIM_ATTRIBUTION_ENABLED and _vc_name:
+            variant_suffix = _vac_crew_variant_suffix(_vc_name, wr_num, week_end_raw)
+        else:
+            # Disabled mode (or no claimer resolved) → exact legacy bare suffix.
+            variant_suffix = '_VacCrew'
     elif variant == 'primary':
         # Primary variant (no suffix needed)
         variant_suffix = ''
@@ -7827,12 +7835,16 @@ def main():  # pyright: ignore[reportGeneralTypeIssues]
                     file_identifier = _RE_SANITIZE_HELPER_NAME.sub('_', helper_foreman)[:50] if helper_foreman else ''
                 elif variant == 'vac_crew':
                     # Subproject C identity site (Site 1 — main-loop identifier /
-                    # history_key / file_identifier). Must match the sanitized
-                    # claimer used at Site 2 (valid_wr_weeks) + Site 3 (current_keys)
-                    # + the filename, or the hash entry is stale-pruned every run
-                    # causing permanent regeneration churn and orphan accumulation.
+                    # history_key / file_identifier). GATED on the kill switch:
+                    # disabled mode MUST reproduce the exact legacy '' identifier
+                    # (bare _VacCrew filename, bare history_key) so existing
+                    # attachments are not treated as stale and regeneration churn
+                    # is not triggered. Enabled mode uses the sanitized claimer.
                     _vc = first_row.get('__current_foreman', '')
-                    identifier = _RE_SANITIZE_IDENTIFIER.sub('_', _vc)[:50] if _vc else ''
+                    identifier = (
+                        _RE_SANITIZE_IDENTIFIER.sub('_', _vc)[:50]
+                        if (VAC_CREW_CLAIM_ATTRIBUTION_ENABLED and _vc) else ''
+                    )
                     file_identifier = identifier
                 elif variant in ('reduced_sub', 'aep_billable'):
                     # Subproject B identity site (Site 1 — main-loop
@@ -8559,9 +8571,15 @@ def main():  # pyright: ignore[reportGeneralTypeIssues]
                     file_id = _RE_SANITIZE_HELPER_NAME.sub('_', helper_foreman)[:50] if helper_foreman else ''
                 elif variant == 'vac_crew':
                     # Subproject C identity site (Site 2 — valid_wr_weeks).
-                    # Mirror Site 1 so cleanup keeps the live per-claimer file.
+                    # GATED on the kill switch (mirrors Site 1): disabled mode
+                    # produces file_id='' so the 4-tuple matches the bare
+                    # _VacCrew attachment identity and cleanup does not delete
+                    # live legacy-mode attachments.
                     _vc = group_rows[0].get('__current_foreman', '')
-                    file_id = _RE_SANITIZE_IDENTIFIER.sub('_', _vc)[:50] if _vc else ''
+                    file_id = (
+                        _RE_SANITIZE_IDENTIFIER.sub('_', _vc)[:50]
+                        if (VAC_CREW_CLAIM_ATTRIBUTION_ENABLED and _vc) else ''
+                    )
                 elif variant in ('reduced_sub', 'aep_billable'):
                     # Subproject B identity site (Site 2 — valid_wr_weeks).
                     # Mirror Site 1 so attachment cleanup keeps the live
@@ -8767,14 +8785,15 @@ def main():  # pyright: ignore[reportGeneralTypeIssues]
                             _ident = f"{_hf}|{_hd}|{_hj}"
                         elif _variant == 'vac_crew':
                             # Subproject C identity site (Site 3 —
-                            # current_keys). Must match the history_key
-                            # written at Site 1 (sanitized claimer) or
-                            # the fresh entry is treated as stale and
-                            # deleted before save.
+                            # current_keys). GATED on the kill switch (mirrors
+                            # Site 1): disabled mode produces _ident='' so the
+                            # reconstructed current_keys entry matches the
+                            # bare history_key written by Site 1 and the fresh
+                            # entry is not treated as stale and deleted.
                             _vc = group_rows[0].get('__current_foreman', '')
                             _ident = (
                                 _RE_SANITIZE_IDENTIFIER.sub('_', _vc)[:50]
-                                if _vc else ''
+                                if (VAC_CREW_CLAIM_ATTRIBUTION_ENABLED and _vc) else ''
                             )
                         elif _variant in ('reduced_sub', 'aep_billable'):
                             # Subproject B identity site (Site 3 —

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -705,9 +705,11 @@ logging.info(
 # operators grepping the banner see the active feature state at a
 # glance. Banner body carries no row PII (just the resolved bools).
 logging.info(
-    f"🚐 VAC Crew claim attribution: "
-    f"{'ENABLED' if VAC_CREW_CLAIM_ATTRIBUTION_ENABLED else 'DISABLED'}; "
-    f"legacy cleanup: "
+    f"📋 VAC Crew claim attribution: "
+    f"{'ENABLED' if VAC_CREW_CLAIM_ATTRIBUTION_ENABLED else 'DISABLED'}"
+)
+logging.info(
+    f"📋 VAC Crew legacy cleanup: "
     f"{'ENABLED' if VAC_CREW_LEGACY_CLEANUP_ENABLED else 'DISABLED'}"
 )
 

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -7826,9 +7826,14 @@ def main():  # pyright: ignore[reportGeneralTypeIssues]
                     # file_identifier matches the sanitized name that generate_excel() puts in the filename
                     file_identifier = _RE_SANITIZE_HELPER_NAME.sub('_', helper_foreman)[:50] if helper_foreman else ''
                 elif variant == 'vac_crew':
-                    # VAC Crew variant: no sub-identifier needed (all vac_crew rows for WR/week go together)
-                    identifier = ''
-                    file_identifier = ''
+                    # Subproject C identity site (Site 1 — main-loop identifier /
+                    # history_key / file_identifier). Must match the sanitized
+                    # claimer used at Site 2 (valid_wr_weeks) + Site 3 (current_keys)
+                    # + the filename, or the hash entry is stale-pruned every run
+                    # causing permanent regeneration churn and orphan accumulation.
+                    _vc = first_row.get('__current_foreman', '')
+                    identifier = _RE_SANITIZE_IDENTIFIER.sub('_', _vc)[:50] if _vc else ''
+                    file_identifier = identifier
                 elif variant in ('reduced_sub', 'aep_billable'):
                     # Subproject B identity site (Site 1 — main-loop
                     # identifier). Partitioned by the frozen primary

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -6355,14 +6355,19 @@ def generate_excel(group_key, group_rows, snapshot_date, ai_analysis_results=Non
         display_dept = first_row.get('__helper_dept', '')
         display_job = first_row.get('__helper_job', '')
     elif variant == 'vac_crew':
-        # Subproject C: show the ATTRIBUTED claimer (__current_foreman, the
+        # Enabled: show the ATTRIBUTED claimer (__current_foreman, the
         # partition key) so the displayed foreman matches the filename.
-        # Falls back to __vac_crew_name when attribution is disabled or absent
-        # (legacy path) — dept/job remain VAC-crew-specific in all cases.
-        display_foreman = (
-            first_row.get('__current_foreman')
-            or first_row.get('__vac_crew_name', 'Unknown VAC Crew')
-        )
+        # Disabled (legacy): show __vac_crew_name exactly as master did —
+        # must NOT fall back to __current_foreman (which in disabled mode
+        # may be the primary / Arrowhead foreman, not the VAC crew member).
+        # dept/job remain VAC-crew-specific in all cases.
+        if VAC_CREW_CLAIM_ATTRIBUTION_ENABLED:
+            display_foreman = (
+                first_row.get('__current_foreman')
+                or first_row.get('__vac_crew_name', 'Unknown VAC Crew')
+            )
+        else:
+            display_foreman = first_row.get('__vac_crew_name', 'Unknown VAC Crew')
         display_dept = first_row.get('__vac_crew_dept', '')
         display_job = first_row.get('__vac_crew_job', '')
     else:
@@ -8980,7 +8985,7 @@ def main():  # pyright: ignore[reportGeneralTypeIssues]
             save_hash_history(HASH_HISTORY_PATH, hash_history)
         elif _hash_history_migration_dirty:
             # Codex P2: no group updates this run, but a one-time migration
-            # prune (Phase 1.1 / Subproject B) mutated hash_history. Persist
+            # prune (Phase 1.1 / Subproject B / Subproject C) mutated hash_history. Persist
             # it now so the migration is durable and does not re-run every
             # execution. Do NOT run the stale-prune on this path — groups
             # were not fully processed, so current_keys would be incomplete
@@ -9024,10 +9029,11 @@ def main():  # pyright: ignore[reportGeneralTypeIssues]
                 _run_summary.update(_billing_audit_writer.get_counters())
             except Exception:
                 pass  # Counter retrieval must never fail the run summary write.
-            # Subproject B: emit ONE aggregate WARNING if any rows were
-            # held this run pending attribution (Supabase outage). B is
-            # the first consumer of Foundation A's HOLD machinery; this
-            # is the single end-of-run summary call. PII-safe (counts +
+            # Subproject B / Subproject C: emit ONE aggregate WARNING if any
+            # rows were held this run pending attribution (Supabase outage).
+            # B is the first consumer of Foundation A's HOLD machinery; C
+            # (vac_crew) also records holds via the same counter. This is
+            # the single end-of-run summary call. PII-safe (counts +
             # sanitized WR list only). Never fail the run summary write.
             try:
                 _billing_audit_writer.summarize_attribution_holds()

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -520,7 +520,7 @@ SUBCONTRACTOR_LEGACY_PRIMARY_CLEANUP_ENABLED = os.getenv(
     'SUBCONTRACTOR_LEGACY_PRIMARY_CLEANUP_ENABLED', '1'
 ).strip().lower() in ('1', 'true', 'yes', 'on')
 
-# Sub-project C (2026-05-21): default-ON kill switch that enables
+# Subproject C (2026-05-21): default-ON kill switch that enables
 # per-claimer partitioning of ``_VacCrew`` Excel files. When enabled,
 # each vac-crew Excel is partitioned by the FROZEN vac-crew claimer
 # (``vac_crew`` role from ``billing_audit.attribution_snapshot`` via
@@ -531,7 +531,7 @@ VAC_CREW_CLAIM_ATTRIBUTION_ENABLED = os.getenv(
     'VAC_CREW_CLAIM_ATTRIBUTION_ENABLED', '1'
 ).strip().lower() in ('1', 'true', 'yes', 'on')
 
-# Sub-project C (2026-05-21): default-ON kill switch for the one-time
+# Subproject C (2026-05-21): default-ON kill switch for the one-time
 # removal of legacy UNPARTITIONED ``_VacCrew`` attachments (no
 # ``_User_`` token, parsed identifier == '') on TARGET_SHEET_ID for
 # vac-crew WRs, once those variants are re-partitioned by frozen
@@ -701,7 +701,7 @@ logging.info(
     f"{SUBCONTRACTOR_LEGACY_PRIMARY_CLEANUP_ENABLED}"
 )
 
-# Sub-project C: surface resolved kill-switch state at startup so
+# Subproject C: surface resolved kill-switch state at startup so
 # operators grepping the banner see the active feature state at a
 # glance. Banner body carries no row PII (just the resolved bools).
 logging.info(
@@ -2503,7 +2503,8 @@ def build_group_identity(filename: str) -> tuple[str, str, str, str | None] | No
         - Primary: (wr, week, 'primary', None)
         - Primary+User: (wr, week, 'primary', user_identifier)
         - Helper: (wr, week, 'helper', helper_name)
-        - VAC Crew: (wr, week, 'vac_crew', '')
+        - VAC Crew (legacy, no claimer): (wr, week, 'vac_crew', '')
+        - VAC Crew (named, Subproject C): (wr, week, 'vac_crew', crew_name)
         - AEP Billable: (wr, week, 'aep_billable', '')
         - Reduced Sub: (wr, week, 'reduced_sub', '')
         - AEP Billable Helper: (wr, week, 'aep_billable_helper', helper_name)
@@ -2518,7 +2519,8 @@ def build_group_identity(filename: str) -> tuple[str, str, str, str | None] | No
     - WR_{wr}_WeekEnding_{week}_{timestamp}_{hash}.xlsx (primary)
     - WR_{wr}_WeekEnding_{week}_{timestamp}_User_{user}_{hash}.xlsx (primary+user)
     - WR_{wr}_WeekEnding_{week}_{timestamp}_Helper_{helper}_{hash}.xlsx (helper)
-    - WR_{wr}_WeekEnding_{week}_{timestamp}_VacCrew_{hash}.xlsx (VAC Crew)
+    - WR_{wr}_WeekEnding_{week}_{timestamp}_VacCrew_{hash}.xlsx (VAC Crew, legacy)
+    - WR_{wr}_WeekEnding_{week}_{timestamp}_VacCrew_{name}_{hash}.xlsx (VAC Crew named, Subproject C)
     - WR_{wr}_WeekEnding_{week}_{timestamp}_AEPBillable_{hash}.xlsx (AEP Billable)
     - WR_{wr}_WeekEnding_{week}_{timestamp}_ReducedSub_{hash}.xlsx (Reduced Sub)
     - WR_{wr}_WeekEnding_{week}_{timestamp}_AEPBillable_Helper_{helper}_{hash}.xlsx
@@ -2677,13 +2679,15 @@ def build_group_identity(filename: str) -> tuple[str, str, str, str | None] | No
             variant = 'reduced_sub'
             identifier = ''
     elif 'VacCrew' in tail:
-        # Sub-project C: _VacCrew_<name>_<hash>. Checked BEFORE the 'Helper'
+        # Subproject C: _VacCrew_<name>_<hash>. Checked BEFORE the 'Helper'
         # scan so a crew name containing the 'Helper' token isn't
         # misclassified as a helper variant (B round-7 lesson). Span-join so
-        # an underscored name survives. Legacy _VacCrew (no name) → ''.
+        # an underscored name survives. Legacy _VacCrew (no name) -> ''.
         variant = 'vac_crew'
         vac_idx_rel = tail.index('VacCrew')
-        identifier = '_'.join(tail[vac_idx_rel + 1:-1])
+        identifier = ''  # legacy _VacCrew (no name) -> '' per identity contract
+        if vac_idx_rel + 1 < len(tail):
+            identifier = '_'.join(tail[vac_idx_rel + 1:-1])
     elif 'Helper' in tail:
         variant = 'helper'
         helper_idx_rel = tail.index('Helper')
@@ -5710,7 +5714,7 @@ def _subcontractor_primary_variant_suffix(
 def _vac_crew_variant_suffix(claimer: str, wr_num: str, week_end_raw: str) -> str:
     """Build the filename suffix for a per-claimer VAC crew file.
 
-    Sub-project C (2026-05-21): vac_crew files are partitioned by frozen
+    Subproject C (2026-05-21): vac_crew files are partitioned by frozen
     vac-crew claimer and named ``_VacCrew_<sanitized name>``. Raises on an
     empty claimer (production never hits this — the emission falls back to
     'Unknown'); the raise surfaces data drift instead of an ambiguous name.
@@ -5718,7 +5722,7 @@ def _vac_crew_variant_suffix(claimer: str, wr_num: str, week_end_raw: str) -> st
     if not claimer:
         logging.error(
             f"⚠️ vac_crew variant row missing claimer for WR {wr_num} "
-            f"week {week_end_raw}; filename would be ambiguous — raising."
+            f"week {week_end_raw}; filename would be ambiguous — raising to surface data drift."
         )
         raise ValueError(
             f"vac_crew requires a non-empty claimer; got empty for "

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -316,6 +316,13 @@ PHASE_1_1_HASH_PRUNE_VERSION = 2
 # Phase 1.1 prune so the two migrations are independent + auditable.
 # Advancing this constant is the kill switch (re-run trigger).
 SUBPROJECT_B_HASH_PRUNE_VERSION = 1
+# Subproject C (2026-05-21): one-time hash-history prune version for
+# dropping LEGACY blank-identifier `vac_crew` orphans left behind when
+# C re-partitions vac_crew variants by frozen claimer. Separate sentinel
+# (`_vac_crew_prune_version`) from Phase 1.1 and Subproject B so all
+# three migrations are independent + auditable.
+# Advancing this constant is the kill switch (re-run trigger).
+VAC_CREW_HASH_PRUNE_VERSION = 1
 # Verbose debug tunables
 DEBUG_SAMPLE_ROWS = int(os.getenv('DEBUG_SAMPLE_ROWS','3') or 3)  # How many initial rows (across all sheets) to show full per-cell mapping
 DEBUG_ESSENTIAL_ROWS = int(os.getenv('DEBUG_ESSENTIAL_ROWS','5') or 5)  # How many initial rows to log essential field summary
@@ -1039,6 +1046,11 @@ _PII_LOG_MARKERS: tuple[str, ...] = (
     # containment with pre-existing markers (this body does not overlap
     # "Phase 1.1 hash-history prune").
     "Subproject B hash-history prune",
+    # Subproject C Task 7: one-time hash-history prune INFO log embeds
+    # the affected-WR list (capped to first 20 entries). Explicit marker
+    # per the [2026-05-15 12:00] rule 3 — no accidental substring
+    # containment with pre-existing markers.
+    "Vac crew hash-history prune",
 )
 
 
@@ -3499,6 +3511,71 @@ def _run_subproject_b_hash_prune(hash_history: dict, groups: dict) -> bool:
     # Codex P2: body path advanced the sentinel (and may have dropped
     # orphans) — report the mutation so the caller persists it even on a
     # no-update run.
+    return True
+
+
+def _run_vac_crew_hash_prune(hash_history: dict, groups: dict) -> bool:
+    """Subproject C (2026-05-21): idempotent one-time hash-history prune.
+
+    Drops LEGACY blank-identifier vac_crew orphans — 4-part keys
+    ``wr|week|vac_crew|`` with an EMPTY identifier — for WRs that are
+    vac_crew in this run. C re-partitions vac_crew variants by frozen
+    claimer (new keys carry a non-empty identifier), so the
+    blank-identifier entries are obsolete. The normal stale-prune at the
+    end of the run would clear them eventually; this makes the migration
+    deterministic on the first run and survives interrupted / no-update
+    runs.
+
+    Scope-building delegates to ``_build_vac_crew_wr_scope`` (shared
+    with the cleanup call site — no drift, per the [2026-05-15 12:00]
+    three-site invariant). Sentinel key ``_vac_crew_prune_version`` is
+    DISTINCT from ``_phase_prune_version`` (Phase 1.1) and
+    ``_subproject_b_prune_version`` (Subproject B) so the three
+    migrations are independent. Mutates ``hash_history`` in place.
+    Dropping a hash entry costs at most one benign regeneration — never
+    data loss — so no live-identity exemption is needed on this drop
+    path (unlike the every-run attachment cleanup).
+    """
+    _persisted = hash_history.pop('_vac_crew_prune_version', 0)
+    if (
+        isinstance(_persisted, int)
+        and _persisted >= VAC_CREW_HASH_PRUNE_VERSION
+    ):
+        hash_history['_vac_crew_prune_version'] = _persisted
+        # Codex P2: no-op sentinel restore only — no save needed.
+        return False
+
+    _scope = _build_vac_crew_wr_scope(groups)
+    _orphans: list[str] = []
+    for _hk in list(hash_history.keys()):
+        if isinstance(_hk, str) and _hk.startswith('_'):
+            continue
+        _parts = str(_hk).split('|')
+        if len(_parts) != 4:
+            continue
+        _hk_wr, _hk_week, _hk_variant, _hk_ident = _parts
+        if (
+            _hk_wr in _scope
+            and _hk_variant == 'vac_crew'
+            and _hk_ident == ''
+        ):
+            _orphans.append(_hk)
+    for _ok in _orphans:
+        del hash_history[_ok]
+    hash_history['_vac_crew_prune_version'] = VAC_CREW_HASH_PRUNE_VERSION
+    if _orphans:
+        _wr_sample = sorted({k.split('|')[0] for k in _orphans})[:20]
+        logging.info(
+            f"🧹 Vac crew hash-history prune: dropped {len(_orphans)} legacy "
+            f"unpartitioned vac_crew orphan(s) "
+            f"(WRs first 20: {_wr_sample})"
+        )
+    else:
+        logging.info(
+            "🧹 Vac crew hash-history prune: no legacy vac_crew orphans to drop"
+        )
+    # Body path advanced the sentinel (and may have dropped orphans) —
+    # report the mutation so the caller persists it even on a no-update run.
     return True
 
 
@@ -7584,6 +7661,18 @@ def main():  # pyright: ignore[reportGeneralTypeIssues]
             logging.warning(
                 f"⚠️ Subproject B hash-history prune failed; continuing "
                 f"with existing history: {_b_prune_exc!r}"
+            )
+
+        # Subproject C: one-time prune of legacy blank-identifier vac_crew
+        # orphans (kill switch is the version constant). Fail-safe — a
+        # failed prune must not break the run.
+        try:
+            if _run_vac_crew_hash_prune(hash_history, groups):
+                _hash_history_migration_dirty = True
+        except Exception as _vc_prune_exc:
+            logging.warning(
+                f"⚠️ Vac crew hash-history prune failed; continuing "
+                f"with existing history: {_vc_prune_exc!r}"
             )
 
         billing_audit_row_cache: set[str] = set()

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -4917,6 +4917,75 @@ def group_source_rows(rows):
                 )
                 _sub_primary_claimer_map = {}
 
+    # Subproject C: Resolve the FROZEN vac-crew claimer for every completed
+    # VAC Crew row BEFORE the grouping loop, so no per-row Supabase
+    # round-trip runs inside the hot loop (honors [2026-04-25 14:00]
+    # latency lesson). The map is keyed by __row_id and consumed by the
+    # vac_crew emission block. A row absent from the map (attribution
+    # disabled, pre-pass skipped, missing __row_id, or unexpected per-row
+    # error) resolves to use-current at emission — NEVER HOLD — so a
+    # plumbing fault can never silently suppress a billing file.
+    # resolve_claimer's own fetch_failure -> HOLD is the only path that
+    # defers a row.
+    _vac_crew_claimer_map: dict = {}
+    if BILLING_AUDIT_AVAILABLE and VAC_CREW_CLAIM_ATTRIBUTION_ENABLED:
+        _vac_pre_rows = []
+        for _r in rows:
+            _rid = _r.get('__row_id')
+            if not isinstance(_rid, int):
+                continue
+            if not _r.get('__is_vac_crew'):
+                continue
+            _wr_raw = _r.get('Work Request #')
+            _ld = _r.get('Weekly Reference Logged Date')
+            if not _wr_raw or not _ld or not is_checked(_r.get('Units Completed?')):
+                continue
+            _we = excel_serial_to_date(_ld)
+            if _we is None:
+                continue
+            _vac_pre_rows.append((
+                _rid,
+                str(_wr_raw).split('.')[0],
+                _we.date() if isinstance(_we, datetime.datetime) else _we,
+                _r.get('__vac_crew_name') or '',
+            ))
+        if _vac_pre_rows:
+            try:
+                from billing_audit.writer import resolve_claimer as _resolve_claimer_vac
+
+                def _resolve_one_vac(_item):
+                    _rid, _wr, _we_date, _current = _item
+                    return _rid, _resolve_claimer_vac(
+                        'vac_crew', _current,
+                        wr=_wr, week_ending=_we_date, row_id=_rid,
+                        enabled=VAC_CREW_CLAIM_ATTRIBUTION_ENABLED,
+                    )
+
+                if len(_vac_pre_rows) <= 1:
+                    for _item in _vac_pre_rows:
+                        _rid, _out = _resolve_one_vac(_item)
+                        _vac_crew_claimer_map[_rid] = _out
+                else:
+                    _workers = min(PARALLEL_WORKERS, len(_vac_pre_rows))
+                    with ThreadPoolExecutor(max_workers=_workers) as _ex:
+                        _futs = [_ex.submit(_resolve_one_vac, _it) for _it in _vac_pre_rows]
+                        for _fut in as_completed(_futs):
+                            try:
+                                _rid, _out = _fut.result()
+                                _vac_crew_claimer_map[_rid] = _out
+                            except Exception:
+                                logging.exception(
+                                    "⚠️ Subproject C attribution pre-pass: "
+                                    "unexpected error for one row (treating "
+                                    "as use-current)"
+                                )
+            except Exception:
+                logging.exception(
+                    "⚠️ Subproject C attribution pre-pass failed; falling "
+                    "back to current vac-crew name for all VAC Crew rows"
+                )
+                _vac_crew_claimer_map = {}
+
     for r in rows:
         wr = r.get('Work Request #')
         log_date_str = r.get('Weekly Reference Logged Date')
@@ -4986,18 +5055,63 @@ def group_source_rows(rows):
             # both primary/helper rows AND VAC Crew rows — they are mutually exclusive per-row
             # because a single row is either a VAC Crew row or a regular/helper row.
             if is_vac_crew_row:
-                vac_crew_key = f"{week_end_for_key}_{wr_key}_VACCREW"
-                # Use VAC Crew name (from 'VAC Crew Helping?' column) as the foreman
-                # for this group — NOT the primary foreman (effective_user).
-                vac_crew_foreman = r.get('__vac_crew_name') or effective_user
-                keys_to_add.append(('vac_crew', vac_crew_key, vac_crew_foreman))
-                # Only log at info level the first time a new group key is seen; subsequent
-                # rows belonging to the same WR/week VAC Crew group log at debug to avoid
-                # flooding logs with hundreds of identical "GROUP CREATED" messages.
-                if vac_crew_key not in groups:
-                    logging.info(f"🏗️ VAC CREW GROUP CREATED: WR={wr_key}, Week={week_end_for_key}")
+                if not VAC_CREW_CLAIM_ATTRIBUTION_ENABLED:
+                    # Kill switch OFF -> exact legacy behavior: one group per
+                    # WR+week, no per-claimer partition.
+                    vac_crew_key = f"{week_end_for_key}_{wr_key}_VACCREW"
+                    # Use VAC Crew name (from 'VAC Crew Helping?' column) as the foreman
+                    # for this group — NOT the primary foreman (effective_user).
+                    vac_crew_foreman = r.get('__vac_crew_name') or effective_user
+                    keys_to_add.append(('vac_crew', vac_crew_key, vac_crew_foreman))
+                    # Only log at info level the first time a new group key is seen;
+                    # subsequent rows belonging to the same WR/week VAC Crew group log at
+                    # debug to avoid flooding logs with identical "GROUP CREATED" messages.
+                    if vac_crew_key not in groups:
+                        logging.info(f"🏗️ VAC CREW GROUP CREATED: WR={wr_key}, Week={week_end_for_key}")
                 else:
-                    logging.debug(f"Adding row to existing VAC Crew group: WR={wr_key}, Week={week_end_for_key}")
+                    # Subproject C: partition by frozen vac-crew claimer.
+                    # Consume the pre-pass map. ``use`` -> partition by claimer;
+                    # ``hold`` -> defer this row (correctness over availability);
+                    # map miss (missing __row_id, pre-pass skipped, plumbing fault)
+                    # -> use-current, NEVER HOLD.
+                    _vac_current = r.get('__vac_crew_name') or effective_user
+                    _c_vac_claimer = None
+                    _vac_outcome = _vac_crew_claimer_map.get(r.get('__row_id'))
+                    if _vac_outcome is not None and _vac_outcome.action == 'hold':
+                        _c_vac_claimer = None  # defer — correctness over availability
+                        try:
+                            from billing_audit.writer import record_attribution_hold
+                            record_attribution_hold(
+                                wr_key,
+                                week_ending_date.date()
+                                if isinstance(week_ending_date, datetime.datetime)
+                                else week_ending_date,
+                                'vac_crew',
+                            )
+                        except Exception:
+                            logging.exception(
+                                "⚠️ Subproject C: record_attribution_hold failed"
+                            )
+                    elif _vac_outcome is not None and _vac_outcome.action == 'use':
+                        _c_vac_claimer = _vac_outcome.name or _vac_current or 'Unknown'
+                    else:
+                        # Map miss (row absent from pre-pass) or unknown action:
+                        # fall back to current name, never HOLD.
+                        _c_vac_claimer = _vac_current or 'Unknown'
+
+                    if _c_vac_claimer is not None:
+                        _c_vac_sanitized = _RE_SANITIZE_IDENTIFIER.sub(
+                            '_', _c_vac_claimer
+                        )[:50]
+                        vac_crew_key = (
+                            f"{week_end_for_key}_{wr_key}_VACCREW_{_c_vac_sanitized}"
+                        )
+                        keys_to_add.append(('vac_crew', vac_crew_key, _c_vac_claimer))
+                        if vac_crew_key not in groups:
+                            logging.info(
+                                f"🏗️ VAC CREW GROUP CREATED: WR={wr_key}, "
+                                f"Week={week_end_for_key}"
+                            )
             else:
                 # Check if helper mode is enabled
                 helper_mode_enabled = RES_GROUPING_MODE in ('helper', 'both')

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -2676,6 +2676,14 @@ def build_group_identity(filename: str) -> tuple[str, str, str, str | None] | No
             # Legacy unpartitioned _ReducedSub_<hash> (no User token).
             variant = 'reduced_sub'
             identifier = ''
+    elif 'VacCrew' in tail:
+        # Sub-project C: _VacCrew_<name>_<hash>. Checked BEFORE the 'Helper'
+        # scan so a crew name containing the 'Helper' token isn't
+        # misclassified as a helper variant (B round-7 lesson). Span-join so
+        # an underscored name survives. Legacy _VacCrew (no name) → ''.
+        variant = 'vac_crew'
+        vac_idx_rel = tail.index('VacCrew')
+        identifier = '_'.join(tail[vac_idx_rel + 1:-1])
     elif 'Helper' in tail:
         variant = 'helper'
         helper_idx_rel = tail.index('Helper')
@@ -2683,9 +2691,6 @@ def build_group_identity(filename: str) -> tuple[str, str, str, str | None] | No
             # Join all parts between Helper and hash (last part)
             # Format: ...Helper_{name}_{hash} or ...Helper_{name}_part2_{hash}
             identifier = '_'.join(tail[helper_idx_rel + 1:-1])
-    elif 'VacCrew' in tail:
-        variant = 'vac_crew'
-        identifier = ''  # No sub-identifier for VAC Crew; use '' to match main() and valid_wr_weeks
     elif 'User' in tail:
         variant = 'primary'
         user_idx_rel = tail.index('User')
@@ -5702,13 +5707,33 @@ def _subcontractor_primary_variant_suffix(
     return f"{token}_User_{claimer_sanitized}"
 
 
+def _vac_crew_variant_suffix(claimer: str, wr_num: str, week_end_raw: str) -> str:
+    """Build the filename suffix for a per-claimer VAC crew file.
+
+    Sub-project C (2026-05-21): vac_crew files are partitioned by frozen
+    vac-crew claimer and named ``_VacCrew_<sanitized name>``. Raises on an
+    empty claimer (production never hits this — the emission falls back to
+    'Unknown'); the raise surfaces data drift instead of an ambiguous name.
+    """
+    if not claimer:
+        logging.error(
+            f"⚠️ vac_crew variant row missing claimer for WR {wr_num} "
+            f"week {week_end_raw}; filename would be ambiguous — raising."
+        )
+        raise ValueError(
+            f"vac_crew requires a non-empty claimer; got empty for "
+            f"WR={wr_num} week={week_end_raw}"
+        )
+    return f"_VacCrew_{_RE_SANITIZE_IDENTIFIER.sub('_', claimer)[:50]}"
+
+
 def generate_excel(group_key, group_rows, snapshot_date, ai_analysis_results=None, data_hash=None):
     """
     FIXED: Generate a formatted Excel report for a group of rows.
-    
+
     SPECIFIC FIXES IMPLEMENTED:
     - WR 90093002 Excel generation (complete implementation)
-    - WR 89954686 specific handling 
+    - WR 89954686 specific handling
     - Proper error handling for worksheet objects
     - Complete daily data block generation
     - Safe cell merging to prevent XML errors

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -520,6 +520,30 @@ SUBCONTRACTOR_LEGACY_PRIMARY_CLEANUP_ENABLED = os.getenv(
     'SUBCONTRACTOR_LEGACY_PRIMARY_CLEANUP_ENABLED', '1'
 ).strip().lower() in ('1', 'true', 'yes', 'on')
 
+# Sub-project C (2026-05-21): default-ON kill switch that enables
+# per-claimer partitioning of ``_VacCrew`` Excel files. When enabled,
+# each vac-crew Excel is partitioned by the FROZEN vac-crew claimer
+# (``vac_crew`` role from ``billing_audit.attribution_snapshot`` via
+# ``resolve_claimer``). When disabled, the legacy one-file-per-WR
+# ``_VacCrew`` behavior is preserved exactly. Pinned in workflow
+# env: block per [2026-05-15 12:00] rule 7.
+VAC_CREW_CLAIM_ATTRIBUTION_ENABLED = os.getenv(
+    'VAC_CREW_CLAIM_ATTRIBUTION_ENABLED', '1'
+).strip().lower() in ('1', 'true', 'yes', 'on')
+
+# Sub-project C (2026-05-21): default-ON kill switch for the one-time
+# removal of legacy UNPARTITIONED ``_VacCrew`` attachments (no
+# ``_User_`` token, parsed identifier == '') on TARGET_SHEET_ID for
+# vac-crew WRs, once those variants are re-partitioned by frozen
+# vac-crew claimer. Set to '0' to skip the destructive cleanup (legacy
+# files then persist until removed manually). Separate from
+# VAC_CREW_CLAIM_ATTRIBUTION_ENABLED (which gates attribution
+# resolution, NOT this cleanup). Workflow-pinned per [2026-05-15
+# 12:00] rule 7.
+VAC_CREW_LEGACY_CLEANUP_ENABLED = os.getenv(
+    'VAC_CREW_LEGACY_CLEANUP_ENABLED', '1'
+).strip().lower() in ('1', 'true', 'yes', 'on')
+
 # Cutoff date for ``_AEPBillable`` variant generation. Awarded to
 # Linetec on 2026-04-12 (subcontractor rate contract). Plan 2 (parser
 # extension) and Plan 3 (variant emission) gate variant emission on
@@ -675,6 +699,16 @@ logging.info(
 logging.info(
     f"📋 SUBCONTRACTOR_LEGACY_PRIMARY_CLEANUP_ENABLED="
     f"{SUBCONTRACTOR_LEGACY_PRIMARY_CLEANUP_ENABLED}"
+)
+
+# Sub-project C: surface resolved kill-switch state at startup so
+# operators grepping the banner see the active feature state at a
+# glance. Banner body carries no row PII (just the resolved bools).
+logging.info(
+    f"🚐 VAC Crew claim attribution: "
+    f"{'ENABLED' if VAC_CREW_CLAIM_ATTRIBUTION_ENABLED else 'DISABLED'}; "
+    f"legacy cleanup: "
+    f"{'ENABLED' if VAC_CREW_LEGACY_CLEANUP_ENABLED else 'DISABLED'}"
 )
 
 RESET_HASH_HISTORY = os.getenv('RESET_HASH_HISTORY','0').lower() in ('1','true','yes')  # When true, delete ALL existing WR_*.xlsx attachments & local files first

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -6030,8 +6030,13 @@ def generate_excel(group_key, group_rows, snapshot_date, ai_analysis_results=Non
             helper_sanitized = _RE_SANITIZE_HELPER_NAME.sub('_', helper_foreman)[:50]
             variant_suffix = f"_Helper_{helper_sanitized}"
     elif variant == 'vac_crew':
-        # VAC Crew variant: fixed suffix to distinguish from primary/helper
-        variant_suffix = '_VacCrew'
+        # Subproject C: per-claimer suffix so each foreman gets their own file.
+        # Falls back to __vac_crew_name when __current_foreman is absent (legacy
+        # disabled-attribution path) so the suffix is never empty.
+        variant_suffix = _vac_crew_variant_suffix(
+            first_row.get('__current_foreman') or first_row.get('__vac_crew_name', ''),
+            wr_num, week_end_raw,
+        )
     elif variant == 'primary':
         # Primary variant (no suffix needed)
         variant_suffix = ''
@@ -6203,9 +6208,14 @@ def generate_excel(group_key, group_rows, snapshot_date, ai_analysis_results=Non
         display_dept = first_row.get('__helper_dept', '')
         display_job = first_row.get('__helper_job', '')
     elif variant == 'vac_crew':
-        # VAC Crew variant: use VAC Crew-specific name, dept, and job fields.
-        # Must NOT fall back to primary foreman or primary Job # (which may be Arrowhead).
-        display_foreman = first_row.get('__vac_crew_name', 'Unknown VAC Crew')
+        # Subproject C: show the ATTRIBUTED claimer (__current_foreman, the
+        # partition key) so the displayed foreman matches the filename.
+        # Falls back to __vac_crew_name when attribution is disabled or absent
+        # (legacy path) — dept/job remain VAC-crew-specific in all cases.
+        display_foreman = (
+            first_row.get('__current_foreman')
+            or first_row.get('__vac_crew_name', 'Unknown VAC Crew')
+        )
         display_dept = first_row.get('__vac_crew_dept', '')
         display_job = first_row.get('__vac_crew_job', '')
     else:
@@ -8543,7 +8553,10 @@ def main():  # pyright: ignore[reportGeneralTypeIssues]
                     helper_foreman = group_rows[0].get('__helper_foreman', '')
                     file_id = _RE_SANITIZE_HELPER_NAME.sub('_', helper_foreman)[:50] if helper_foreman else ''
                 elif variant == 'vac_crew':
-                    file_id = ''
+                    # Subproject C identity site (Site 2 — valid_wr_weeks).
+                    # Mirror Site 1 so cleanup keeps the live per-claimer file.
+                    _vc = group_rows[0].get('__current_foreman', '')
+                    file_id = _RE_SANITIZE_IDENTIFIER.sub('_', _vc)[:50] if _vc else ''
                 elif variant in ('reduced_sub', 'aep_billable'):
                     # Subproject B identity site (Site 2 — valid_wr_weeks).
                     # Mirror Site 1 so attachment cleanup keeps the live
@@ -8748,7 +8761,16 @@ def main():  # pyright: ignore[reportGeneralTypeIssues]
                             _hj = group_rows[0].get('__helper_job', '')
                             _ident = f"{_hf}|{_hd}|{_hj}"
                         elif _variant == 'vac_crew':
-                            _ident = ''
+                            # Subproject C identity site (Site 3 —
+                            # current_keys). Must match the history_key
+                            # written at Site 1 (sanitized claimer) or
+                            # the fresh entry is treated as stale and
+                            # deleted before save.
+                            _vc = group_rows[0].get('__current_foreman', '')
+                            _ident = (
+                                _RE_SANITIZE_IDENTIFIER.sub('_', _vc)[:50]
+                                if _vc else ''
+                            )
                         elif _variant in ('reduced_sub', 'aep_billable'):
                             # Subproject B identity site (Site 3 —
                             # current_keys). Must match the history_key

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -3535,7 +3535,17 @@ def _run_vac_crew_hash_prune(hash_history: dict, groups: dict) -> bool:
     Dropping a hash entry costs at most one benign regeneration — never
     data loss — so no live-identity exemption is needed on this drop
     path (unlike the every-run attachment cleanup).
+
+    Codex P2 (PR #219): when ``VAC_CREW_CLAIM_ATTRIBUTION_ENABLED`` is OFF,
+    the blank-identifier ``wr|week|vac_crew|`` key is the ACTIVE legacy
+    format (the kill-switch-OFF path emits the bare ``_VACCREW`` key), so
+    pruning it would delete valid current history and force regeneration
+    churn — breaking the exact-legacy contract. Skip entirely when the flag
+    is off, and do NOT advance the sentinel, so the one-time migration still
+    runs if attribution is later enabled.
     """
+    if not VAC_CREW_CLAIM_ATTRIBUTION_ENABLED:
+        return False
     _persisted = hash_history.pop('_vac_crew_prune_version', 0)
     if (
         isinstance(_persisted, int)
@@ -4943,11 +4953,19 @@ def group_source_rows(rows):
     - Key format: MMDDYY_WRNUMBER_HELPER_<sanitized_helper_name>
     - Only created for rows where __is_helper_row = True
     
-    VAC Crew Variant:
-    - VAC Crew Promax grouping (one Excel per WR/Week for VAC Crew sheets)
-    - Key format: MMDDYY_WRNUMBER_VACCREW
+    VAC Crew Variant (Sub-project C — per-claimer partitioning):
     - Only created for rows where __is_vac_crew = True (row-level column-based detection)
-    - Generates a separate Excel file with _VacCrew suffix in the filename
+    - Two key shapes, gated on VAC_CREW_CLAIM_ATTRIBUTION_ENABLED:
+      * ON (default): partitioned by FROZEN vac-crew claimer →
+        MMDDYY_WRNUMBER_VACCREW_<sanitized_claimer>, one Excel per
+        WR/Week/claimer, filename suffix _VacCrew_<claimer>. Claimer is
+        resolved in the pre-pass (frozen_vac_crew; falls back to the current
+        vac-crew name on no_history; HOLD defers the row on a Supabase
+        fetch_failure).
+      * OFF (exact legacy): single group per WR/Week →
+        MMDDYY_WRNUMBER_VACCREW, filename suffix _VacCrew (no claimer).
+    - VAC crew rows never also emit the subcontractor primary variants
+      (the subcontractor block is gated on `not is_vac_crew_row`).
     
     Activity Log (DECOMMISSIONED - only in primary mode):
     - No longer uses Modified By cache - direct column assignment only
@@ -5385,7 +5403,15 @@ def group_source_rows(rows):
             # remain in scope), so the variant emission block below
             # reads the SAME boolean — no behavioural change to the
             # variant emission contract.
-            if is_subcontractor_row and SUBCONTRACTOR_RATE_VARIANTS_ENABLED:
+            # Copilot (PR #219): ``not is_vac_crew_row`` excludes VAC crew
+            # rows from the subcontractor variant emission. ``__is_vac_crew``
+            # is set by column presence (not sheet membership), so a VAC crew
+            # row can come from a subcontractor-folder sheet; without this
+            # gate it would be DOUBLE-emitted (VACCREW + REDUCEDSUB/AEPBILLABLE)
+            # and a vac ``hold`` outcome would be bypassed by the sub variants.
+            # A vac row already produced its own group above; it must not also
+            # emit subcontractor primary variants.
+            if is_subcontractor_row and not is_vac_crew_row and SUBCONTRACTOR_RATE_VARIANTS_ENABLED:
                 # Snapshot cutoff is needed by BOTH the primary block
                 # here and the helper-shadow block below, so compute it
                 # once up front. ``excel_serial_to_date`` returns ``None``
@@ -5808,6 +5834,10 @@ def group_source_rows(rows):
                 suffix == wr
                 or suffix.startswith(f"{wr}_HELPER_")
                 or suffix == f"{wr}_VACCREW"
+                # Subproject C: per-claimer vac key {wr}_VACCREW_<claimer>
+                # (attribution on). Prefix-match so EXCLUDE_WRS / WR_FILTER
+                # cover both the legacy bare and the per-claimer shapes.
+                or suffix.startswith(f"{wr}_VACCREW_")
                 # Phase 1 subcontractor variants (REVIEW-CR-03).
                 or suffix == f"{wr}_REDUCEDSUB"
                 or suffix == f"{wr}_AEPBILLABLE"
@@ -5855,6 +5885,10 @@ def group_source_rows(rows):
                 or suffix.startswith(f"{wr}_HELPER_")
                 or suffix.startswith(f"{wr}_USER_")
                 or suffix == f"{wr}_VACCREW"
+                # Subproject C: per-claimer vac key {wr}_VACCREW_<claimer>
+                # (attribution on). Prefix-match so EXCLUDE_WRS / WR_FILTER
+                # cover both the legacy bare and the per-claimer shapes.
+                or suffix.startswith(f"{wr}_VACCREW_")
                 # Phase 1 subcontractor variants (REVIEW-CR-02).
                 or suffix == f"{wr}_REDUCEDSUB"
                 or suffix == f"{wr}_AEPBILLABLE"

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -2756,6 +2756,7 @@ def cleanup_untracked_sheet_attachments(
     sub_wr_scope: set[str] | None = None,
     sub_offcontract_variants: set[str] | None = None,
     sub_legacy_primary_variants: set[str] | None = None,
+    vac_legacy_wr_scope: set[str] | None = None,
 ):
     """Prune only older variants for identities processed this run (VARIANT-AWARE).
 
@@ -2810,6 +2811,19 @@ def cleanup_untracked_sheet_attachments(
         exemption). New per-claimer files (non-empty identifier) are
         never matched. When None (default), this gate is skipped.
         Gated at the call sites by SUBCONTRACTOR_LEGACY_PRIMARY_CLEANUP_ENABLED.
+
+    vac_legacy_wr_scope: Subproject C (2026-05-21) Task 6 one-time
+        migration. When provided, any attachment whose parsed ``wr`` is
+        in this set, whose parsed ``variant`` is ``'vac_crew'``, and
+        whose parsed ``identifier`` is empty (legacy unpartitioned bare
+        ``_VacCrew``) is unconditionally deleted — UNLESS its identity is
+        in ``valid_wr_weeks`` (live-identity exemption). Per-claimer files
+        (non-empty identifier like ``_VacCrew_John``) are never matched.
+        When None (default), this gate is skipped — byte-identical legacy
+        behaviour for callers that do not pass the parameter.
+        Gated at the TARGET call site by VAC_CREW_LEGACY_CLEANUP_ENABLED.
+        vac_crew files route to TARGET_SHEET_ID only (never PPP); the
+        PPP call site must NOT receive this parameter.
 
     CRITICAL: Identity includes variant dimension to prevent primary/helper cross-deletion.
               Each (wr, week, variant, identifier) is treated as independent.
@@ -2904,6 +2918,32 @@ def cleanup_untracked_sheet_attachments(
                         and wr in sub_wr_scope
                         and sub_legacy_primary_variants is not None
                         and variant in sub_legacy_primary_variants
+                        and not _identifier
+                        and ident not in valid_wr_weeks
+                    ):
+                        off_contract_attachments.append(att)
+                        continue
+                    # Subproject C Task 6 (2026-05-21): one-time migration —
+                    # delete LEGACY UNPARTITIONED bare ``_VacCrew`` attachments
+                    # (parsed identifier == '') for in-scope vac_crew WRs.
+                    # Subproject C re-partitions vac_crew files by frozen
+                    # claimer (``_VacCrew_<name>``), so the old bare
+                    # one-file-per-WR attachment is an obsolete duplicate.
+                    # The ``not _identifier`` check is the precise legacy
+                    # selector: new per-claimer files carry a non-empty
+                    # identifier and are NOT deleted here.
+                    # WR-01 live-identity exemption: an attachment whose
+                    # identity IS in ``valid_wr_weeks`` is kept — this
+                    # protects a live per-claimer file from being deleted
+                    # if its identifier happened to be empty (belt-and-
+                    # suspenders; per-claimer files always have non-empty
+                    # identifiers so this branch is effectively unreachable
+                    # for them, but the guard keeps the contract symmetric
+                    # with the B sub_legacy_primary gate).
+                    if (
+                        vac_legacy_wr_scope is not None
+                        and wr in vac_legacy_wr_scope
+                        and variant == 'vac_crew'
                         and not _identifier
                         and ident not in valid_wr_weeks
                     ):
@@ -3220,6 +3260,28 @@ def _build_subcontractor_wr_scope(groups: dict) -> set[str]:
     _scope: set[str] = set()
     for _key, _g_rows in groups.items():
         if '_REDUCEDSUB' in _key and _g_rows:
+            _g_wr_raw = _g_rows[0].get('Work Request #', '')
+            _g_wr = str(_g_wr_raw).split('.')[0]
+            _g_wr = _RE_SANITIZE_HELPER_NAME.sub('_', _g_wr)[:50]
+            if _g_wr:
+                _scope.add(_g_wr)
+    return _scope
+
+
+def _build_vac_crew_wr_scope(groups: dict) -> set[str]:
+    """Return the set of sanitized WR tokens active as vac_crew in this run.
+
+    Scans ``groups.keys()`` for keys containing ``'_VACCREW'``, extracts
+    each group's WR# from the first row of the group, and returns the
+    sanitized set.
+
+    Shared by the TARGET ``cleanup_untracked_sheet_attachments`` call site
+    (Task 6 vac-crew legacy cleanup scope).  A single implementation prevents
+    scope-build drift — mirrors ``_build_subcontractor_wr_scope``.
+    """
+    _scope: set[str] = set()
+    for _key, _g_rows in groups.items():
+        if '_VACCREW' in _key and _g_rows:
             _g_wr_raw = _g_rows[0].get('Work Request #', '')
             _g_wr = str(_g_wr_raw).split('.')[0]
             _g_wr = _RE_SANITIZE_HELPER_NAME.sub('_', _g_wr)[:50]
@@ -8630,6 +8692,16 @@ def main():  # pyright: ignore[reportGeneralTypeIssues]
                 if _sub_scope and SUBCONTRACTOR_LEGACY_PRIMARY_CLEANUP_ENABLED
                 else None
             )
+            # Subproject C Task 6 (2026-05-21): build the vac_crew WR scope
+            # for legacy bare _VacCrew cleanup on TARGET. vac_crew files route
+            # to TARGET_SHEET_ID only (never PPP) — do NOT pass this to PPP.
+            # Kill-switch-gated: VAC_CREW_LEGACY_CLEANUP_ENABLED=0 reverts to
+            # byte-identical pre-fix TARGET behaviour (vac orphans persist).
+            _vac_scope = (
+                _build_vac_crew_wr_scope(groups)
+                if VAC_CREW_LEGACY_CLEANUP_ENABLED
+                else None
+            )
             with sentry_sdk.start_span(op="smartsheet.cleanup", name="Cleanup untracked sheet attachments"):
                 cleanup_untracked_sheet_attachments(
                     client, TARGET_SHEET_ID, valid_wr_weeks, TEST_MODE,
@@ -8640,6 +8712,7 @@ def main():  # pyright: ignore[reportGeneralTypeIssues]
                     # `is not None`, not truthiness).
                     sub_offcontract_variants=(_target_offcontract or None),
                     sub_legacy_primary_variants=_target_legacy_primary,
+                    vac_legacy_wr_scope=_vac_scope,
                 )
 
             # Phase 01 gap closure (REVIEW-WR-01): parallel cleanup pass

--- a/tests/test_security_audit_followup.py
+++ b/tests/test_security_audit_followup.py
@@ -2728,23 +2728,24 @@ class TestPppCleanupUntrackedAttachments(unittest.TestCase):
         # (SUB-09 helper-dimension) appends two more trailing kwargs:
         # sub_wr_scope and sub_offcontract_variants. Subproject B
         # (2026-05-20, Task 7) appends one more trailing kwarg:
-        # sub_legacy_primary_variants. All four are optional (None
-        # default) so existing TARGET / PPP call sites remain
-        # byte-identical. IN-PLACE UPDATE per [2026-05-20 00:26]
-        # rule 2 — the assertion follows the v3 signature contract.
+        # sub_legacy_primary_variants. Subproject C Task 6 (2026-05-21)
+        # appends one more trailing kwarg: vac_legacy_wr_scope. All five
+        # are optional (None default) so existing TARGET / PPP call sites
+        # remain byte-identical. IN-PLACE UPDATE per [2026-05-20 00:26]
+        # rule 2 — the assertion follows the v4 signature contract.
         self.assertEqual(
             params,
             ['client', 'target_sheet_id', 'valid_wr_weeks',
              'test_mode', 'attachment_cache', 'target_sheet',
              'variant_whitelist', 'sub_wr_scope', 'sub_offcontract_variants',
-             'sub_legacy_primary_variants'],
-            "Subproject B (Task 7) appends a trailing kwarg after "
-            "'sub_offcontract_variants': 'sub_legacy_primary_variants'. "
+             'sub_legacy_primary_variants', 'vac_legacy_wr_scope'],
+            "Subproject C Task 6 appends a trailing kwarg after "
+            "'sub_legacy_primary_variants': 'vac_legacy_wr_scope'. "
             "Any further drift must be reviewed against D-09 (TARGET "
             "legacy behavior). "
             f"Got: {params}"
         )
-        # All three trailing kwargs must default to None (D-09) so
+        # All trailing kwargs must default to None (D-09) so
         # existing call sites without the new kwargs are unaffected.
         self.assertIs(
             sig.parameters['variant_whitelist'].default, None,
@@ -2762,6 +2763,11 @@ class TestPppCleanupUntrackedAttachments(unittest.TestCase):
             sig.parameters['sub_legacy_primary_variants'].default, None,
             'sub_legacy_primary_variants must default to None '
             '(Subproject B Task 7).'
+        )
+        self.assertIs(
+            sig.parameters['vac_legacy_wr_scope'].default, None,
+            'vac_legacy_wr_scope must default to None '
+            '(Subproject C Task 6).'
         )
 
 

--- a/tests/test_subcontractor_primary_claim_attribution.py
+++ b/tests/test_subcontractor_primary_claim_attribution.py
@@ -691,11 +691,34 @@ class TestNonSubVariantsPreserved(unittest.TestCase):
         self.assertFalse(any('REDUCEDSUB' in k for k in groups))
 
     def test_vac_crew_row_unaffected(self):
+        """Subproject B does not route a vac_crew row into a subcontractor primary variant.
+
+        The INTENT of this test — "B does not turn a vac_crew row into a
+        _REDUCEDSUB/_AEPBILLABLE/_USER_ key" — is unchanged.  However,
+        Subproject C (2026-05-21) now partitions the VACCREW group key by
+        frozen claimer, so the key is ``..._VACCREW_<claimer>`` rather than
+        the bare ``..._VACCREW`` (see CLAUDE.md Living Ledger [2026-05-21]).
+        The assertion is updated to the per-claimer shape per [2026-05-20 00:26]
+        rule-2: rewrite in-place, add a docstring citing the ledger, change the
+        assertion so the real intent ("no sub primary key") remains the guard,
+        and do NOT pin the pre-C suffix.
+        """
         row = _make_sub_primary_row(source_sheet_id=99999999)
         row['__is_vac_crew'] = True
         row['__vac_crew_name'] = 'VacGuy'
         groups = generate_weekly_pdfs.group_source_rows([row])
-        self.assertTrue(any(k.endswith('_VACCREW') for k in groups))
+        keys = list(groups.keys())
+        # The row must produce a vac_crew group (VACCREW present anywhere in the key).
+        self.assertTrue(
+            any('VACCREW' in k for k in keys),
+            f"Expected a VACCREW group key; got: {keys}",
+        )
+        # The real intent: Subproject B must NOT emit any subcontractor primary
+        # variant for this vac_crew row.
+        self.assertFalse(
+            any('_REDUCEDSUB' in k or '_AEPBILLABLE' in k or '_USER_' in k for k in keys),
+            f"B must not produce sub primary variants for a vac_crew row; got: {keys}",
+        )
 
 
 class TestPrePassConcurrency(unittest.TestCase):

--- a/tests/test_vac_crew.py
+++ b/tests/test_vac_crew.py
@@ -261,12 +261,70 @@ class TestVacCrewGroupingLogic(unittest.TestCase):
             self.assertIn('_VACCREW', key)
 
     def test_vac_crew_key_format(self):
-        """VAC Crew group key ends with _VACCREW."""
+        """VAC Crew group key contains _VACCREW_ followed by a per-claimer suffix.
+
+        Rewritten in-place per [2026-05-20 00:26] rule-2 discipline (same as Plan
+        01-03 Test 1 for Subproject B): the test was authored under the legacy
+        one-file-per-WR contract where the key ended with bare ``_VACCREW``.
+        Subproject C (2026-05-21) introduces per-claimer partitioning — the key
+        now ends with ``_VACCREW_<sanitized_claimer>`` (see CLAUDE.md Living
+        Ledger [2026-05-21]).
+
+        When ``VAC_CREW_CLAIM_ATTRIBUTION_ENABLED`` is True (default), a row
+        with no Supabase history (no ``__row_id`` in the pre-pass map) falls
+        through the map-miss branch and uses the current vac-crew name.  The
+        ``_make_row`` helper does not set ``__vac_crew_name``, so the fallback
+        resolves to ``__effective_user`` = ``'TestForeman'``, producing a key
+        ending with ``_VACCREW_TestForeman``.
+        """
         rows = [self._make_row('99887766', '2025-08-17', '$200.00', is_vac_crew=True)]
         groups = generate_weekly_pdfs.group_source_rows(rows)
         keys = list(groups.keys())
-        self.assertTrue(any(k.endswith('_VACCREW') for k in keys),
-                        f"Expected a key ending with _VACCREW; got: {keys}")
+        # Post-Subproject-C: key contains '_VACCREW_' (trailing underscore) with a
+        # non-empty claimer token after it.
+        self.assertTrue(
+            any('_VACCREW_' in k for k in keys),
+            f"Expected a key containing '_VACCREW_<claimer>'; got: {keys}",
+        )
+        # The claimer token must be non-empty (not just '_VACCREW_').
+        for k in keys:
+            if '_VACCREW_' in k:
+                suffix = k.split('_VACCREW_', 1)[1]
+                self.assertTrue(
+                    suffix,
+                    f"Claimer suffix after '_VACCREW_' must be non-empty; key: {k}",
+                )
+        # The resolved fallback claimer is 'TestForeman' (effective_user from _make_row).
+        self.assertTrue(
+            any('_VACCREW_TestForeman' in k for k in keys),
+            f"Expected claimer 'TestForeman' in key; got: {keys}",
+        )
+
+    def test_vac_crew_key_format_legacy_when_disabled(self):
+        """Kill switch OFF -> VAC Crew key uses the bare legacy ``_VACCREW`` suffix.
+
+        Sibling to ``test_vac_crew_key_format``, locking in the kill-switch-OFF
+        = exact-legacy contract per [2026-05-20 00:26] rule-2: the rewrite must
+        add a sibling that asserts the pre-C invariant is preserved when the
+        feature flag is disabled.
+        """
+        orig = generate_weekly_pdfs.VAC_CREW_CLAIM_ATTRIBUTION_ENABLED
+        try:
+            generate_weekly_pdfs.VAC_CREW_CLAIM_ATTRIBUTION_ENABLED = False
+            rows = [self._make_row('99887766', '2025-08-17', '$200.00', is_vac_crew=True)]
+            groups = generate_weekly_pdfs.group_source_rows(rows)
+            keys = list(groups.keys())
+            self.assertTrue(
+                any(k.endswith('_VACCREW') for k in keys),
+                f"Kill-switch OFF: expected a key ending with bare '_VACCREW'; got: {keys}",
+            )
+            # Confirm no per-claimer suffix was appended.
+            self.assertFalse(
+                any('_VACCREW_' in k for k in keys),
+                f"Kill-switch OFF: key must NOT contain '_VACCREW_<claimer>'; got: {keys}",
+            )
+        finally:
+            generate_weekly_pdfs.VAC_CREW_CLAIM_ATTRIBUTION_ENABLED = orig
 
     def test_non_vac_crew_rows_produce_primary_variant(self):
         """Rows NOT flagged as VAC Crew produce primary groups, unaffected by VAC Crew logic."""

--- a/tests/test_vac_crew_claim_attribution.py
+++ b/tests/test_vac_crew_claim_attribution.py
@@ -1,0 +1,44 @@
+"""Sub-project C — VAC Crew claim attribution tests.
+
+Drives real production code paths (parser, group_source_rows pre-pass +
+emission, generate_excel, migration cleanup, hash prune, HOLD wiring) per
+the [2026-05-20 00:26] rule 4: row-flow changes require TRUE end-to-end
+tests, not static mirrors.
+"""
+from __future__ import annotations
+
+import inspect
+import pathlib
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from tests.test_billing_audit_shadow import _ensure_smartsheet_mocked, _reset_all
+
+_ensure_smartsheet_mocked()
+import generate_weekly_pdfs  # noqa: E402
+from billing_audit.writer import ResolveOutcome  # noqa: E402
+
+
+class TestVacCrewConfigFlags(unittest.TestCase):
+    def test_attribution_flag_exists_and_is_bool_default_on(self):
+        self.assertIsInstance(
+            generate_weekly_pdfs.VAC_CREW_CLAIM_ATTRIBUTION_ENABLED, bool
+        )
+
+    def test_legacy_cleanup_flag_exists_and_is_bool(self):
+        self.assertIsInstance(
+            generate_weekly_pdfs.VAC_CREW_LEGACY_CLEANUP_ENABLED, bool
+        )
+
+    def test_flags_pinned_in_workflow(self):
+        wf = (_REPO_ROOT / ".github/workflows/weekly-excel-generation.yml").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("VAC_CREW_CLAIM_ATTRIBUTION_ENABLED", wf)
+        self.assertIn("VAC_CREW_LEGACY_CLEANUP_ENABLED", wf)

--- a/tests/test_vac_crew_claim_attribution.py
+++ b/tests/test_vac_crew_claim_attribution.py
@@ -244,3 +244,80 @@ class TestVacCrewIdentitySitesAndDisplay(unittest.TestCase):
             None,
         )
         self.assertEqual(foreman, 'FrozenCrew')  # display = attributed claimer
+
+    def test_disabled_mode_generate_excel_emits_bare_vaccrew_filename(self):
+        """Disabled mode (VAC_CREW_CLAIM_ATTRIBUTION_ENABLED=False) must produce
+        the exact legacy bare _VacCrew suffix — no claimer name — matching the
+        legacy identity tuple '' at Sites 1/2/3 so no churn occurs."""
+        import datetime as dt
+        import tempfile
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        orig_out = generate_weekly_pdfs.OUTPUT_FOLDER
+        orig_flag = generate_weekly_pdfs.VAC_CREW_CLAIM_ATTRIBUTION_ENABLED
+        generate_weekly_pdfs.OUTPUT_FOLDER = tmp.name
+        generate_weekly_pdfs.VAC_CREW_CLAIM_ATTRIBUTION_ENABLED = False
+        self.addCleanup(
+            lambda: setattr(generate_weekly_pdfs, 'OUTPUT_FOLDER', orig_out)
+        )
+        self.addCleanup(
+            lambda: setattr(
+                generate_weekly_pdfs,
+                'VAC_CREW_CLAIM_ATTRIBUTION_ENABLED',
+                orig_flag,
+            )
+        )
+        row = {
+            'Work Request #': '91467680',
+            'Units Completed?': True,
+            'Units Total Price': '$100.00',
+            'Customer Name': 'Cust',
+            'Dept #': '500',
+            'Job #': 'J-1',
+            'CU': 'ANC-M',
+            'Work Type': 'Inst',
+            'Quantity': 2,
+            '__variant': 'vac_crew',
+            '__current_foreman': 'CurrentCrew',  # non-empty — must NOT appear in filename
+            '__vac_crew_name': 'CurrentCrew',
+            '__vac_crew_dept': '700',
+            '__vac_crew_job': 'VJ-1',
+            '__week_ending_date': dt.datetime(2026, 4, 19),
+        }
+        result = generate_weekly_pdfs.generate_excel(
+            '041926_91467680_VACCREW', [row], dt.datetime(2026, 4, 19),
+            data_hash='deadbeefcafe0c02',
+        )
+        filename = result[1]
+        # Disabled mode: filename must contain bare _VacCrew token only;
+        # the claimer name must NOT appear in the _VacCrew suffix position.
+        self.assertNotIn('_VacCrew_CurrentCrew', filename,
+                         "Disabled mode must not embed claimer name in _VacCrew token")
+        # Bare _VacCrew followed by the hash/timestamp separator (_, not a name)
+        self.assertRegex(
+            filename,
+            r'_VacCrew_[0-9a-f]+\.xlsx$',
+            "Disabled mode filename must be bare _VacCrew_<hash>.xlsx (no claimer name)",
+        )
+
+    def test_valid_wr_weeks_site2_vac_crew_gated_on_kill_switch(self):
+        """Site 2 grep guard: the valid_wr_weeks vac_crew branch must NOT
+        hard-code file_id='' unconditionally — it must be gated on the flag."""
+        self.assertNotRegex(
+            self._src,
+            r"variant == 'vac_crew':\s*\n\s*#[^\n]*\n\s*_vc = [^\n]+\n\s*file_id = ''",
+            "Site 2 valid_wr_weeks must not hard-code '' for vac_crew unconditionally; "
+            "must be gated on VAC_CREW_CLAIM_ATTRIBUTION_ENABLED",
+        )
+        # Positive guard: the kill-switch name must appear near the vac_crew file_id block.
+        vc_site2_idx = self._src.find(
+            "elif variant == 'vac_crew':\n"
+            "                    # Subproject C identity site (Site 2"
+        )
+        self.assertNotEqual(vc_site2_idx, -1, "Site 2 vac_crew block not found")
+        window = self._src[vc_site2_idx: vc_site2_idx + 750]
+        self.assertIn(
+            'VAC_CREW_CLAIM_ATTRIBUTION_ENABLED',
+            window,
+            "Site 2 vac_crew file_id derivation must reference VAC_CREW_CLAIM_ATTRIBUTION_ENABLED",
+        )

--- a/tests/test_vac_crew_claim_attribution.py
+++ b/tests/test_vac_crew_claim_attribution.py
@@ -26,15 +26,22 @@ from billing_audit.writer import ResolveOutcome  # noqa: E402
 
 
 class TestVacCrewConfigFlags(unittest.TestCase):
-    def test_attribution_flag_exists_and_is_bool_default_on(self):
+    def test_attribution_flag_exists_and_is_bool(self):
         self.assertIsInstance(
             generate_weekly_pdfs.VAC_CREW_CLAIM_ATTRIBUTION_ENABLED, bool
         )
+
+    def test_attribution_flag_default_on(self):
+        # Env var unset in the test harness → default '1' → True.
+        self.assertTrue(generate_weekly_pdfs.VAC_CREW_CLAIM_ATTRIBUTION_ENABLED)
 
     def test_legacy_cleanup_flag_exists_and_is_bool(self):
         self.assertIsInstance(
             generate_weekly_pdfs.VAC_CREW_LEGACY_CLEANUP_ENABLED, bool
         )
+
+    def test_legacy_cleanup_flag_default_on(self):
+        self.assertTrue(generate_weekly_pdfs.VAC_CREW_LEGACY_CLEANUP_ENABLED)
 
     def test_flags_pinned_in_workflow(self):
         wf = (_REPO_ROOT / ".github/workflows/weekly-excel-generation.yml").read_text(

--- a/tests/test_vac_crew_claim_attribution.py
+++ b/tests/test_vac_crew_claim_attribution.py
@@ -182,3 +182,50 @@ class TestVacCrewEmission(unittest.TestCase):
             groups = generate_weekly_pdfs.group_source_rows([row])
         self.assertTrue(any('VACCREW_CurrentCrew' in k for k in groups))
         self.assertEqual(get_counters()['attribution_rows_held'], 0)
+
+
+class TestVacCrewIdentitySitesAndDisplay(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._src = pathlib.Path(
+            inspect.getsourcefile(generate_weekly_pdfs)
+        ).read_text(encoding='utf-8')
+
+    def test_current_keys_site_carries_vac_claimer(self):
+        # Site 3: the hash-prune current_keys reconstruction must derive the
+        # vac_crew identifier from __current_foreman, not hard-code ''.
+        self.assertNotRegex(
+            self._src,
+            r"_variant == 'vac_crew':\s*\n\s*_ident = ''",
+            "current_keys must derive vac_crew identifier from the claimer",
+        )
+
+    def test_generate_excel_vac_crew_file_named_by_claimer(self):
+        import datetime as dt, tempfile, openpyxl
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        orig = generate_weekly_pdfs.OUTPUT_FOLDER
+        generate_weekly_pdfs.OUTPUT_FOLDER = tmp.name
+        self.addCleanup(lambda: setattr(generate_weekly_pdfs, 'OUTPUT_FOLDER', orig))
+        row = {
+            'Work Request #': '91467680', 'Units Completed?': True,
+            'Units Total Price': '$100.00', 'Customer Name': 'Cust',
+            'Dept #': '500', 'Job #': 'J-1', 'CU': 'ANC-M', 'Work Type': 'Inst', 'Quantity': 2,
+            '__variant': 'vac_crew', '__current_foreman': 'FrozenCrew',
+            '__vac_crew_name': 'CurrentCrew', '__vac_crew_dept': '700', '__vac_crew_job': 'VJ-1',
+            '__week_ending_date': dt.datetime(2026, 4, 19),
+        }
+        result = generate_weekly_pdfs.generate_excel(
+            '041926_91467680_VACCREW_FrozenCrew', [row], dt.datetime(2026, 4, 19),
+            data_hash='deadbeefcafe0c01',
+        )
+        excel_path, filename = result[0], result[1]
+        self.assertIn('_VacCrew_FrozenCrew', filename)
+        wb = openpyxl.load_workbook(excel_path)
+        ws = wb.active
+        foreman = next(
+            (ws.cell(row=r, column=7).value for r in range(1, ws.max_row + 1)
+             if ws.cell(row=r, column=6).value == 'Foreman:'),
+            None,
+        )
+        self.assertEqual(foreman, 'FrozenCrew')  # display = attributed claimer

--- a/tests/test_vac_crew_claim_attribution.py
+++ b/tests/test_vac_crew_claim_attribution.py
@@ -785,3 +785,87 @@ class TestVacCrewProductionInvariants(unittest.TestCase):
         # file_id. Guard the two that previously regressed.
         self.assertNotRegex(self._src, r"variant == 'vac_crew':\s*\n\s*identifier = ''")
         self.assertNotRegex(self._src, r"_variant == 'vac_crew':\s*\n\s*_ident = ''")
+
+
+class TestVacCrewReviewFixes(unittest.TestCase):
+    """PR #219 review fixes: Codex P1 (WR matchers recognize per-claimer
+    _VACCREW_<claimer>), Codex P2 (prune skipped when kill switch off),
+    Copilot (vac_crew row on a subcontractor sheet must not double-emit
+    subcontractor primary variants)."""
+
+    def setUp(self):
+        _reset_all()
+        self._orig_attr = generate_weekly_pdfs.VAC_CREW_CLAIM_ATTRIBUTION_ENABLED
+        self._orig_excl = list(generate_weekly_pdfs.EXCLUDE_WRS)
+        self._orig_filter = list(generate_weekly_pdfs.WR_FILTER)
+        self._orig_subvar = generate_weekly_pdfs.SUBCONTRACTOR_RATE_VARIANTS_ENABLED
+        self._orig_sub_ids = set(generate_weekly_pdfs._FOLDER_DISCOVERED_SUB_IDS)
+        generate_weekly_pdfs.VAC_CREW_CLAIM_ATTRIBUTION_ENABLED = True
+
+    def tearDown(self):
+        generate_weekly_pdfs.VAC_CREW_CLAIM_ATTRIBUTION_ENABLED = self._orig_attr
+        generate_weekly_pdfs.EXCLUDE_WRS = self._orig_excl
+        generate_weekly_pdfs.WR_FILTER = self._orig_filter
+        generate_weekly_pdfs.SUBCONTRACTOR_RATE_VARIANTS_ENABLED = self._orig_subvar
+        generate_weekly_pdfs._FOLDER_DISCOVERED_SUB_IDS.clear()
+        generate_weekly_pdfs._FOLDER_DISCOVERED_SUB_IDS.update(self._orig_sub_ids)
+        _reset_all()
+
+    def test_exclude_wrs_excludes_per_claimer_vaccrew_key(self):
+        # Codex P1: EXCLUDE_WRS must drop the per-claimer _VACCREW_<claimer>
+        # key (attribution on), not just the legacy bare _VACCREW.
+        generate_weekly_pdfs.EXCLUDE_WRS = ['91467680']
+        with mock.patch('billing_audit.writer.resolve_claimer',
+                        return_value=ResolveOutcome('use', 'CrewA', 'frozen', 'success')):
+            groups = generate_weekly_pdfs.group_source_rows([_make_vac_row(wr='91467680')])
+        self.assertFalse(
+            any('VACCREW' in k for k in groups),
+            f"excluded WR's per-claimer vac key must be dropped; got {list(groups)}",
+        )
+
+    def test_wr_filter_retains_per_claimer_vaccrew_key(self):
+        # Codex P1 sibling: WR_FILTER must RETAIN the per-claimer vac key.
+        generate_weekly_pdfs.WR_FILTER = ['91467680']
+        with mock.patch('billing_audit.writer.resolve_claimer',
+                        return_value=ResolveOutcome('use', 'CrewA', 'frozen', 'success')):
+            groups = generate_weekly_pdfs.group_source_rows([_make_vac_row(wr='91467680')])
+        self.assertTrue(
+            any('VACCREW_CrewA' in k for k in groups),
+            f"WR_FILTER must retain the per-claimer vac key; got {list(groups)}",
+        )
+
+    def test_prune_skipped_when_attribution_disabled(self):
+        # Codex P2: with the kill switch OFF, the blank-identifier vac key IS
+        # the active legacy format — the prune must NOT delete it, and must
+        # NOT advance the sentinel (so the migration still runs if attribution
+        # is later enabled).
+        generate_weekly_pdfs.VAC_CREW_CLAIM_ATTRIBUTION_ENABLED = False
+        hist = {'91467680|041926|vac_crew|': {'hash': 'h1'}}
+        groups = {'041926_91467680_VACCREW': [{'Work Request #': '91467680'}]}
+        changed = generate_weekly_pdfs._run_vac_crew_hash_prune(hist, groups)
+        self.assertIs(changed, False)
+        self.assertIn('91467680|041926|vac_crew|', hist)
+        self.assertNotIn('_vac_crew_prune_version', hist)
+
+    def test_prune_still_runs_when_attribution_enabled(self):
+        # Guard: with the kill switch ON, the prune still drops legacy orphans.
+        generate_weekly_pdfs.VAC_CREW_CLAIM_ATTRIBUTION_ENABLED = True
+        hist = {'91467680|041926|vac_crew|': {'hash': 'h1'}}
+        groups = {'041926_91467680_VACCREW_CrewA': [{'Work Request #': '91467680'}]}
+        changed = generate_weekly_pdfs._run_vac_crew_hash_prune(hist, groups)
+        self.assertIs(changed, True)
+        self.assertNotIn('91467680|041926|vac_crew|', hist)
+
+    def test_vac_row_on_subcontractor_sheet_does_not_double_emit(self):
+        # Copilot: a vac_crew row from a subcontractor-folder sheet must emit
+        # ONLY the VACCREW key — never the subcontractor primary variants.
+        generate_weekly_pdfs.SUBCONTRACTOR_RATE_VARIANTS_ENABLED = True
+        generate_weekly_pdfs._FOLDER_DISCOVERED_SUB_IDS.add(8162920222379908)
+        with mock.patch('billing_audit.writer.resolve_claimer',
+                        return_value=ResolveOutcome('use', 'CrewA', 'frozen', 'success')):
+            groups = generate_weekly_pdfs.group_source_rows([_make_vac_row(wr='91467680')])
+        self.assertTrue(any('VACCREW' in k for k in groups))
+        self.assertFalse(
+            any('REDUCEDSUB' in k or 'AEPBILLABLE' in k for k in groups),
+            f"vac row on a sub sheet must not emit subcontractor variants; got {list(groups)}",
+        )

--- a/tests/test_vac_crew_claim_attribution.py
+++ b/tests/test_vac_crew_claim_attribution.py
@@ -569,3 +569,67 @@ class TestVacCrewHashPrune(unittest.TestCase):
         src = pathlib.Path(inspect.getsourcefile(generate_weekly_pdfs)).read_text(encoding='utf-8')
         self.assertIn('_run_vac_crew_hash_prune(hash_history, groups)', src)
         self.assertRegex(src, r'(?m)^VAC_CREW_HASH_PRUNE_VERSION = 1$')
+
+
+class TestVacCrewEndToEnd(unittest.TestCase):
+    def setUp(self):
+        _reset_all()
+        self._orig = generate_weekly_pdfs.VAC_CREW_CLAIM_ATTRIBUTION_ENABLED
+        generate_weekly_pdfs.VAC_CREW_CLAIM_ATTRIBUTION_ENABLED = True
+
+    def tearDown(self):
+        generate_weekly_pdfs.VAC_CREW_CLAIM_ATTRIBUTION_ENABLED = self._orig
+        _reset_all()
+
+    def test_two_claimers_same_wr_week_coexist(self):
+        def _resolve(variant, current, *, wr, week_ending, row_id, enabled):
+            return ResolveOutcome('use', 'CrewA' if row_id == 6001 else 'CrewB', 'frozen', 'success')
+        with mock.patch('billing_audit.writer.resolve_claimer', side_effect=_resolve):
+            groups = generate_weekly_pdfs.group_source_rows(
+                [_make_vac_row(row_id=6001), _make_vac_row(row_id=6002)]
+            )
+        self.assertTrue(any('VACCREW_CrewA' in k for k in groups))
+        self.assertTrue(any('VACCREW_CrewB' in k for k in groups))
+
+    def test_non_vac_primary_row_unaffected(self):
+        row = {
+            'Work Request #': '91467680', 'Weekly Reference Logged Date': '2026-04-19',
+            'Snapshot Date': '2026-04-19', 'Units Completed?': True, 'Units Total Price': '$10.00',
+            'CU': 'X', 'Work Type': 'Inst', 'Quantity': 1,
+            '__effective_user': 'Boss', '__is_helper_row': False, '__is_vac_crew': False,
+            '__helper_foreman': '', '__helper_dept': '', '__helper_job': '',
+            '__source_sheet_id': 99999999, '__row_id': 1,
+        }
+        groups = generate_weekly_pdfs.group_source_rows([row])
+        self.assertTrue(any(k.startswith('041926_91467680') and 'VACCREW' not in k for k in groups))
+
+
+class TestVacCrewProductionInvariants(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._src = pathlib.Path(inspect.getsourcefile(generate_weekly_pdfs)).read_text(encoding='utf-8')
+
+    def test_prepass_present(self):
+        self.assertIn('_vac_crew_claimer_map', self._src)
+
+    def test_emission_uses_claimer_key(self):
+        self.assertIn('_VACCREW_{_c_vac_sanitized}', self._src)
+
+    def test_prune_version_constant(self):
+        self.assertRegex(self._src, r'(?m)^VAC_CREW_HASH_PRUNE_VERSION = 1$')
+
+    def test_prune_call_site_wired_to_migration_dirty(self):
+        # Tighter than a bare presence grep: confirm the prune call result
+        # flips _hash_history_migration_dirty (the no-update-run persistence).
+        self.assertRegex(
+            self._src,
+            r"if _run_vac_crew_hash_prune\(hash_history, groups\):\s*\n\s*_hash_history_migration_dirty = True",
+            "vac prune call must wire its True return into _hash_history_migration_dirty",
+        )
+
+    def test_four_identity_sites_carry_vac_claimer(self):
+        # Belt-and-suspenders: none of the four vac_crew identity surfaces may
+        # hard-code '' (Site 1 main-loop, Site 3 current_keys). Site 2 uses
+        # file_id. Guard the two that previously regressed.
+        self.assertNotRegex(self._src, r"variant == 'vac_crew':\s*\n\s*identifier = ''")
+        self.assertNotRegex(self._src, r"_variant == 'vac_crew':\s*\n\s*_ident = ''")

--- a/tests/test_vac_crew_claim_attribution.py
+++ b/tests/test_vac_crew_claim_attribution.py
@@ -1,4 +1,4 @@
-"""Sub-project C — VAC Crew claim attribution tests.
+"""Subproject C — VAC Crew claim attribution tests.
 
 Drives real production code paths (parser, group_source_rows pre-pass +
 emission, generate_excel, migration cleanup, hash prune, HOLD wiring) per
@@ -81,4 +81,14 @@ class TestVacCrewSuffixAndParser(unittest.TestCase):
         self.assertEqual(
             generate_weekly_pdfs.build_group_identity(fname),
             ('91467680', '041926', 'vac_crew', ''),
+        )
+
+    def test_suffix_truncates_long_name_and_round_trips(self):
+        long_name = 'A' * 60
+        suffix = generate_weekly_pdfs._vac_crew_variant_suffix(long_name, '91467680', '041926')
+        self.assertEqual(suffix, '_VacCrew_' + 'A' * 50)
+        fname = f'WR_91467680_WeekEnding_041926_120000{suffix}_abc123.xlsx'
+        self.assertEqual(
+            generate_weekly_pdfs.build_group_identity(fname),
+            ('91467680', '041926', 'vac_crew', 'A' * 50),
         )

--- a/tests/test_vac_crew_claim_attribution.py
+++ b/tests/test_vac_crew_claim_attribution.py
@@ -200,6 +200,21 @@ class TestVacCrewIdentitySitesAndDisplay(unittest.TestCase):
             "current_keys must derive vac_crew identifier from the claimer",
         )
 
+    def test_main_loop_identity_site_carries_vac_claimer(self):
+        # Site 1: the main-loop identifier/history_key for vac_crew must
+        # derive from __current_foreman, not hard-code '' (else the hash
+        # entry is stale-pruned every run → permanent regeneration churn).
+        self.assertNotRegex(
+            self._src,
+            r"variant == 'vac_crew':\s*\n\s*# VAC Crew variant: no sub-identifier",
+            "Site 1 main-loop must not use the old 'no sub-identifier' comment (legacy blank pattern)",
+        )
+        self.assertNotRegex(
+            self._src,
+            r"variant == 'vac_crew':[^\n]*\n[^\n]*\n\s*identifier = ''",
+            "Site 1 main-loop identifier must not hard-code '' for vac_crew",
+        )
+
     def test_generate_excel_vac_crew_file_named_by_claimer(self):
         import datetime as dt, tempfile, openpyxl
         tmp = tempfile.TemporaryDirectory()

--- a/tests/test_vac_crew_claim_attribution.py
+++ b/tests/test_vac_crew_claim_attribution.py
@@ -321,3 +321,214 @@ class TestVacCrewIdentitySitesAndDisplay(unittest.TestCase):
             window,
             "Site 2 vac_crew file_id derivation must reference VAC_CREW_CLAIM_ATTRIBUTION_ENABLED",
         )
+
+
+class TestVacCrewLegacyCleanup(unittest.TestCase):
+    """Task 6: legacy unpartitioned _VacCrew TARGET cleanup.
+
+    When vac_crew files become per-claimer (``_VacCrew_<name>``), the OLD
+    bare ``_VacCrew`` (no name, empty identifier) attachments on
+    TARGET_SHEET_ID are orphans that must be cleaned up.  Mirrors the
+    Subproject B ``sub_legacy_primary_variants`` gate exactly.
+    """
+
+    def setUp(self):
+        _ensure_smartsheet_mocked()
+
+    # ------------------------------------------------------------------
+    # Helpers (same fixture style as TestLegacyHelperTargetCleanupE2E)
+    # ------------------------------------------------------------------
+
+    def _make_attachment(self, name, att_id):
+        att = mock.MagicMock()
+        att.name = name
+        att.id = att_id
+        return att
+
+    def _build_client_with_attachments(self, attachments):
+        client = mock.MagicMock()
+        sheet = mock.MagicMock()
+        row = mock.MagicMock()
+        row.id = 1
+        client.Attachments.list_row_attachments.return_value.data = attachments
+        sheet.rows = [row]
+        client.Sheets.get_sheet.return_value = sheet
+        return client, sheet
+
+    # ------------------------------------------------------------------
+    # Scope builder
+    # ------------------------------------------------------------------
+
+    def test_scope_builder_collects_vac_wrs(self):
+        """_build_vac_crew_wr_scope extracts WR# from VACCREW groups only."""
+        groups = {
+            '041926_91467680_VACCREW_John': [{'Work Request #': '91467680'}],
+            '041926_55555_REDUCEDSUB_USER_X': [{'Work Request #': '55555'}],
+        }
+        scope = generate_weekly_pdfs._build_vac_crew_wr_scope(groups)
+        self.assertIn('91467680', scope)
+        self.assertNotIn('55555', scope)
+
+    def test_scope_builder_empty_groups(self):
+        """Empty groups dict returns empty scope."""
+        self.assertEqual(generate_weekly_pdfs._build_vac_crew_wr_scope({}), set())
+
+    def test_scope_builder_ignores_helper_and_primary_keys(self):
+        """Non-VACCREW group keys are excluded from the vac scope."""
+        groups = {
+            '041926_11111_HELPER_Alice': [{'Work Request #': '11111'}],
+            '041926_22222': [{'Work Request #': '22222'}],
+        }
+        scope = generate_weekly_pdfs._build_vac_crew_wr_scope(groups)
+        self.assertEqual(scope, set())
+
+    # ------------------------------------------------------------------
+    # Legacy bare _VacCrew deletion + live per-claimer exemption
+    # ------------------------------------------------------------------
+
+    def test_legacy_vaccrew_deleted_live_claimer_exempt(self):
+        """WR-01 analog: the live-identity exemption must protect a
+        per-claimer _VacCrew_<name> file while still deleting the
+        legacy bare _VacCrew file for the same in-scope WR.
+
+        Mirrors TestLegacyHelperTargetCleanupE2E::
+        test_target_cleanup_exempts_live_helper_for_overlapping_sub_wr.
+        """
+        # Legacy bare _VacCrew — empty identifier → NOT in valid_wr_weeks
+        # → must be deleted.
+        att_legacy = self._make_attachment(
+            'WR_91467680_WeekEnding_041926_120000_VacCrew_abc123.xlsx',
+            101,
+        )
+        # Live per-claimer _VacCrew_John — identity IS in valid_wr_weeks
+        # → must be EXEMPT from deletion.
+        att_live = self._make_attachment(
+            'WR_91467680_WeekEnding_041926_120000_VacCrew_John_def456.xlsx',
+            102,
+        )
+        client, sheet = self._build_client_with_attachments([att_legacy, att_live])
+
+        valid_wr_weeks = {('91467680', '041926', 'vac_crew', 'John')}
+
+        generate_weekly_pdfs.cleanup_untracked_sheet_attachments(
+            client,
+            target_sheet_id=5723337641643908,
+            valid_wr_weeks=valid_wr_weeks,
+            test_mode=False,
+            target_sheet=sheet,
+            vac_legacy_wr_scope={'91467680'},
+        )
+
+        deletes = [call.args for call in client.Attachments.delete_attachment.call_args_list]
+
+        self.assertIn(
+            (5723337641643908, 101),
+            deletes,
+            f"Legacy bare _VacCrew must be deleted for in-scope vac WR; "
+            f"got deletes={deletes}",
+        )
+        self.assertNotIn(
+            (5723337641643908, 102),
+            deletes,
+            f"Live per-claimer _VacCrew_John whose identity is in "
+            f"valid_wr_weeks must be EXEMPT; got deletes={deletes}",
+        )
+
+    def test_non_vac_wr_not_affected_by_vac_gate(self):
+        """A bare _VacCrew file for a WR NOT in vac_legacy_wr_scope is
+        not deleted by the vac gate (falls through to normal identity-grouping
+        logic). This confirms the gate is WR-scoped, not global."""
+        # WR 99999 is NOT in the vac scope.
+        att = self._make_attachment(
+            'WR_99999_WeekEnding_041926_120000_VacCrew_abc123.xlsx',
+            201,
+        )
+        client, sheet = self._build_client_with_attachments([att])
+
+        generate_weekly_pdfs.cleanup_untracked_sheet_attachments(
+            client,
+            target_sheet_id=5723337641643908,
+            valid_wr_weeks=set(),
+            test_mode=False,
+            target_sheet=sheet,
+            vac_legacy_wr_scope={'91467680'},  # 99999 NOT in scope
+        )
+
+        deletes = [call.args for call in client.Attachments.delete_attachment.call_args_list]
+        self.assertNotIn(
+            (5723337641643908, 201),
+            deletes,
+            "WR outside vac_legacy_wr_scope must not be deleted by the vac gate",
+        )
+
+    def test_none_scope_no_vac_gate(self):
+        """vac_legacy_wr_scope=None (default) means no vac gate fires —
+        byte-identical legacy behaviour for callers that don't pass it."""
+        att = self._make_attachment(
+            'WR_91467680_WeekEnding_041926_120000_VacCrew_abc123.xlsx',
+            301,
+        )
+        client, sheet = self._build_client_with_attachments([att])
+
+        # Pass nothing for vac_legacy_wr_scope — relies on default None.
+        generate_weekly_pdfs.cleanup_untracked_sheet_attachments(
+            client,
+            target_sheet_id=5723337641643908,
+            valid_wr_weeks=set(),
+            test_mode=False,
+            target_sheet=sheet,
+        )
+
+        deletes = [call.args for call in client.Attachments.delete_attachment.call_args_list]
+        self.assertNotIn(
+            (5723337641643908, 301),
+            deletes,
+            "vac_legacy_wr_scope=None must not trigger vac gate (legacy behaviour)",
+        )
+
+    def test_kill_switch_off_target_passes_none_scope(self):
+        """Source-grep guard: when VAC_CREW_LEGACY_CLEANUP_ENABLED is False,
+        the TARGET call site must pass vac_legacy_wr_scope=None (or
+        equivalent falsy) so no vac deletion occurs.
+
+        We verify the production source wires the scope conditionally on
+        VAC_CREW_LEGACY_CLEANUP_ENABLED rather than passing the scope
+        unconditionally.  We search the CALL SITE occurrence (inside
+        cleanup_untracked_sheet_attachments(...)) rather than the
+        function-signature occurrence.
+        """
+        src = pathlib.Path(
+            inspect.getsourcefile(generate_weekly_pdfs)
+        ).read_text(encoding='utf-8')
+        # The TARGET call site must gate the vac scope on the kill switch.
+        self.assertIn(
+            'VAC_CREW_LEGACY_CLEANUP_ENABLED',
+            src,
+            "VAC_CREW_LEGACY_CLEANUP_ENABLED must appear in source",
+        )
+        # The vac_legacy_wr_scope kwarg must appear at the TARGET call site.
+        self.assertIn(
+            'vac_legacy_wr_scope',
+            src,
+            "vac_legacy_wr_scope kwarg must be wired at the TARGET call site",
+        )
+        # The call-site wiring must reference the kill switch alongside the
+        # scope builder.  Find the kwarg ASSIGNMENT (``_vac_scope =``) which
+        # is the call-site variable, and verify VAC_CREW_LEGACY_CLEANUP_ENABLED
+        # appears in its neighbourhood.
+        assign_idx = src.find('_vac_scope =')
+        self.assertNotEqual(assign_idx, -1,
+                            "_vac_scope assignment not found in source")
+        window = src[max(0, assign_idx - 100): assign_idx + 400]
+        self.assertIn(
+            'VAC_CREW_LEGACY_CLEANUP_ENABLED',
+            window,
+            "The _vac_scope assignment must be gated on "
+            "VAC_CREW_LEGACY_CLEANUP_ENABLED at the call site",
+        )
+        # The kwarg pass at cleanup_untracked_sheet_attachments(...)
+        # must also appear after the assignment.
+        pass_idx = src.find('vac_legacy_wr_scope=_vac_scope')
+        self.assertNotEqual(pass_idx, -1,
+                            "vac_legacy_wr_scope=_vac_scope must be passed "
+                            "to cleanup_untracked_sheet_attachments")

--- a/tests/test_vac_crew_claim_attribution.py
+++ b/tests/test_vac_crew_claim_attribution.py
@@ -300,6 +300,106 @@ class TestVacCrewIdentitySitesAndDisplay(unittest.TestCase):
             "Disabled mode filename must be bare _VacCrew_<hash>.xlsx (no claimer name)",
         )
 
+    def test_disabled_mode_display_uses_vac_crew_name_not_primary_foreman(self):
+        """M1: disabled mode must display __vac_crew_name, not __current_foreman.
+
+        When VAC_CREW_CLAIM_ATTRIBUTION_ENABLED=False, generate_excel's
+        vac_crew display branch must read __vac_crew_name directly — NOT
+        fall back through __current_foreman, which in disabled mode may be
+        the primary / Arrowhead foreman, not the VAC crew member.
+
+        Two sub-cases:
+        a) __vac_crew_name populated, __current_foreman is a different
+           primary-foreman name → display must be the vac crew name.
+        b) __vac_crew_name is '' (empty) → display must be 'Unknown VAC Crew',
+           NOT the primary foreman value.
+        """
+        import datetime as dt
+        import tempfile
+        import openpyxl
+
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        orig_out = generate_weekly_pdfs.OUTPUT_FOLDER
+        orig_flag = generate_weekly_pdfs.VAC_CREW_CLAIM_ATTRIBUTION_ENABLED
+        generate_weekly_pdfs.OUTPUT_FOLDER = tmp.name
+        generate_weekly_pdfs.VAC_CREW_CLAIM_ATTRIBUTION_ENABLED = False
+        self.addCleanup(
+            lambda: setattr(generate_weekly_pdfs, 'OUTPUT_FOLDER', orig_out)
+        )
+        self.addCleanup(
+            lambda: setattr(
+                generate_weekly_pdfs,
+                'VAC_CREW_CLAIM_ATTRIBUTION_ENABLED',
+                orig_flag,
+            )
+        )
+
+        def _foreman_cell(path):
+            wb = openpyxl.load_workbook(path)
+            ws = wb.active
+            return next(
+                (ws.cell(row=r, column=7).value for r in range(1, ws.max_row + 1)
+                 if ws.cell(row=r, column=6).value == 'Foreman:'),
+                None,
+            )
+
+        base_row = {
+            'Work Request #': '91467680',
+            'Units Completed?': True,
+            'Units Total Price': '$100.00',
+            'Customer Name': 'Cust',
+            'Dept #': '500',
+            'Job #': 'J-1',
+            'CU': 'ANC-M',
+            'Work Type': 'Inst',
+            'Quantity': 2,
+            '__variant': 'vac_crew',
+            '__vac_crew_dept': '700',
+            '__vac_crew_job': 'VJ-1',
+            '__week_ending_date': dt.datetime(2026, 4, 19),
+        }
+
+        # --- sub-case a: __vac_crew_name != __current_foreman ---
+        # __current_foreman is the primary/Arrowhead foreman; __vac_crew_name
+        # is the actual VAC crew member. Disabled mode MUST show the vac name.
+        row_a = dict(base_row)
+        row_a['__current_foreman'] = 'Arrowhead_PrimaryForeman'
+        row_a['__vac_crew_name'] = 'Alice_VacCrew'
+        result_a = generate_weekly_pdfs.generate_excel(
+            '041926_91467680_VACCREW', [row_a], dt.datetime(2026, 4, 19),
+            data_hash='deadbeefcafe0ca1',
+        )
+        foreman_a = _foreman_cell(result_a[0])
+        self.assertEqual(
+            foreman_a, 'Alice_VacCrew',
+            "Disabled mode: display must be __vac_crew_name, not "
+            f"__current_foreman ('Arrowhead_PrimaryForeman'); got {foreman_a!r}",
+        )
+        self.assertNotEqual(
+            foreman_a, 'Arrowhead_PrimaryForeman',
+            "Disabled mode must NOT fall back to the primary foreman",
+        )
+
+        # --- sub-case b: __vac_crew_name is empty ---
+        # Even with __current_foreman set, display must NOT be the primary
+        # foreman value. The cell may be None/empty or 'Unknown VAC Crew'
+        # depending on how generate_excel renders the fallback; what is
+        # strictly required is that the primary foreman does NOT appear.
+        row_b = dict(base_row)
+        row_b['__current_foreman'] = 'Arrowhead_PrimaryForeman'
+        row_b['__vac_crew_name'] = ''
+        result_b = generate_weekly_pdfs.generate_excel(
+            '041926_91467680_VACCREW', [row_b], dt.datetime(2026, 4, 19),
+            data_hash='deadbeefcafe0cb2',
+        )
+        foreman_b = _foreman_cell(result_b[0])
+        self.assertNotEqual(
+            foreman_b, 'Arrowhead_PrimaryForeman',
+            "Disabled mode with empty __vac_crew_name must NOT display the "
+            f"primary/Arrowhead foreman; got {foreman_b!r}",
+        )
+
     def test_valid_wr_weeks_site2_vac_crew_gated_on_kill_switch(self):
         """Site 2 grep guard: the valid_wr_weeks vac_crew branch must NOT
         hard-code file_id='' unconditionally — it must be gated on the flag."""
@@ -532,6 +632,58 @@ class TestVacCrewLegacyCleanup(unittest.TestCase):
         self.assertNotEqual(pass_idx, -1,
                             "vac_legacy_wr_scope=_vac_scope must be passed "
                             "to cleanup_untracked_sheet_attachments")
+
+    def test_attribution_off_cleanup_on_live_bare_vaccrew_exempt(self):
+        """M4 mixed-flag: attribution OFF + legacy cleanup ON.
+
+        When VAC_CREW_CLAIM_ATTRIBUTION_ENABLED=False (disabled mode),
+        group_source_rows emits the BARE vac_crew key with empty identifier,
+        so valid_wr_weeks contains ('wr', 'week', 'vac_crew', '').  The
+        legacy cleanup gate must honour the live-identity exemption and NOT
+        delete that bare _VacCrew attachment — it is current-run output.
+
+        This guards the mixed-flag combination: attribution OFF means no
+        per-claimer files are generated, so a bare _VacCrew file is the
+        LIVE file for that WR and must survive cleanup even when
+        VAC_CREW_LEGACY_CLEANUP_ENABLED=True.
+        """
+        orig_attr_flag = generate_weekly_pdfs.VAC_CREW_CLAIM_ATTRIBUTION_ENABLED
+        generate_weekly_pdfs.VAC_CREW_CLAIM_ATTRIBUTION_ENABLED = False
+        try:
+            # Bare _VacCrew — in disabled mode this IS the live file for the WR.
+            att_bare = self._make_attachment(
+                'WR_77712345_WeekEnding_050926_120000_VacCrew_ff1122.xlsx',
+                201,
+            )
+            client, sheet = self._build_client_with_attachments([att_bare])
+
+            # Disabled mode: the bare-key identity ('77712345','050926','vac_crew','')
+            # is in valid_wr_weeks because group_source_rows emits it without a
+            # claimer suffix when the flag is off.
+            valid_wr_weeks = {('77712345', '050926', 'vac_crew', '')}
+
+            generate_weekly_pdfs.cleanup_untracked_sheet_attachments(
+                client,
+                target_sheet_id=5723337641643908,
+                valid_wr_weeks=valid_wr_weeks,
+                test_mode=False,
+                target_sheet=sheet,
+                vac_legacy_wr_scope={'77712345'},
+            )
+
+            deletes = [
+                call.args
+                for call in client.Attachments.delete_attachment.call_args_list
+            ]
+            self.assertNotIn(
+                (5723337641643908, 201),
+                deletes,
+                "Attribution OFF + cleanup ON: the bare _VacCrew file whose "
+                "identity IS in valid_wr_weeks must be EXEMPT from deletion; "
+                f"got deletes={deletes}",
+            )
+        finally:
+            generate_weekly_pdfs.VAC_CREW_CLAIM_ATTRIBUTION_ENABLED = orig_attr_flag
 
 
 class TestVacCrewHashPrune(unittest.TestCase):

--- a/tests/test_vac_crew_claim_attribution.py
+++ b/tests/test_vac_crew_claim_attribution.py
@@ -49,3 +49,36 @@ class TestVacCrewConfigFlags(unittest.TestCase):
         )
         self.assertIn("VAC_CREW_CLAIM_ATTRIBUTION_ENABLED", wf)
         self.assertIn("VAC_CREW_LEGACY_CLEANUP_ENABLED", wf)
+
+
+class TestVacCrewSuffixAndParser(unittest.TestCase):
+    def test_suffix_embeds_name(self):
+        self.assertEqual(
+            generate_weekly_pdfs._vac_crew_variant_suffix('John Smith', '91467680', '041926'),
+            '_VacCrew_John_Smith',
+        )
+
+    def test_suffix_empty_claimer_raises(self):
+        with self.assertRaises(ValueError):
+            generate_weekly_pdfs._vac_crew_variant_suffix('', '91467680', '041926')
+
+    def test_parser_vaccrew_name_round_trips(self):
+        fname = 'WR_91467680_WeekEnding_041926_120000_VacCrew_John_Smith_abc123.xlsx'
+        self.assertEqual(
+            generate_weekly_pdfs.build_group_identity(fname),
+            ('91467680', '041926', 'vac_crew', 'John_Smith'),
+        )
+
+    def test_parser_name_containing_helper_token_stays_vac_crew(self):
+        fname = 'WR_91467680_WeekEnding_041926_120000_VacCrew_Pat_Helper_abc123.xlsx'
+        self.assertEqual(
+            generate_weekly_pdfs.build_group_identity(fname),
+            ('91467680', '041926', 'vac_crew', 'Pat_Helper'),
+        )
+
+    def test_parser_legacy_vaccrew_no_name(self):
+        fname = 'WR_91467680_WeekEnding_041926_120000_VacCrew_abc123.xlsx'
+        self.assertEqual(
+            generate_weekly_pdfs.build_group_identity(fname),
+            ('91467680', '041926', 'vac_crew', ''),
+        )

--- a/tests/test_vac_crew_claim_attribution.py
+++ b/tests/test_vac_crew_claim_attribution.py
@@ -92,3 +92,93 @@ class TestVacCrewSuffixAndParser(unittest.TestCase):
             generate_weekly_pdfs.build_group_identity(fname),
             ('91467680', '041926', 'vac_crew', 'A' * 50),
         )
+
+
+def _make_vac_row(row_id=6001, wr='91467680', name='CurrentCrew', snapshot='2026-04-19'):
+    return {
+        '__row_id': row_id,
+        'Work Request #': wr,
+        'Weekly Reference Logged Date': '2026-04-19',
+        'Snapshot Date': snapshot,
+        'Units Completed?': True,
+        'Units Total Price': '$100.00',
+        'CU': 'ANC-M', 'Work Type': 'Inst', 'Quantity': 2,
+        '__effective_user': 'PrimaryForeman',
+        '__is_helper_row': False, '__helper_foreman': '', '__helper_dept': '', '__helper_job': '',
+        '__is_vac_crew': True,
+        '__vac_crew_name': name, '__vac_crew_dept': '700', '__vac_crew_job': 'VJ-1',
+        '__source_sheet_id': 8162920222379908,
+    }
+
+
+class TestVacCrewPrePassConcurrency(unittest.TestCase):
+    def setUp(self):
+        _reset_all()
+        self._orig = generate_weekly_pdfs.VAC_CREW_CLAIM_ATTRIBUTION_ENABLED
+        generate_weekly_pdfs.VAC_CREW_CLAIM_ATTRIBUTION_ENABLED = True
+
+    def tearDown(self):
+        generate_weekly_pdfs.VAC_CREW_CLAIM_ATTRIBUTION_ENABLED = self._orig
+        _reset_all()
+
+    def test_fifty_rows_each_partition_to_their_own_claimer(self):
+        def _resolve(variant, current, *, wr, week_ending, row_id, enabled):
+            return ResolveOutcome('use', f'Crew{row_id}', 'frozen', 'success')
+        rows = [_make_vac_row(row_id=7000 + i) for i in range(50)]
+        with mock.patch('billing_audit.writer.resolve_claimer', side_effect=_resolve):
+            groups = generate_weekly_pdfs.group_source_rows(rows)
+        keys = list(groups.keys())
+        for i in range(50):
+            self.assertTrue(
+                any(f'VACCREW_Crew{7000 + i}' in k for k in keys),
+                f"row {7000+i} must partition to its own claimer; got {keys[:5]}…",
+            )
+
+
+class TestVacCrewEmission(unittest.TestCase):
+    def setUp(self):
+        _reset_all()
+        self._orig = generate_weekly_pdfs.VAC_CREW_CLAIM_ATTRIBUTION_ENABLED
+        generate_weekly_pdfs.VAC_CREW_CLAIM_ATTRIBUTION_ENABLED = True
+
+    def tearDown(self):
+        generate_weekly_pdfs.VAC_CREW_CLAIM_ATTRIBUTION_ENABLED = self._orig
+        _reset_all()
+
+    def test_frozen_claimer_partitions(self):
+        with mock.patch('billing_audit.writer.resolve_claimer',
+                        return_value=ResolveOutcome('use', 'FrozenCrew', 'frozen', 'success')):
+            groups = generate_weekly_pdfs.group_source_rows([_make_vac_row()])
+        self.assertTrue(any('VACCREW_FrozenCrew' in k for k in groups))
+
+    def test_no_history_falls_back_to_current_name(self):
+        with mock.patch('billing_audit.writer.resolve_claimer',
+                        return_value=ResolveOutcome('use', 'CurrentCrew', 'current', 'no_history')):
+            groups = generate_weekly_pdfs.group_source_rows([_make_vac_row(name='CurrentCrew')])
+        self.assertTrue(any('VACCREW_CurrentCrew' in k for k in groups))
+
+    def test_hold_suppresses_and_records(self):
+        from billing_audit.writer import get_counters
+        with mock.patch('billing_audit.writer.resolve_claimer',
+                        return_value=ResolveOutcome('hold', None, None, 'fetch_failure')):
+            groups = generate_weekly_pdfs.group_source_rows([_make_vac_row()])
+        self.assertFalse(any('VACCREW' in k for k in groups))
+        self.assertEqual(get_counters()['attribution_rows_held'], 1)
+
+    def test_disabled_emits_exact_legacy_key(self):
+        generate_weekly_pdfs.VAC_CREW_CLAIM_ATTRIBUTION_ENABLED = False
+        with mock.patch('billing_audit.writer.resolve_claimer') as m:
+            groups = generate_weekly_pdfs.group_source_rows([_make_vac_row(name='CurrentCrew')])
+            m.assert_not_called()
+        self.assertIn('041926_91467680_VACCREW', groups)
+        self.assertFalse(any('VACCREW_' in k for k in groups))
+
+    def test_map_miss_uses_current_name_not_hold(self):
+        from billing_audit.writer import get_counters
+        row = _make_vac_row()
+        del row['__row_id']
+        with mock.patch('billing_audit.writer.resolve_claimer',
+                        return_value=ResolveOutcome('use', 'X', 'frozen', 'success')):
+            groups = generate_weekly_pdfs.group_source_rows([row])
+        self.assertTrue(any('VACCREW_CurrentCrew' in k for k in groups))
+        self.assertEqual(get_counters()['attribution_rows_held'], 0)

--- a/tests/test_vac_crew_claim_attribution.py
+++ b/tests/test_vac_crew_claim_attribution.py
@@ -532,3 +532,40 @@ class TestVacCrewLegacyCleanup(unittest.TestCase):
         self.assertNotEqual(pass_idx, -1,
                             "vac_legacy_wr_scope=_vac_scope must be passed "
                             "to cleanup_untracked_sheet_attachments")
+
+
+class TestVacCrewHashPrune(unittest.TestCase):
+    def setUp(self):
+        _ensure_smartsheet_mocked()
+
+    def _groups(self, wrs):
+        return {f"041926_{wr}_VACCREW_John": [{'Work Request #': wr}] for wr in wrs}
+
+    def test_drops_legacy_vaccrew_orphans_returns_true(self):
+        hist = {
+            '91467680|041926|vac_crew|': {'hash': 'h1'},
+            '91467680|041926|vac_crew|John': {'hash': 'h2'},  # new — survives
+            '55555|041926|vac_crew|': {'hash': 'h3'},          # non-scope — survives
+        }
+        changed = generate_weekly_pdfs._run_vac_crew_hash_prune(hist, self._groups(['91467680']))
+        self.assertIs(changed, True)
+        self.assertNotIn('91467680|041926|vac_crew|', hist)
+        self.assertIn('91467680|041926|vac_crew|John', hist)
+        self.assertIn('55555|041926|vac_crew|', hist)
+        self.assertEqual(hist['_vac_crew_prune_version'],
+                         generate_weekly_pdfs.VAC_CREW_HASH_PRUNE_VERSION)
+
+    def test_idempotent_returns_false(self):
+        hist = {'_vac_crew_prune_version': generate_weekly_pdfs.VAC_CREW_HASH_PRUNE_VERSION}
+        self.assertIs(
+            generate_weekly_pdfs._run_vac_crew_hash_prune(hist, self._groups(['91467680'])),
+            False,
+        )
+
+    def test_pii_marker_registered(self):
+        self.assertIn('Vac crew hash-history prune', generate_weekly_pdfs._PII_LOG_MARKERS)
+
+    def test_call_site_present_and_wired_to_migration_dirty(self):
+        src = pathlib.Path(inspect.getsourcefile(generate_weekly_pdfs)).read_text(encoding='utf-8')
+        self.assertIn('_run_vac_crew_hash_prune(hash_history, groups)', src)
+        self.assertRegex(src, r'(?m)^VAC_CREW_HASH_PRUNE_VERSION = 1$')

--- a/website/docs/reference/environment.md
+++ b/website/docs/reference/environment.md
@@ -368,7 +368,9 @@ FROZEN vac-crew claimer from `billing_audit.attribution_snapshot`
 (`frozen_vac_crew` column) — resolved via Foundation A's
 `resolve_claimer` contract. Each file holds only one claimer's
 completed line items and is named `_VacCrew_<claimer>` (e.g.
-`WR_90773033_WeekEnding_051226_VacCrew_Jane_Smith_<hash>.xlsx`).
+`WR_90773033_WeekEnding_051226_<timestamp>_VacCrew_Jane_Smith_<hash>.xlsx`
+— the generator inserts an `<HHMMSS>` timestamp token before the
+variant suffix).
 Rows with no frozen claimer yet (`no_history`) fall back to the
 current Smartsheet vac-crew name (first-write semantics — this run
 freezes them). A Supabase outage (`fetch_failure`) HOLDs the affected
@@ -388,13 +390,16 @@ every VAC crew row's claimer BEFORE the `group_source_rows` grouping
 loop — no per-row Supabase I/O in the hot loop (per the
 [2026-04-25 14:00] per-row-latency rule).
 
-**Kill-switch-OFF exact legacy behaviour:** When disabled, the
-partition key, `valid_wr_weeks` identity, `current_keys` hash entry,
-and `build_group_identity` parser ALL revert to the empty-identifier
-form so the output is byte-identical to the pre-C baseline
-(`_VacCrew` bare, no `_<name>` suffix). ALL FOUR identity sites are
-gated on this flag; disabling only some would produce attachment
-churn.
+**Kill-switch-OFF exact legacy behaviour:** When disabled, the three
+identity-*construction* sites — the partition key, the `valid_wr_weeks`
+identity, and the `current_keys` hash entry — all revert to the
+empty-identifier form, so the *generated* output is byte-identical to
+the pre-C baseline (`_VacCrew` bare, no `_<name>` suffix). All three are
+gated on this flag; gating only some would produce attachment churn.
+The `build_group_identity` parser is read-only and intentionally NOT
+gated — it still correctly parses any `_VacCrew_<name>` attachments that
+already exist on the sheet (from a prior attribution-on run), but with
+the flag off no new per-claimer filenames are produced.
 
 **Rollback path:** Set to `'0'` in the workflow `env:` block. The
 next run generates a bare unpartitioned `_VacCrew` file per WR+week,

--- a/website/docs/reference/environment.md
+++ b/website/docs/reference/environment.md
@@ -410,7 +410,7 @@ prior run.
 silently override the pinned value without code review.
 
 **Startup banner:** The resolved state is logged at startup as
-`📋 VAC_CREW_CLAIM_ATTRIBUTION_ENABLED=<bool>`.
+`📋 VAC Crew claim attribution: ENABLED` or `📋 VAC Crew claim attribution: DISABLED`.
 
 ### `VAC_CREW_LEGACY_CLEANUP_ENABLED`
 
@@ -457,7 +457,7 @@ partitioning still runs.
 silently override the pinned value without code review.
 
 **Startup banner:** The resolved state is logged at startup as
-`📋 VAC_CREW_LEGACY_CLEANUP_ENABLED=<bool>`.
+`📋 VAC Crew legacy cleanup: ENABLED` or `📋 VAC Crew legacy cleanup: DISABLED`.
 
 ### `AEP_BILLABLE_CUTOFF`
 

--- a/website/docs/reference/environment.md
+++ b/website/docs/reference/environment.md
@@ -355,6 +355,110 @@ cannot silently override the pinned value without code review.
 **Startup banner:** The resolved state is logged at startup as
 `📋 SUBCONTRACTOR_LEGACY_PRIMARY_CLEANUP_ENABLED=<bool>`.
 
+### `VAC_CREW_CLAIM_ATTRIBUTION_ENABLED`
+
+*(Added 2026-05-21, Sub-project C — VAC crew claim attribution.)*
+
+**Default:** `'1'` (on) — truthy values are `1` / `true` / `yes` / `on`
+(case-insensitive). Any other value (including empty string, `0`,
+`false`) disables the feature.
+
+**Purpose:** When on, VAC crew Excel files are re-partitioned by the
+FROZEN vac-crew claimer from `billing_audit.attribution_snapshot`
+(`frozen_vac_crew` column) — resolved via Foundation A's
+`resolve_claimer` contract. Each file holds only one claimer's
+completed line items and is named `_VacCrew_<claimer>` (e.g.
+`WR_90773033_WeekEnding_051226_VacCrew_Jane_Smith_<hash>.xlsx`).
+Rows with no frozen claimer yet (`no_history`) fall back to the
+current Smartsheet vac-crew name (first-write semantics — this run
+freezes them). A Supabase outage (`fetch_failure`) HOLDs the affected
+rows for that run (no VAC crew file is emitted — correctness over
+availability) and the end-of-run `summarize_attribution_holds()`
+WARNING reports the hold count.
+
+**Scope:** ALL sheets that have VAC crew columns — including both
+subcontractor-folder sheets and original-contract-folder sheets. This
+is broader than `SUBCONTRACTOR_HELPER_CLAIM_ATTRIBUTION_ENABLED`
+(subcontractor sheets only); it uses its own dedicated kill switch
+for independent rollback.
+
+**Wiring:** A bounded parallel pre-pass (`_vac_crew_claimer_map`,
+`ThreadPoolExecutor(max_workers=min(PARALLEL_WORKERS, n))`) resolves
+every VAC crew row's claimer BEFORE the `group_source_rows` grouping
+loop — no per-row Supabase I/O in the hot loop (per the
+[2026-04-25 14:00] per-row-latency rule).
+
+**Kill-switch-OFF exact legacy behaviour:** When disabled, the
+partition key, `valid_wr_weeks` identity, `current_keys` hash entry,
+and `build_group_identity` parser ALL revert to the empty-identifier
+form so the output is byte-identical to the pre-C baseline
+(`_VacCrew` bare, no `_<name>` suffix). ALL FOUR identity sites are
+gated on this flag; disabling only some would produce attachment
+churn.
+
+**Rollback path:** Set to `'0'` in the workflow `env:` block. The
+next run generates a bare unpartitioned `_VacCrew` file per WR+week,
+exactly as before Sub-project C. No code revert required.
+`VAC_CREW_LEGACY_CLEANUP_ENABLED` may be left on — it carries a
+`valid_wr_weeks` live-identity exemption so current per-claimer files
+are never deleted even if the partitioned files still exist from a
+prior run.
+
+**Workflow pin:** `.github/workflows/weekly-excel-generation.yml`
+`env:` block alongside `VAC_CREW_LEGACY_CLEANUP_ENABLED`. Per the
+[2026-04-24 14:30] workflow-pinning rule, a repo Variable cannot
+silently override the pinned value without code review.
+
+**Startup banner:** The resolved state is logged at startup as
+`📋 VAC_CREW_CLAIM_ATTRIBUTION_ENABLED=<bool>`.
+
+### `VAC_CREW_LEGACY_CLEANUP_ENABLED`
+
+*(Added 2026-05-21, Sub-project C — VAC crew claim attribution.)*
+
+**Default:** `'1'` (on) — truthy values are `1` / `true` / `yes` / `on`
+(case-insensitive). Any other value (including empty string, `0`,
+`false`) disables the cleanup.
+
+**Scope:** Sub-project C one-time migration.
+
+**Purpose:** Gates the destructive removal of legacy UNPARTITIONED
+`_VacCrew` attachments (no claimer suffix, so the parsed identifier is
+empty) on `TARGET_SHEET_ID` for in-scope vac-crew WRs, once those
+variants are re-partitioned by the frozen vac-crew claimer
+(Sub-project C). Before the migration, each vac-crew WR had one bare
+`_VacCrew` file; after, it has one file per claimer
+(`_VacCrew_<name>`). The bare files become duplicate-billing
+leftovers. The deletion predicate matches ONLY empty-identifier files
+for in-scope vac WRs and carries a `valid_wr_weeks` live-identity
+exemption, so a current per-claimer file (non-empty identifier) is
+never deleted.
+
+**Companion:** A one-time, idempotent hash-history prune
+(`_run_vac_crew_hash_prune`, sentinel `_vac_crew_prune_version`,
+version `VAC_CREW_HASH_PRUNE_VERSION`) drops the matching
+blank-identifier `vac_crew` hash-history orphans so the migration is
+deterministic on the first run. The prune is benign (a dropped hash
+entry costs at most one regeneration) and is NOT gated by this env var
+— advancing the version constant is its re-run trigger. The prune
+returns a `bool` wired into `_hash_history_migration_dirty` so it
+persists even on a no-update run (per the [2026-05-21] one-time
+migration rule).
+
+**Separate from `VAC_CREW_CLAIM_ATTRIBUTION_ENABLED`,** which gates
+attribution RESOLUTION (which claimer a row belongs to), NOT this
+cleanup. Set this var to `'0'` to skip the destructive cleanup (legacy
+bare `_VacCrew` files persist until removed manually); attribution
+partitioning still runs.
+
+**Workflow pin:** `.github/workflows/weekly-excel-generation.yml`
+`env:` block alongside `VAC_CREW_CLAIM_ATTRIBUTION_ENABLED`. Per the
+[2026-04-24 14:30] workflow-pinning rule, a repo Variable cannot
+silently override the pinned value without code review.
+
+**Startup banner:** The resolved state is logged at startup as
+`📋 VAC_CREW_LEGACY_CLEANUP_ENABLED=<bool>`.
+
 ### `AEP_BILLABLE_CUTOFF`
 
 **Default:** `2026-04-12` (AEP rate-increase contract awarded to Linetec)


### PR DESCRIPTION
## Objective

Re-partition `vac_crew` Excel files by the **frozen** vac-crew claimer (`frozen_vac_crew` via Foundation A's `resolve_claimer`), so each file holds only one claimer's completed line items, named `_VacCrew_<name>`. Third consumer of the Foundation A attribution layer (A → B → **C** → D → E). Mirrors the already-shipped Subproject B (subcontractor primary).

## Changes Made

- **`generate_weekly_pdfs.py`**
  - New `_vac_crew_variant_suffix` helper + reordered `build_group_identity` (VacCrew checked **before** Helper, so a crew name containing "Helper" isn't misclassified).
  - Parallel claimer **pre-pass** (`_vac_crew_claimer_map`, bounded `ThreadPoolExecutor`, single-row skip) — no per-row Supabase I/O in the grouping loop.
  - Emission partitions `{week}_{wr}_VACCREW` → `{week}_{wr}_VACCREW_{claimer}`; fallback-to-current on `no_history`; **HOLD** on `resolve_claimer` `fetch_failure` (defer + `record_attribution_hold` + end-of-run `summarize_attribution_holds`); map-miss → use-current (never HOLD).
  - **CR-01 four-site lockstep**: claimer identifier carried identically at the main-loop `identifier`/`file_identifier`/`history_key`, `valid_wr_weeks`, `current_keys`, and the parser — **all gated on the kill switch** so OFF reproduces the exact legacy bare `_VacCrew`/`''` shape.
  - `generate_excel` filename `_VacCrew_<claimer>` + display foreman = attributed claimer (dept/job from vac fields; never the primary/Arrowhead foreman).
  - Migration: TARGET-only legacy `_VacCrew` cleanup (`_build_vac_crew_wr_scope`, live-identity exemption) + one-time idempotent `_run_vac_crew_hash_prune` (distinct `_vac_crew_prune_version` sentinel, wired into the no-update-run save path).
  - Two new default-on, workflow-pinned kill switches: `VAC_CREW_CLAIM_ATTRIBUTION_ENABLED`, `VAC_CREW_LEGACY_CLEANUP_ENABLED`.
- **`.github/workflows/weekly-excel-generation.yml`** — pinned both flags to `'1'`.
- **`tests/test_vac_crew_claim_attribution.py`** — new end-to-end suite (config, suffix/parser, pre-pass concurrency, emission, identity sites + display, legacy cleanup, hash prune, coexistence, production-site invariants). Two legacy contract-override rewrites (`test_vac_crew.py::test_vac_crew_key_format` + sibling; `test_subcontractor_primary_claim_attribution.py::test_vac_crew_row_unaffected`).
- **`website/docs/reference/environment.md`** + **`CLAUDE.md`** Living Ledger — documented the feature, decisions, and the CR-01 four-site lesson.
- Spec + plan committed under `docs/superpowers/`.

## Production Safety Check

- `billing_audit/` is **not modified** (Foundation A already provides everything); hash-in-filename is **retained** (token-stripping is Sub-project E).
- All changes are `vac_crew`-scoped — primary / helper / subcontractor (`reduced_sub`/`aep_billable`/`*_helper`) grouping, filenames, hashing, and upload routing are unchanged (verified by the existing suites + the four-site round-trip review).
- Kill switch OFF reproduces **exact legacy** behavior at every surface (bare `_VacCrew` file, `''` identifier, single group per WR+week).
- Migration cleanup deletes only empty-identifier legacy `_VacCrew` for in-scope WRs **with a live-identity exemption** (no data loss); the hash prune is idempotent.
- Per-task two-stage review (spec + code quality) + a final comprehensive review: **READY TO MERGE**, no Critical/Important findings.
- `pytest tests/` → **809 passed / 26 skipped / 60 subtests, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)