### PR TITLE
feat(billing): Subproject D — primary-workflow primary claim attribution

### DIFF
--- a/.github/workflows/weekly-excel-generation.yml
+++ b/.github/workflows/weekly-excel-generation.yml
@@ -392,6 +392,23 @@ jobs:
           # resolution, NOT this cleanup). Living Ledger [2026-05-21].
           VAC_CREW_LEGACY_CLEANUP_ENABLED: '1'
 
+          # Sub-project D (2026-05-25): kill switch for per-claimer
+          # partitioning of the PRODUCTION primary Excel files by frozen
+          # primary foreman from billing_audit.attribution_snapshot. Set
+          # to '0' to preserve legacy one-file-per-WR bare primary
+          # behavior. Unlike Subproject B, the core primary path never
+          # holds on a Supabase outage — it falls back to the current
+          # foreman and still generates. Living Ledger [2026-05-25].
+          PRIMARY_CLAIM_ATTRIBUTION_ENABLED: '1'
+          # Sub-project D (2026-05-25): kill switch for the one-time
+          # removal of legacy UNPARTITIONED bare primary attachments (no
+          # _User_ token) on TARGET_SHEET_ID for non-subcontractor WRs.
+          # Set to '0' to skip the destructive cleanup (legacy duplicates
+          # persist until removed manually). Separate from
+          # PRIMARY_CLAIM_ATTRIBUTION_ENABLED (which gates attribution
+          # resolution, NOT this cleanup). Living Ledger [2026-05-25].
+          LEGACY_PRIMARY_PARTITION_CLEANUP_ENABLED: '1'
+
           # AEP_BILLABLE_CUTOFF is intentionally UNSET in the
           # workflow — the Python default (datetime.date(2026,
           # 4, 12), the contract award date) is the source of

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2801,3 +2801,168 @@ When proposing new workflows, dynamically evaluate the absolute best technology.
   skipped when disabled / runs when enabled, vac-on-sub row emits only
   VACCREW). ``pytest tests/`` → **814 passed / 26 skipped / 60
   subtests** (was 809; +5).
+- [2026-05-25 16:30] Sub-project D (primary-workflow primary claim
+  attribution) shipped — the fourth and final consumer of Foundation
+  A's ``resolve_claimer`` + HOLD contract ([2026-05-20 13:45]).
+  Production (non-subcontractor) primary Excel files are now
+  partitioned by the FROZEN primary claimer (``primary_foreman`` from
+  ``billing_audit.attribution_snapshot``, surfaced via Foundation A's
+  ``ROLE_BY_VARIANT['primary'] = 'primary_foreman'`` mapping) instead
+  of one bare file per WR+week. Each file is named
+  ``_User_<claimer>`` (the same reserved ``_User_`` token as
+  Subproject B's per-claimer primary files, parser-unambiguous vs
+  ``_Helper_``). A WR+week claimed by two foremen yields two
+  coexistent files (distinct identity tuples — ``(wr, week,
+  'primary', claimer_a)`` vs ``(wr, week, 'primary', claimer_b)``)
+  that never cross-delete: the attachment-cleanup path only prunes
+  older copies WITHIN the same identity, so a foreman switch within
+  the same week produces a second file rather than destroying the
+  first. Only Sub-project E (Supabase hash-store migration + filename
+  ``_<hash>``/``_<timestamp>`` token stripping) remains in the
+  universal-claim-attribution sequence (A → Phase 1.1 → B → C → D
+  → E).
+  **No-HOLD operator decision (the key D-vs-B distinction).** Unlike
+  Subproject B (which HOLDs subcontractor primary on a Supabase
+  outage), D's core primary path NEVER holds. On ``resolve_claimer``
+  returning ``fetch_failure`` (outage, run-global kill, retries
+  exhausted), ``no_history``, ``disabled``, or a ``_primary_claimer_map``
+  miss, D falls back to the CURRENT ``effective_user`` and still
+  generates the primary file. Rationale: D covers EVERY
+  non-subcontractor WR in every run; HOLDing on a Supabase outage
+  would suppress ALL primary billing output for that session — a
+  data-absent outcome strictly worse than a possibly-late
+  attribution. ``record_attribution_hold`` is never called for the
+  primary path; the HOLD machinery from Foundation A is reserved for
+  Subproject B's subcontractor-primary flow. A ``no_history`` row is
+  the common new-claim case: the current ``effective_user`` is the
+  correct partition key (this run IS what freezes the claim via
+  ``freeze_row``).
+  **Approach A (parallel pre-pass).** ``_primary_claimer_map`` is
+  resolved in a bounded ``ThreadPoolExecutor(min(PARALLEL_WORKERS,
+  n))`` BEFORE the ``group_source_rows`` grouping loop, scoped to
+  completed (``Units Completed?`` checked) non-vac-crew
+  non-subcontractor rows (per-row ``is_vac_crew_row`` /
+  ``is_subcontractor_row`` checks). Single-row groups skip the
+  executor to avoid setup overhead. This follows the
+  [2026-04-25 14:00] rule (per-row attribution I/O must live in a
+  pre-pass, never the hot loop) and the [2026-05-21 09:21] Subproject
+  B wiring pattern. Zero changes to ``billing_audit/`` — Foundation A
+  already exposes ``_lookup_attribution_all`` + ``resolve_claimer``
+  for the ``'primary'`` role.
+  **CR-01 four-site lockstep (extended to a fifth-and-sixth site).**
+  The claimer identifier is byte-identical at: (1) the per-group
+  main-loop ``identifier`` / ``file_identifier`` construction that
+  feeds ``history_key = f"{wr_num}|{week_raw}|{variant}|{identifier}"``;
+  (2) the ``valid_wr_weeks.add(...)`` cleanup-tuple builder; (3) the
+  ``current_keys`` hash-prune set construction; (4) the
+  ``build_group_identity`` parser (already supported ``_User_<name>``
+  from Subproject B — zero parser change required); (5) the
+  ``generate_excel`` filename-suffix branch; and (6) the
+  ``_key_matches_wr`` (WR_FILTER) mirror-matcher. ALL construction
+  sites are gated on ``PRIMARY_CLAIM_ATTRIBUTION_ENABLED``; when OFF,
+  the identifier is ``''`` and the history key is the legacy bare
+  ``{wr}|{week}|primary|`` form, reproducing exact pre-D behavior
+  byte-for-byte.
+  **Corrected design finding (generate_excel filename surface).**
+  The original D spec assumed ``generate_excel`` needed no change
+  because the primary variant's filename branch was "bare." In
+  practice that branch set ``variant_suffix = ''`` UNCONDITIONALLY —
+  without a gated fix, every per-claimer primary group would produce
+  the same bare filename (``WR_{wr}_WeekEnding_{mmddyy}_{ts}_{hash}.xlsx``),
+  causing every group after the first to clobber the prior file on
+  disk and producing a single-file output regardless of claimer count.
+  D added a gated ``elif PRIMARY_CLAIM_ATTRIBUTION_ENABLED and
+  identifier: variant_suffix = f"_User_{identifier}"`` branch
+  (mirroring the vac_crew ``_User_`` branch added by Subproject C),
+  so each claimer's file has a distinct on-disk name and can be
+  uploaded to a distinct Smartsheet attachment without collision.
+  **Mirror-matcher rule applied.** ``_key_matches_wr`` (the WR_FILTER
+  matcher, used in TEST_MODE diagnostic runs) gained the
+  ``or suffix.startswith(f"{wr}_USER_")`` clause for D's per-claimer
+  primary keys; ``_key_matches_excluded_wr`` (EXCLUDE_WRS) already
+  carried the ``_USER_`` clause from Subproject B — zero change
+  needed there. Both matchers revert to the bare ``suffix == wr``
+  exact-match when ``PRIMARY_CLAIM_ATTRIBUTION_ENABLED`` is off, so
+  the filter semantics are identical to the pre-D legacy contract.
+  **Migration (gated on default-on ``LEGACY_PRIMARY_PARTITION_CLEANUP_ENABLED``).** Two
+  components: (a) forced bare-primary attachment cleanup on
+  TARGET_SHEET_ID for in-scope WRs via a new ``primary_wr_scope``
+  parameter to ``cleanup_untracked_sheet_attachments``. The scope is
+  built by a shared ``_build_primary_wr_scope(groups)`` helper (union
+  of WR numbers from all non-sub non-vac primary groups — deliberately
+  excludes Subproject B's ``_REDUCEDSUB`` / ``_AEPBILLABLE`` ``_USER_``
+  keys to prevent scope overlap). The safety-critical
+  ``ident not in valid_wr_weeks`` live-identity exemption
+  ([2026-05-19 23:45] rule 1) is applied so a current per-claimer
+  attachment is never deleted as collateral cleanup. TARGET-only: PPP
+  is never touched by D (primary variants never route to PPP).
+  (b) One-time ``_run_subproject_d_hash_prune`` drops legacy
+  blank-identifier ``{wr}|{week}|primary|`` orphans from
+  ``hash_history.json``. Uses a DISTINCT ``_subproject_d_prune_version``
+  sentinel and ``SUBPROJECT_D_HASH_PRUNE_VERSION = 1`` constant
+  (separate from Phase 1.1's ``_phase_prune_version`` and Subproject
+  B's ``_subproject_b_prune_version`` sentinels). The prune is gated
+  on ``PRIMARY_CLAIM_ATTRIBUTION_ENABLED`` — when OFF the bare key IS
+  the active legacy key; pruning it would force unnecessary
+  regeneration churn on every quiet run. The prune returns a ``bool``
+  (``True`` when the sentinel was advanced) wired into
+  ``_hash_history_migration_dirty`` per the [2026-05-21 13:20] rule 3
+  (one-time migrations must persist independently of
+  ``history_updates``). The ``_build_primary_wr_scope`` helper is
+  shared by both the cleanup call site and the prune (prevents scope
+  drift — the [2026-05-19 22:00] rule 3).
+  **Test-contract reconciliation (new rule).** D's change to the
+  non-subcontractor primary emission contract inverted the assertions
+  in three prior B/B1-era isolation tests (which asserted a
+  non-subcontractor non-helper row emits the BARE primary key
+  ``{wr}_{week}`` with no claimer suffix) and one stale WR-filter
+  mirror test (``test_user_variant_intentionally_not_matched``, which
+  asserted WR_FILTER did NOT match the ``_USER_`` clause for
+  non-subcontractor rows). Per the [2026-05-20 00:26] rule 2
+  (test-contract override), the three isolation tests were pinned to
+  ``PRIMARY_CLAIM_ATTRIBUTION_ENABLED=False`` in their
+  ``setUp``/``tearDown`` (preserving their B/B1-isolation purpose
+  exactly — they test B's subcontractor rows under the D-off
+  contract); D's new partitioning behavior is covered end-to-end by
+  the D suite. The stale mirror test's obsolete assertion was inverted
+  to match the post-D reality (WR_FILTER now DOES match per-claimer
+  primary keys) and its docstring updated to cite this ledger entry.
+  **New rule — test-contract reconciliation discipline.** When a new
+  universal-attribution sub-project changes a shared emission contract
+  (here: D changes the non-sub primary key shape from bare to
+  ``_User_<claimer>``), the implementer MUST audit prior sub-projects'
+  isolation tests and mirror tests for the inverted assumption before
+  the branch is pushed. Reconcile in the same branch by: (a) pinning
+  now-orthogonal feature flags to ``False`` in the prior tests'
+  setUp/tearDown (preserves their isolation purpose), or (b) inverting
+  + citing the ledger entry when the prior assertion was testing the
+  exact behavior D is changing. Do not let the full-suite gate be the
+  first discovery of the conflict — that requires a red-to-green
+  repair cycle on a branch that should have been green from the start.
+  **Two new default-on kill switches** — ``PRIMARY_CLAIM_ATTRIBUTION_ENABLED``
+  and ``LEGACY_PRIMARY_PARTITION_CLEANUP_ENABLED`` — are workflow-pinned
+  to ``'1'`` in ``.github/workflows/weekly-excel-generation.yml``
+  with prominent LEGACY-style comments explaining their revert paths,
+  surfaced in the startup banner alongside all prior sub-project flags,
+  and documented in ``website/docs/reference/environment.md`` (the
+  "Primary foreman claim attribution" section). Regression tests: new
+  file ``tests/test_primary_claim_attribution.py`` covering
+  ``TestBuildGroupIdentityParsesUserToken`` (primary ``_User_``
+  round-trip), ``TestPrimaryClaimAttributionKillSwitch`` (OFF reverts
+  to bare key, ON emits ``_User_<claimer>``),
+  ``TestPrimaryClaimerPrePassEmission`` (pre-pass resolves claimer,
+  no-history falls back to current user, outage falls back not HOLDs),
+  ``TestThreeIdentitySitesCarryPrimaryClaimer`` (history_key /
+  valid_wr_weeks / current_keys lockstep), ``TestFilenameVariantSuffix``
+  (gated ``_User_`` suffix in generate_excel),
+  ``TestMirrorMatcherPrimaryUser`` (WR_FILTER matches per-claimer key
+  on, OFF reverts), ``TestMigrationCleanupPrimary`` (scope excludes
+  sub WRs, live-identity exemption preserved),
+  ``TestSubprojectDHashPrune`` (prune gate on flag, sentinel distinct,
+  return-bool wired to dirty-flag, idempotent), and
+  ``TestNonSubNonVacPrimaryPreserved`` (vac and sub rows unaffected).
+  Plus reconciled prior tests: B/B1 isolation tests pinned to
+  ``PRIMARY_CLAIM_ATTRIBUTION_ENABLED=False``; stale WR-filter mirror
+  assertion inverted. ``pytest tests/`` → **854 passed / 26 skipped /
+  61 subtests** (was 814 / 26 / 60 at Sub-project C close; +40 net
+  passing, +1 subtest).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3117,3 +3117,85 @@ When proposing new workflows, dynamically evaluate the absolute best technology.
   clause, citing this entry) per the [2026-05-25 16:30] test-contract
   reconciliation rule. ``pytest tests/`` → **871 passed / 26 skipped / 61
   subtests** (was 866; +5, zero regressions).
+- [2026-05-25 18:35] Sub-project D PR #223 second review round
+  (Copilot on ``f7ac747``). One correctness fix + one cosmetic rename;
+  the perf fix was landed by the Codex bot in parallel (commit
+  ``9d300f7``, integrated); Codex's P2 on the same commit was
+  evaluated and REJECTED (see below).
+  **(1) WR-matcher gap — production EXCLUDE_WRS silently fails for
+  subcontractor per-claimer primary files (correctness, fixed).**
+  Sub-project B emits subcontractor PRIMARY GROUP KEYS as
+  ``{week}_{wr}_REDUCEDSUB_USER_<claimer>`` /
+  ``{week}_{wr}_AEPBILLABLE_USER_<claimer>`` (the GROUP KEY, not just
+  the filename) whenever attribution is on — the production default.
+  But both ``_key_matches_wr`` (WR_FILTER, TEST_MODE) and
+  ``_key_matches_excluded_wr`` (EXCLUDE_WRS, **production-active**)
+  carried only the exact ``suffix == f"{wr}_REDUCEDSUB"`` /
+  ``== f"{wr}_AEPBILLABLE"`` clauses plus the ``_HELPER_`` prefixes —
+  no ``_REDUCEDSUB_USER_`` / ``_AEPBILLABLE_USER_`` prefix clause. The
+  bare-exact clauses match only the attribution-OFF shape, so with
+  attribution ON an operator excluding a subcontractor WR still
+  generated AND uploaded its per-claimer primary files (the
+  "do-not-bill-yet" intent silently failed), and a TEST_MODE
+  ``WR_FILTER`` of such a WR dropped them. This is a latent
+  Sub-project B ([2026-05-21 09:21]) violation of the mirror-matcher
+  rule ([2026-05-15] CR-02/CR-03) — B added the new group-key shape
+  but did not extend the two matchers. Fixed here (carried in the D
+  PR because the matchers are the same functions D already modified):
+  added ``or suffix.startswith(f"{wr}_REDUCEDSUB_USER_")`` and
+  ``or suffix.startswith(f"{wr}_AEPBILLABLE_USER_")`` to BOTH matchers
+  + updated the shape-list comment headers ("eleven shapes"). The
+  ``_VACCREW_<claimer>`` clause — present in production but missing
+  from the EXCLUDE-side test MIRROR (``_exclude_matches``) — was also
+  synced. **(2) Pre-pass resolves wasted primary claimers for helper
+  rows (perf, fixed by the Codex bot in ``9d300f7``, integrated).**
+  The Sub-project D ``_primary_claimer_map`` pre-pass scoped rows by
+  completed + non-vac + non-sub but did NOT exclude ``valid_helper_row``
+  rows — which the emission later routes to the ``_Helper_<name>``
+  shadow file and NEVER to a primary ``_USER_`` group (the emission
+  gate is ``not valid_helper_row``). So every completed helper row
+  cost a wasted ``resolve_claimer('primary', …)`` Supabase RPC. The
+  bot added ``if _r.get('__is_helper_row') and
+  _r.get('__helper_foreman') and _r.get('__helper_dept'): continue``
+  to the pre-pass scope (helper_mode is guaranteed by the outer
+  ``RES_GROUPING_MODE in ('helper','both')`` gate; helper_job is
+  optional, matching the emission). It skips ONLY rows the emission
+  would exclude from primary anyway, so attribution for genuine
+  primary rows is unaffected — extends the [2026-04-25 14:00]
+  per-row-RPC-latency rule (a pre-pass must mirror emission
+  eligibility, not just variant type). Two behavioral regression
+  tests were added on top of the bot's fix. **(3) Cosmetic:**
+  ``test_all_{seven,eight}_variants_{retained,excluded}_for_target_wr``
+  → ``test_all_variants_*`` (the shape count has grown past eight).
+  **Codex P2 (REJECTED) — "Resolve primary claimers in primary
+  grouping mode."** Codex argued primary mode "silently skips frozen
+  attribution." That is INTENTIONAL: the [2026-05-25 18:15] fix made
+  every D surface consistently bare in ``RES_GROUPING_MODE ==
+  'primary'`` because the spec documents primary-mode partitioning as
+  "semantically wrong" (it lumps helper + sub rows into one file).
+  Codex's premise ("identity/filename logic still consumes
+  ``__current_foreman``") is stale — all four surfaces are now
+  mode-gated. No action; rationale posted to the PR.
+  **New rule — a new group-key shape requires BOTH a matcher update
+  AND a test-mirror update in the same change.** The mirror-matcher
+  rule ([2026-05-15]) is necessary but not sufficient: the
+  ``test_security_audit_followup.py`` matcher tests use LOCAL MIRROR
+  copies (``_filter_matches`` / ``_exclude_matches``) of the
+  production matcher bodies, tied to production only by the
+  ``test_production_function_body_contains_all_*_clauses`` source-grep
+  guards. When adding a variant key shape you MUST (a) extend both
+  production matchers, (b) extend both test mirrors, AND (c) add the
+  new clause's f-string needle to the source-grep guards — otherwise
+  the mirror tests pass against a stale copy while production stays
+  broken (exactly how B's gap survived two phases of green suites).
+  Regression tests: ``tests/test_security_audit_followup.py`` — the
+  renamed ``test_all_variants_{retained,excluded}_for_target_wr`` gain
+  the ``_REDUCEDSUB_USER_`` / ``_AEPBILLABLE_USER_`` (+ ``_VACCREW_``)
+  keys, the filter-side source guard now requires both new needles in
+  BOTH matchers (``count >= 2``);
+  ``tests/test_primary_claim_attribution.py::TestPrimaryPrePass``
+  gains ``test_prepass_skips_valid_helper_row`` (resolve_claimer not
+  called) and ``test_prepass_resolves_primary_only_skipping_helper``
+  (called exactly once for a primary+helper pair). ``pytest tests/``
+  → **873 passed / 26 skipped / 69 subtests** (was 871; +2, zero
+  regressions).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3046,3 +3046,74 @@ When proposing new workflows, dynamically evaluate the absolute best technology.
   skipped / 61 subtests** (was 854 at the D close; +12: 11 reserved-token
   parser tests + 1 scope-builder regression). CI on PR #223 was fully
   green pre-fix (CodeQL, tests+coverage, codecov, Snyk, Semgrep, Vercel).
+- [2026-05-25 18:15] Sub-project D PR #223 follow-up — Codex P1
+  "partition primary groups in primary mode too": grouping-vs-identity
+  inconsistency in ``RES_GROUPING_MODE == 'primary'``. **Finding (valid).**
+  D's primary emission in ``group_source_rows`` correctly stays bare in
+  primary mode — ``if RES_GROUPING_MODE == 'primary': keys_to_add.append(
+  ('primary', f"{week}_{wr}", None))`` — lumping every non-helper/non-sub
+  foreman's rows into ONE workbook per WR+week (the pre-pass at the
+  ``_primary_claimer_map`` block is also already gated on
+  ``RES_GROUPING_MODE in ('helper', 'both')``). But the FOUR consuming
+  identity/filename surfaces gated ONLY on ``PRIMARY_CLAIM_ATTRIBUTION_ENABLED``
+  (default on), NEVER on the mode: (1) ``generate_excel``'s primary
+  ``variant_suffix`` branch, (2) Site 1 main-loop ``history_key`` /
+  ``file_identifier``, (3) Site 2 ``valid_wr_weeks`` builder, (4) Site 3
+  ``current_keys`` builder. ``__current_foreman`` is set on every row
+  (``r_copy['__current_foreman'] = current_foreman or effective_user``),
+  so in primary mode these surfaces derived ``_User_<first-sorted
+  foreman>`` for a MERGED multi-foreman workbook — mislabeling it under one
+  foreman and letting row-sort-order changes flip the filename / history
+  key / attachment identity between runs (regeneration churn + orphan
+  accumulation). Operator-reachable: the production schedule pins
+  ``RES_GROUPING_MODE='both'`` (unaffected), but a manual
+  ``workflow_dispatch`` with ``res_grouping_mode: primary`` hits it.
+  **Codex's proposed remedy ("partition in primary mode too") is REJECTED**
+  — the design spec (§Scope / Out of scope) documents that primary mode
+  lumps helper + subcontractor rows into one file per WR where
+  "partitioning by ``primary_foreman`` would be semantically wrong"; it
+  must "stay bare/legacy." **Fix (the spec-aligned remedy):** gate all
+  four consuming surfaces on ``PRIMARY_CLAIM_ATTRIBUTION_ENABLED and
+  RES_GROUPING_MODE in ('helper', 'both')`` so primary mode is
+  *consistently* bare at every surface — matching the already-mode-gated
+  pre-pass + emission. In primary mode the surfaces now fall through to the
+  legacy ``User``-field identifier path (``User`` "is never populated in
+  production" per the spec → identifier ``''`` → bare key/filename,
+  byte-identical to pre-D primary-mode behaviour). ``both`` / ``helper``
+  production behaviour is unchanged (the mode predicate is True there). The
+  Site 2/3 inner ``if (PRIMARY_CLAIM_ATTRIBUTION_ENABLED and _pf)`` ternary
+  re-checks were left unchanged (they sit inside the now-mode-gated outer
+  block, so they are unreachable in primary mode anyway). **New rule —
+  emission-mode gates must be mirrored at every consuming identity/filename
+  surface.** Extends the CR-01 four-site lockstep ([2026-05-15] /
+  [2026-05-21 09:21]): when a variant's GROUP-KEY emission is gated on a
+  grouping-mode predicate (``RES_GROUPING_MODE in (...)``), EVERY surface
+  that later derives an identifier from that variant's rows — the
+  ``generate_excel`` filename suffix AND all three identity sites
+  (``history_key``/``file_identifier``, ``valid_wr_weeks``,
+  ``current_keys``) — MUST carry the SAME mode predicate, not just the
+  kill switch. A kill-switch-only gate on the consumers while the emission
+  also gates on mode is a split-brain: the grouping says "bare/merged" but
+  the filename/identity say "partitioned," and whichever row sorts first
+  silently decides the (wrong) identity. The lesson generalizes the
+  long-standing rule that the identity tuple must be built identically at
+  every site — "identically" now explicitly includes the gating predicate,
+  not only the value expression. Coverage gap that let it ship: the D test
+  suite drove every ``group_source_rows`` / ``generate_excel`` case in
+  ``both`` mode and had ZERO ``RES_GROUPING_MODE == 'primary'`` coverage
+  for the identity/filename surfaces; the Sites A/B/C source-regex guards
+  asserted the kill-switch gate but not the mode gate. Regression tests:
+  new ``TestPrimaryModeStaysBare`` in
+  ``tests/test_primary_claim_attribution.py`` (5 methods) — a BEHAVIORAL
+  test that drives the real ``generate_excel`` in primary mode and asserts
+  the produced filename has NO ``_User_`` suffix, a ``both``-mode positive
+  control that asserts it DOES keep ``_User_<claimer>`` (guards against
+  over-fixing), and three source-regex guards that the filename suffix +
+  Sites 1/2/3 all carry the ``RES_GROUPING_MODE in ('helper', 'both')``
+  predicate. Two prior filename-suffix source guards
+  (``TestPrimaryFilenameSuffix.test_primary_branch_builds_user_suffix_gated``
+  and ``TestSubprojectDProductionInvariants.test_filename_suffix_user_gated``)
+  were reconciled in-place (regex widened to tolerate the interposed mode
+  clause, citing this entry) per the [2026-05-25 16:30] test-contract
+  reconciliation rule. ``pytest tests/`` → **871 passed / 26 skipped / 61
+  subtests** (was 866; +5, zero regressions).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2871,11 +2871,15 @@ When proposing new workflows, dynamically evaluate the absolute best technology.
   the same bare filename (``WR_{wr}_WeekEnding_{mmddyy}_{ts}_{hash}.xlsx``),
   causing every group after the first to clobber the prior file on
   disk and producing a single-file output regardless of claimer count.
-  D added a gated ``elif PRIMARY_CLAIM_ATTRIBUTION_ENABLED and
-  identifier: variant_suffix = f"_User_{identifier}"`` branch
-  (mirroring the vac_crew ``_User_`` branch added by Subproject C),
-  so each claimer's file has a distinct on-disk name and can be
-  uploaded to a distinct Smartsheet attachment without collision.
+  D added a gated branch in the ``elif variant == 'primary':`` arm:
+  ``_pf = first_row.get('__current_foreman', '')`` then
+  ``if PRIMARY_CLAIM_ATTRIBUTION_ENABLED and _pf: variant_suffix =
+  f"_User_{_RE_SANITIZE_IDENTIFIER.sub('_', _pf)[:50]}"`` (else bare
+  ``''``) — mirroring the vac_crew ``_User_`` branch added by Subproject
+  C. The suffix derives from the attributed claimer (``__current_foreman``,
+  the partition key), sanitized via ``_RE_SANITIZE_IDENTIFIER`` exactly as
+  the four identity sites do, so each claimer's file has a distinct on-disk
+  name and round-trips through ``build_group_identity``.
   **Mirror-matcher rule applied.** ``_key_matches_wr`` (the WR_FILTER
   matcher, used in TEST_MODE diagnostic runs) gained the
   ``or suffix.startswith(f"{wr}_USER_")`` clause for D's per-claimer
@@ -2966,3 +2970,79 @@ When proposing new workflows, dynamically evaluate the absolute best technology.
   assertion inverted. ``pytest tests/`` → **854 passed / 26 skipped /
   61 subtests** (was 814 / 26 / 60 at Sub-project C close; +40 net
   passing, +1 subtest).
+- [2026-05-25 17:50] Sub-project D PR #223 pre-merge review hardening
+  (Opus final whole-implementation review + Codex/Copilot bot pass on the
+  PR). Two code fixes + doc reconciliation; all on the
+  ``feat/subproject-d-primary-claim-attribution`` branch BEFORE merge.
+  **(1) Parser earliest-reserved-token dispatch (final-review Issue #1,
+  commit 9489310).** ``build_group_identity`` dispatched variants by a
+  FIXED order (``if 'AEPBillable' in tail: elif 'ReducedSub' ... elif
+  'VacCrew' ... elif 'Helper' ... elif 'User'``), so a bare
+  ``_User_<claimer>`` primary file whose CLAIMER NAME contains a reserved
+  token (e.g. a foreman literally named "Pat Helper" →
+  ``_User_Pat_Helper_<hash>``) misparsed as ``helper`` — breaking the
+  identity round-trip (regeneration churn + orphan attachments). Fix:
+  dispatch on the EARLIEST reserved-token POSITION in the tail
+  (``min(_reserved_positions, key=...)``). Because ``generate_excel``
+  always emits the structural marker FIRST in ``variant_suffix`` (tail[0]
+  is the marker), the earliest-position token is ALWAYS the true variant —
+  so this is byte-equivalent to the old order for every PRODUCED filename
+  AND strictly more correct for reserved-token-in-name cases (an Opus
+  equivalence harness found 15 divergences, all bug fixes incl. latent
+  B-shape bugs like ``_ReducedSub_User_AEPBillable_Sue``). Generalizes the
+  [2026-05-21 13:20] reserved-token-parse-order rule (which fixed the
+  two-level ``_ReducedSub_User_`` shape) to the bare ``_User_`` /
+  ``_VacCrew`` / ``_Helper`` shapes. Branch bodies + tail-scoping
+  unchanged. Regression class
+  ``TestBuildGroupIdentityReservedTokenInClaimerName`` (11 tests).
+  **(2) Scope-builder authoritative-``__variant`` dispatch (Codex PR #223
+  P1).** ``_build_primary_wr_scope`` decided "is this a partitioned
+  primary group" by substring-matching the group KEY
+  (``'_USER_' in _key and '_REDUCEDSUB' not in _key and '_AEPBILLABLE'
+  not in _key``). Same fragility class: a helper NAMED "USER" →
+  ``..._HELPER_USER_...`` (key contains ``_USER_``) was mis-bucketed as a
+  primary, and a primary claimer named "REDUCEDSUB"/"AEPBILLABLE" was
+  wrongly excluded. Since the scope feeds the DESTRUCTIVE bare-primary
+  attachment cleanup AND the hash prune, a false positive could (in the
+  worst case, narrowed by the ``ident not in valid_wr_weeks`` exemption)
+  delete a legacy bare-primary attachment for a WR that never produced a
+  primary ``_User_`` group. Fix: gate on the authoritative ``__variant``
+  field (set at emission, ``r_copy['__variant'] = variant``):
+  ``_g_rows[0].get('__variant') == 'primary' and '_USER_' in _key``. The
+  ``__variant`` gate excludes helper/vac/sub groups regardless of NAME;
+  the ``'_USER_' in _key`` clause then distinguishes a partitioned primary
+  from a bare one (both call sites gate on
+  ``PRIMARY_CLAIM_ATTRIBUTION_ENABLED``, so in production ``'both'`` mode
+  every primary group is partitioned). Regression test
+  ``TestBuildPrimaryWrScope::test_reserved_token_in_name_does_not_false_positive``.
+  **New rule — variant detection MUST use the authoritative ``__variant``
+  field (or the positional ``build_group_identity`` parse), never a key
+  substring scan.** A claimer/helper/vac NAME — or a pathological WR token
+  — can itself contain any reserved word (``USER``/``HELPER``/``VACCREW``/
+  ``REDUCEDSUB``/``AEPBILLABLE``), so substring presence in a group key is
+  not a reliable variant signal. This applies to the parser dispatch
+  (fixed) and to ``_build_primary_wr_scope`` (fixed). NOTE: the sibling
+  ``_build_subcontractor_wr_scope`` (``'_REDUCEDSUB' in _key``) and
+  ``_build_vac_crew_wr_scope`` (``'_VACCREW' in _key``) carry the SAME
+  latent substring pattern; their tokens are uppercase-unique so the
+  realistic-data risk is nil (an all-caps "REDUCEDSUB"/"VACCREW" foreman
+  name is required to trigger, and the effect is benign — a skipped
+  migration / a no-op cleanup on a non-matching WR). They were left as-is
+  to keep PR #223 scoped to D + the flagged P1; converting all three to
+  ``__variant`` is a clean separate consistency-pass follow-up.
+  **(3) Doc/comment reconciliation (Copilot nits, no behavior change):**
+  (a) two D code comments said bare-primary "parsed identifier == ''" —
+  corrected to ``identifier=None`` (``build_group_identity`` returns
+  ``None`` for a bare primary with no ``_User_`` token; the ``not
+  _identifier`` gate handles both None and ''; B/C legacy shapes DO parse
+  to '' so their comments were left unchanged); (b) ``environment.md``
+  ``LEGACY_PRIMARY_PARTITION_CLEANUP_ENABLED`` clarified that the companion
+  hash prune is gated on ``PRIMARY_CLAIM_ATTRIBUTION_ENABLED`` (not this
+  cleanup flag) — the CODE was always correct (mirrors C); only the doc
+  was misleading; (c) this ledger entry's [2026-05-25 16:30] filename-suffix
+  description + the design-spec finding #3 ("ZERO parser changes") + the
+  plan's Task 11 intro ("No production code change") were updated to note
+  the post-review parser hardening. ``pytest tests/`` → **866 passed / 26
+  skipped / 61 subtests** (was 854 at the D close; +12: 11 reserved-token
+  parser tests + 1 scope-builder regression). CI on PR #223 was fully
+  green pre-fix (CodeQL, tests+coverage, codecov, Snyk, Semgrep, Vercel).

--- a/docs/superpowers/plans/2026-05-25-subproject-d-primary-claim-attribution.md
+++ b/docs/superpowers/plans/2026-05-25-subproject-d-primary-claim-attribution.md
@@ -1508,7 +1508,7 @@ git commit -m "feat(billing): Subproject D — forced bare-primary cleanup on TA
 
 ## Task 11: `build_group_identity` round-trip regression + production-invariants source-grep
 
-No production code change — the parser already handles `_User_<name>`. This task locks the contract and the four-site lockstep against silent regression.
+No production code change *in this task* — the parser already handles `_User_<name>`, so Task 11 just locks the contract and the four-site lockstep against silent regression. **(Post-implementation note:** a separate post-review fix later hardened `build_group_identity` to dispatch on the earliest reserved-token position, fixing a misparse when a claimer NAME contains a reserved token — see the Living Ledger entry. That parser change is NOT part of Task 11; this task remains test-only.)**
 
 **Files:**
 - Test: `tests/test_primary_claim_attribution.py`

--- a/docs/superpowers/plans/2026-05-25-subproject-d-primary-claim-attribution.md
+++ b/docs/superpowers/plans/2026-05-25-subproject-d-primary-claim-attribution.md
@@ -307,7 +307,7 @@ Append to `tests/test_primary_claim_attribution.py`:
 def _make_primary_row(
     row_id,
     wr='90001',
-    week_serial=46100,  # arbitrary Excel serial -> a real date
+    week_serial='2026-04-19',  # ISO date; excel_serial_to_date is STRICT (rejects numeric serials) -> week key 041926
     effective_user='CurrentForeman',
     source_sheet_id=99999,  # NOT in _FOLDER_DISCOVERED_SUB_IDS
 ):

--- a/docs/superpowers/plans/2026-05-25-subproject-d-primary-claim-attribution.md
+++ b/docs/superpowers/plans/2026-05-25-subproject-d-primary-claim-attribution.md
@@ -1,0 +1,1742 @@
+# Sub-project D — Primary-Workflow Primary Claim Attribution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Partition the production primary Excel files by the FROZEN primary foreman who claimed each line item (`resolve_claimer('primary', …)`), naming each file `_User_<claimer>`, with a fall-back-to-current-and-generate policy on attribution unavailability (no HOLD), and a B/C-style one-time migration of the legacy bare-primary attachments + hash keys.
+
+**Architecture:** Mirror Sub-projects B and C. A bounded `ThreadPoolExecutor` pre-pass resolves each completed non-subcontractor primary row's frozen claimer into `_primary_claimer_map` before the grouping loop. The production primary emission partitions the bare `{week}_{wr}` key into `{week}_{wr}_USER_{claimer}`. The four identity surfaces (main-loop `history_key`, `valid_wr_weeks`, `current_keys`, `build_group_identity` parser) plus the `generate_excel` filename suffix are kept in lockstep, all gated on a new default-on kill switch so OFF reproduces exact legacy behavior. A one-time version-sentinel hash prune + a forced bare-primary attachment cleanup on `TARGET_SHEET_ID` migrate existing deployments.
+
+**Tech Stack:** Python 3.10+, `openpyxl`, Smartsheet SDK, `billing_audit` (Supabase reader — NOT modified), `concurrent.futures.ThreadPoolExecutor`, `unittest` + `unittest.mock`, pytest.
+
+**Spec:** `docs/superpowers/specs/2026-05-25-subproject-d-primary-claim-attribution-design.md`
+
+**Branch:** `feat/subproject-d-primary-claim-attribution` (already created off `origin/master`).
+
+---
+
+## Critical context for the implementer (read before Task 1)
+
+You are editing `generate_weekly_pdfs.py` — a ~8,800-line production billing engine. **Do not refactor anything not named in a task.** Every change is additive and gated on a kill switch. The four prior sub-projects (Phase 1.1, B, C) established the exact patterns you are mirroring; when in doubt, find the `reduced_sub` / `vac_crew` analog and copy its shape.
+
+**The non-negotiable invariants (from CLAUDE.md Living Ledger + the spec):**
+
+1. **CR-01 four-site lockstep.** A variant's claimer identifier must be byte-identical at (a) the main-loop `identifier`/`file_identifier`/`history_key` site, (b) the `valid_wr_weeks` builder, (c) the `current_keys` hash-prune set, and (d) the `build_group_identity` parser. For D, the parser (d) ALREADY handles `_User_<name>` → `('primary', wr, week, name)` — you do NOT change it (but Task 11 adds a regression test). Sites (a)/(b)/(c) + the `generate_excel` filename suffix are the surfaces you change.
+2. **Kill-switch gates every identity surface.** `PRIMARY_CLAIM_ATTRIBUTION_ENABLED=0` must reproduce EXACT legacy: bare `{week}_{wr}` key, `''` identifier, bare filename, `{wr}|{week}|primary|` history key, no migration.
+3. **Mirror-matcher rule.** `_key_matches_wr` (WR_FILTER) needs the `_USER_` clause added; `_key_matches_excluded_wr` (EXCLUDE_WRS) already has it. Both keep `suffix == wr` for OFF.
+4. **No HOLD.** D treats `resolve_claimer` `action=='hold'` (Supabase outage) the same as map-miss/disabled → use current `effective_user` and still generate. D NEVER calls `record_attribution_hold` and emits no hold summary.
+5. **Per-row attribution I/O in a bounded pre-pass**, never the hot loop.
+6. **`billing_audit/` is NOT modified.** `resolve_claimer('primary', …)` already maps to `primary_foreman` via `ROLE_BY_VARIANT`.
+
+**Key facts you will rely on (verified against the C-merged base, commit `8f546ae`; line numbers are anchors that may drift — search for the quoted code):**
+
+- The emission foreman propagates: `group_source_rows` line ~5750 does `r_copy['__current_foreman'] = current_foreman or effective_user`. Whatever you put in the `keys_to_add` tuple's 3rd element becomes `__current_foreman`.
+- `_RE_SANITIZE_IDENTIFIER` is the claimer sanitizer used by B/C (`.sub('_', name)[:50]`). Use it for D too. Do NOT invent a new regex.
+- `ResolveOutcome` (from `billing_audit.writer`) has fields `action` (`'use'`/`'hold'`), `name`, `source`, `status`.
+- The production primary emission is the `if not is_subcontractor_row and not valid_helper_row:` branch inside the `elif RES_GROUPING_MODE in ('helper', 'both'):` block. `valid_helper_row` and `is_subcontractor_row` are both in scope there.
+
+**Validation commands (run from repo root):**
+- Single test: `pytest tests/test_primary_claim_attribution.py::ClassName::test_name -v`
+- Full suite (must stay green; baseline 814 passed / 26 skipped / 60 subtests): `pytest tests/`
+- Syntax: `python -m py_compile generate_weekly_pdfs.py`
+
+---
+
+## File structure
+
+| File | Change | Responsibility |
+|------|--------|----------------|
+| `generate_weekly_pdfs.py` | Modify | Config (Task 1), `generate_excel` filename suffix (Task 2), pre-pass (Task 3), emission (Task 4), identity sites a/b/c (Tasks 5–6), WR_FILTER matcher (Task 7), `_build_primary_wr_scope` (Task 8), `_run_subproject_d_hash_prune` + wiring (Task 9), cleanup param/gate/call-site (Task 10) |
+| `tests/test_primary_claim_attribution.py` | Create | All D unit + E2E + source-grep tests |
+| `.github/workflows/weekly-excel-generation.yml` | Modify | Pin both new env vars (Task 12) |
+| `website/docs/reference/environment.md` | Modify | Document both new env vars (Task 12) |
+| `CLAUDE.md` | Modify | Living Ledger entry (Task 13) |
+
+---
+
+## Task 1: Config — version constant, two kill-switch env vars, startup banner
+
+**Files:**
+- Modify: `generate_weekly_pdfs.py` (constants block ~line 325; env-var block ~line 552; banner ~line 714)
+- Test: `tests/test_primary_claim_attribution.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_primary_claim_attribution.py` with:
+
+```python
+"""Sub-project D — primary-workflow primary claim attribution tests."""
+import datetime
+import inspect
+import unittest
+from unittest import mock
+
+import generate_weekly_pdfs  # noqa: E402
+from tests.test_billing_audit_shadow import _ensure_smartsheet_mocked, _reset_all  # noqa: E402
+
+_ensure_smartsheet_mocked()
+
+from billing_audit.writer import ResolveOutcome  # noqa: E402
+
+gwp = generate_weekly_pdfs
+
+
+class TestConfigConstants(unittest.TestCase):
+    """Task 1: D config surface exists with the right defaults."""
+
+    def test_hash_prune_version_constant(self):
+        self.assertEqual(gwp.SUBPROJECT_D_HASH_PRUNE_VERSION, 1)
+
+    def test_attribution_flag_is_bool(self):
+        self.assertIsInstance(gwp.PRIMARY_CLAIM_ATTRIBUTION_ENABLED, bool)
+
+    def test_cleanup_flag_is_bool(self):
+        self.assertIsInstance(
+            gwp.LEGACY_PRIMARY_PARTITION_CLEANUP_ENABLED, bool
+        )
+
+    def test_banner_logs_attribution_flag(self):
+        src = inspect.getsource(generate_weekly_pdfs)
+        self.assertIn(
+            "📋 PRIMARY_CLAIM_ATTRIBUTION_ENABLED=", src
+        )
+        self.assertIn(
+            "📋 LEGACY_PRIMARY_PARTITION_CLEANUP_ENABLED=", src
+        )
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_primary_claim_attribution.py::TestConfigConstants -v`
+Expected: FAIL — `AttributeError: module 'generate_weekly_pdfs' has no attribute 'SUBPROJECT_D_HASH_PRUNE_VERSION'`.
+
+- [ ] **Step 3a: Add the version constant**
+
+In `generate_weekly_pdfs.py`, immediately after the `VAC_CREW_HASH_PRUNE_VERSION = 1` line (~line 325), add:
+
+```python
+# Subproject D (2026-05-25): one-time hash-history prune version for
+# dropping LEGACY blank-identifier `primary` orphans left behind when
+# D re-partitions the production primary variant by frozen primary
+# claimer. Separate sentinel (`_subproject_d_prune_version`) from
+# Phase 1.1, Subproject B, and Subproject C so all four migrations are
+# independent + auditable. Advancing this constant is the kill switch
+# (re-run trigger).
+SUBPROJECT_D_HASH_PRUNE_VERSION = 1
+```
+
+- [ ] **Step 3b: Add the two env vars**
+
+In `generate_weekly_pdfs.py`, immediately after the `VAC_CREW_LEGACY_CLEANUP_ENABLED = os.getenv(...)` block ends (~line 552, before the `# Cutoff date for _AEPBillable` comment ~line 554), add:
+
+```python
+# Subproject D (2026-05-25): default-ON kill switch that enables
+# per-claimer partitioning of the PRODUCTION primary Excel files. When
+# enabled, each non-subcontractor primary Excel is partitioned by the
+# FROZEN primary foreman (``primary`` role from
+# ``billing_audit.attribution_snapshot`` via ``resolve_claimer``) and
+# named ``_User_<claimer>``. When disabled, the legacy one-file-per-WR
+# bare primary behavior is preserved exactly. Unlike Subproject B, the
+# core primary path NEVER holds on a Supabase outage — it falls back to
+# the current foreman and still generates (operator decision: this path
+# covers every non-sub WR, so HOLD would suppress all primary billing
+# during an outage). Pinned in workflow env: block per [2026-05-15
+# 12:00] rule 7.
+PRIMARY_CLAIM_ATTRIBUTION_ENABLED = os.getenv(
+    'PRIMARY_CLAIM_ATTRIBUTION_ENABLED', '1'
+).strip().lower() in ('1', 'true', 'yes', 'on')
+
+# Subproject D (2026-05-25): default-ON kill switch for the one-time
+# removal of legacy UNPARTITIONED bare ``primary`` attachments (no
+# ``_User_`` token, parsed identifier == '') on TARGET_SHEET_ID for
+# non-subcontractor WRs, once those files are re-partitioned by frozen
+# primary claimer. Set to '0' to skip the destructive cleanup (legacy
+# duplicates then persist until removed manually). Separate from
+# PRIMARY_CLAIM_ATTRIBUTION_ENABLED (which gates attribution
+# resolution, NOT this cleanup). Workflow-pinned per [2026-05-15
+# 12:00] rule 7.
+LEGACY_PRIMARY_PARTITION_CLEANUP_ENABLED = os.getenv(
+    'LEGACY_PRIMARY_PARTITION_CLEANUP_ENABLED', '1'
+).strip().lower() in ('1', 'true', 'yes', 'on')
+```
+
+- [ ] **Step 3c: Add the startup banner logs**
+
+In `generate_weekly_pdfs.py`, find the Subproject C banner block (the `logging.info(...)` that prints `📋 VAC_CREW_*` ~line 714) and add AFTER that block:
+
+```python
+# Subproject D: surface resolved kill-switch state at startup so
+# operators grepping the banner see the active feature state at a
+# glance. Banner body carries no row PII (just the resolved bools).
+logging.info(
+    f"📋 PRIMARY_CLAIM_ATTRIBUTION_ENABLED="
+    f"{PRIMARY_CLAIM_ATTRIBUTION_ENABLED}"
+)
+logging.info(
+    f"📋 LEGACY_PRIMARY_PARTITION_CLEANUP_ENABLED="
+    f"{LEGACY_PRIMARY_PARTITION_CLEANUP_ENABLED}"
+)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_primary_claim_attribution.py::TestConfigConstants -v`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Syntax check + commit**
+
+```bash
+python -m py_compile generate_weekly_pdfs.py
+git add generate_weekly_pdfs.py tests/test_primary_claim_attribution.py
+git commit -m "feat(billing): Subproject D config — primary claim attribution kill switches"
+```
+
+---
+
+## Task 2: `generate_excel` — emit `_User_<claimer>` filename suffix for primary variant
+
+This is the surface that produces the per-claimer filename. Without it, all of a WR's per-claimer primary groups generate to the SAME bare filename and collide.
+
+**Files:**
+- Modify: `generate_weekly_pdfs.py` (the `elif variant == 'primary':` filename-suffix branch ~line 6221-6223)
+- Test: `tests/test_primary_claim_attribution.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_primary_claim_attribution.py`:
+
+```python
+class TestPrimaryFilenameSuffix(unittest.TestCase):
+    """Task 2: generate_excel emits _User_<claimer> for primary variant
+    when attribution is enabled, bare otherwise."""
+
+    def setUp(self):
+        self._orig = gwp.PRIMARY_CLAIM_ATTRIBUTION_ENABLED
+
+    def tearDown(self):
+        gwp.PRIMARY_CLAIM_ATTRIBUTION_ENABLED = self._orig
+
+    def _suffix_for(self, enabled, current_foreman):
+        # Drive the suffix branch in isolation by reading the source and
+        # confirming the gated construction exists (the branch lives deep
+        # inside generate_excel; a source-level assertion is the reliable
+        # unit check, paired with the E2E filename test in Task 4).
+        src = inspect.getsource(generate_weekly_pdfs)
+        return src
+
+    def test_primary_branch_builds_user_suffix_gated(self):
+        src = inspect.getsource(generate_weekly_pdfs)
+        # The primary branch must build _User_<sanitized claimer> gated on
+        # the kill switch + a non-empty __current_foreman.
+        self.assertIn("_User_", src)
+        # Confirm the gate wording is present in the primary suffix branch.
+        self.assertRegex(
+            src,
+            r"PRIMARY_CLAIM_ATTRIBUTION_ENABLED and _pf"
+            r"[\s\S]{0,200}_User_\{",
+        )
+```
+
+> Note: the deep-nested `generate_excel` suffix branch is verified here by source assertion; the *behavioral* round-trip (filename actually contains `_User_<claimer>` and parses back) is covered end-to-end in Task 4 Step 1's `test_two_claimers_distinct_filenames` and Task 11's parser round-trip.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_primary_claim_attribution.py::TestPrimaryFilenameSuffix -v`
+Expected: FAIL — the regex `PRIMARY_CLAIM_ATTRIBUTION_ENABLED and _pf ... _User_{` is not yet present.
+
+- [ ] **Step 3: Replace the primary suffix branch**
+
+In `generate_weekly_pdfs.py`, find:
+
+```python
+    elif variant == 'primary':
+        # Primary variant (no suffix needed)
+        variant_suffix = ''
+```
+
+Replace with:
+
+```python
+    elif variant == 'primary':
+        # Subproject D (2026-05-25): partition the production primary
+        # file by the FROZEN primary claimer (__current_foreman is the
+        # resolved claimer set in group_source_rows' emission tuple).
+        # GATED on the kill switch (mirrors the vac_crew branch above):
+        #   • Enabled + claimer present -> _User_<sanitized claimer> so
+        #     each claimer's file is distinct and round-trips through
+        #     build_group_identity as ('primary', wr, week, claimer).
+        #   • Disabled (or no claimer) -> exact legacy bare suffix '',
+        #     preserving byte-identical filenames with pre-D attachments.
+        # __current_foreman in disabled mode is effective_user (the
+        # emission passes None -> `current_foreman or effective_user`),
+        # but the kill-switch gate keeps the suffix bare in that case.
+        _pf = first_row.get('__current_foreman', '')
+        if PRIMARY_CLAIM_ATTRIBUTION_ENABLED and _pf:
+            variant_suffix = (
+                f"_User_{_RE_SANITIZE_IDENTIFIER.sub('_', _pf)[:50]}"
+            )
+        else:
+            variant_suffix = ''
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_primary_claim_attribution.py::TestPrimaryFilenameSuffix -v`
+Expected: PASS.
+
+- [ ] **Step 5: Syntax check + commit**
+
+```bash
+python -m py_compile generate_weekly_pdfs.py
+git add generate_weekly_pdfs.py tests/test_primary_claim_attribution.py
+git commit -m "feat(billing): Subproject D — _User_<claimer> primary filename suffix"
+```
+
+---
+
+## Task 3: Pre-pass — `_primary_claimer_map` in `group_source_rows`
+
+**Files:**
+- Modify: `generate_weekly_pdfs.py` (after the Subproject C vac-crew pre-pass block, which ends ~line 5144, just before `for r in rows:`)
+- Test: `tests/test_primary_claim_attribution.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_primary_claim_attribution.py`:
+
+```python
+def _make_primary_row(
+    row_id,
+    wr='90001',
+    week_serial=46100,  # arbitrary Excel serial -> a real date
+    effective_user='CurrentForeman',
+    source_sheet_id=99999,  # NOT in _FOLDER_DISCOVERED_SUB_IDS
+):
+    """Build a synthetic NON-subcontractor, completed, non-helper,
+    non-vac primary row for group_source_rows."""
+    return {
+        '__row_id': row_id,
+        '__source_sheet_id': source_sheet_id,
+        '__effective_user': effective_user,
+        '__is_helper_row': False,
+        '__is_vac_crew': False,
+        'Work Request #': wr,
+        'Weekly Reference Logged Date': week_serial,
+        'Units Completed?': True,
+        'Units Total Price': 100.0,
+        'Dept #': '500',
+        'Job #': 'J-1',
+    }
+
+
+class TestPrimaryPrePass(unittest.TestCase):
+    """Task 3: the pre-pass resolves frozen claimers for non-sub
+    completed primary rows into _primary_claimer_map."""
+
+    def setUp(self):
+        _ensure_smartsheet_mocked()
+        _reset_all()
+        self._saved = {
+            'attr': gwp.PRIMARY_CLAIM_ATTRIBUTION_ENABLED,
+            'avail': gwp.BILLING_AUDIT_AVAILABLE,
+            'mode': gwp.RES_GROUPING_MODE,
+            'sub': set(gwp._FOLDER_DISCOVERED_SUB_IDS),
+        }
+        gwp.PRIMARY_CLAIM_ATTRIBUTION_ENABLED = True
+        gwp.BILLING_AUDIT_AVAILABLE = True
+        gwp.RES_GROUPING_MODE = 'both'
+        gwp._FOLDER_DISCOVERED_SUB_IDS.clear()  # row sheet 99999 is non-sub
+
+    def tearDown(self):
+        gwp.PRIMARY_CLAIM_ATTRIBUTION_ENABLED = self._saved['attr']
+        gwp.BILLING_AUDIT_AVAILABLE = self._saved['avail']
+        gwp.RES_GROUPING_MODE = self._saved['mode']
+        gwp._FOLDER_DISCOVERED_SUB_IDS.clear()
+        gwp._FOLDER_DISCOVERED_SUB_IDS.update(self._saved['sub'])
+
+    def test_prepass_resolves_frozen_claimer_into_group_key(self):
+        rows = [_make_primary_row(1001, effective_user='CurrentFM')]
+        with mock.patch(
+            'billing_audit.writer.resolve_claimer',
+            return_value=ResolveOutcome('use', 'FrozenFM', 'frozen', 'success'),
+        ):
+            groups = gwp.group_source_rows(rows)
+        keys = list(groups.keys())
+        self.assertTrue(
+            any(k.endswith('_USER_FrozenFM') for k in keys),
+            f"expected a _USER_FrozenFM primary group, got {keys}",
+        )
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_primary_claim_attribution.py::TestPrimaryPrePass -v`
+Expected: FAIL — no `_USER_FrozenFM` key (emission not partitioned yet; the pre-pass map isn't built/consumed).
+
+> This test exercises Task 3 (pre-pass) AND Task 4 (emission) together. It will fully pass only after Task 4. After Task 3 alone, it still fails (emission unchanged), which is expected — keep it red until Task 4. To confirm Task 3 in isolation, add the source-grep assertion below.
+
+- [ ] **Step 3: Implement the pre-pass**
+
+In `generate_weekly_pdfs.py`, immediately AFTER the Subproject C vac-crew pre-pass block (the one ending with `_vac_crew_claimer_map = {}` in its outer `except`, ~line 5144) and BEFORE `for r in rows:`, add:
+
+```python
+    # Subproject D (2026-05-25): resolve the FROZEN primary claimer for
+    # every completed NON-subcontractor, non-vac primary row BEFORE the
+    # grouping loop, so no per-row Supabase round-trip runs inside the
+    # hot loop (honors [2026-04-25 14:00] latency lesson). The map is
+    # keyed by __row_id and consumed by the production primary emission
+    # branch. A row absent from the map (attribution disabled, pre-pass
+    # skipped, missing __row_id, or unexpected per-row error) resolves to
+    # use-current at emission. Unlike B/C, a ``hold`` outcome (Supabase
+    # outage) is ALSO consumed as use-current at emission — D never
+    # defers a primary file (operator decision: the core path prioritizes
+    # availability). resolve_claimer is still called so frozen attribution
+    # is used whenever Supabase is healthy.
+    _primary_claimer_map: dict = {}
+    if BILLING_AUDIT_AVAILABLE and PRIMARY_CLAIM_ATTRIBUTION_ENABLED:
+        _d_pre_rows = []
+        for _r in rows:
+            _rid = _r.get('__row_id')
+            if not isinstance(_rid, int):
+                continue
+            if _r.get('__is_vac_crew'):
+                continue
+            _sid = _r.get('__source_sheet_id')
+            if _sid is not None and _sid in _FOLDER_DISCOVERED_SUB_IDS:
+                continue  # subcontractor rows are Sub-project B's domain
+            _wr_raw = _r.get('Work Request #')
+            _ld = _r.get('Weekly Reference Logged Date')
+            if not _wr_raw or not _ld or not is_checked(_r.get('Units Completed?')):
+                continue
+            _we = excel_serial_to_date(_ld)
+            if _we is None:
+                continue
+            _d_pre_rows.append((
+                _rid,
+                str(_wr_raw).split('.')[0],
+                _we.date() if isinstance(_we, datetime.datetime) else _we,
+                _r.get('__effective_user', 'Unknown Foreman'),
+            ))
+        if _d_pre_rows:
+            try:
+                from billing_audit.writer import resolve_claimer as _resolve_claimer_primary
+
+                def _resolve_one_primary(_item):
+                    _rid, _wr, _we_date, _eu = _item
+                    return _rid, _resolve_claimer_primary(
+                        'primary', _eu,
+                        wr=_wr, week_ending=_we_date, row_id=_rid,
+                        enabled=PRIMARY_CLAIM_ATTRIBUTION_ENABLED,
+                    )
+
+                if len(_d_pre_rows) <= 1:
+                    for _item in _d_pre_rows:
+                        _rid, _out = _resolve_one_primary(_item)
+                        _primary_claimer_map[_rid] = _out
+                else:
+                    _workers = min(PARALLEL_WORKERS, len(_d_pre_rows))
+                    with ThreadPoolExecutor(max_workers=_workers) as _ex:
+                        _futs = [_ex.submit(_resolve_one_primary, _it) for _it in _d_pre_rows]
+                        for _fut in as_completed(_futs):
+                            try:
+                                _rid, _out = _fut.result()
+                                _primary_claimer_map[_rid] = _out
+                            except Exception:
+                                logging.exception(
+                                    "⚠️ Subproject D attribution pre-pass: "
+                                    "unexpected error for one row (treating "
+                                    "as use-current)"
+                                )
+            except Exception:
+                logging.exception(
+                    "⚠️ Subproject D attribution pre-pass failed; falling "
+                    "back to current foreman for all primary rows"
+                )
+                _primary_claimer_map = {}
+```
+
+- [ ] **Step 4: Add a source-grep confirmation for Task 3 (keeps Task 3 verifiable before Task 4)**
+
+Append to `tests/test_primary_claim_attribution.py`:
+
+```python
+class TestPrimaryPrePassSource(unittest.TestCase):
+    """Task 3: the pre-pass exists with the right shape."""
+
+    def test_prepass_block_present(self):
+        src = inspect.getsource(generate_weekly_pdfs)
+        self.assertIn("_primary_claimer_map", src)
+        self.assertRegex(
+            src,
+            r"resolve_claimer_primary\(\s*'primary'",
+        )
+        # Pre-pass must exclude subcontractor + vac rows.
+        self.assertRegex(
+            src,
+            r"_primary_claimer_map[\s\S]{0,600}_FOLDER_DISCOVERED_SUB_IDS",
+        )
+```
+
+- [ ] **Step 5: Run + commit**
+
+Run: `pytest tests/test_primary_claim_attribution.py::TestPrimaryPrePassSource -v`
+Expected: PASS.
+(`TestPrimaryPrePass::test_prepass_resolves_frozen_claimer_into_group_key` stays RED until Task 4.)
+
+```bash
+python -m py_compile generate_weekly_pdfs.py
+git add generate_weekly_pdfs.py tests/test_primary_claim_attribution.py
+git commit -m "feat(billing): Subproject D — primary claimer attribution pre-pass"
+```
+
+---
+
+## Task 4: Emission — partition the production primary key by claimer
+
+**Files:**
+- Modify: `generate_weekly_pdfs.py` (the production primary emission branch ~line 5303-5305)
+- Test: `tests/test_primary_claim_attribution.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_primary_claim_attribution.py`:
+
+```python
+class TestPrimaryEmission(unittest.TestCase):
+    """Task 4: production primary emission partitions by claimer when on,
+    bare when off; never holds."""
+
+    def setUp(self):
+        _ensure_smartsheet_mocked()
+        _reset_all()
+        self._saved = {
+            'attr': gwp.PRIMARY_CLAIM_ATTRIBUTION_ENABLED,
+            'avail': gwp.BILLING_AUDIT_AVAILABLE,
+            'mode': gwp.RES_GROUPING_MODE,
+            'sub': set(gwp._FOLDER_DISCOVERED_SUB_IDS),
+        }
+        gwp.PRIMARY_CLAIM_ATTRIBUTION_ENABLED = True
+        gwp.BILLING_AUDIT_AVAILABLE = True
+        gwp.RES_GROUPING_MODE = 'both'
+        gwp._FOLDER_DISCOVERED_SUB_IDS.clear()
+
+    def tearDown(self):
+        gwp.PRIMARY_CLAIM_ATTRIBUTION_ENABLED = self._saved['attr']
+        gwp.BILLING_AUDIT_AVAILABLE = self._saved['avail']
+        gwp.RES_GROUPING_MODE = self._saved['mode']
+        gwp._FOLDER_DISCOVERED_SUB_IDS.clear()
+        gwp._FOLDER_DISCOVERED_SUB_IDS.update(self._saved['sub'])
+
+    def test_frozen_claimer_partitions_key(self):
+        rows = [_make_primary_row(1, effective_user='CurFM')]
+        with mock.patch(
+            'billing_audit.writer.resolve_claimer',
+            return_value=ResolveOutcome('use', 'FrozenFM', 'frozen', 'success'),
+        ):
+            groups = gwp.group_source_rows(rows)
+        self.assertTrue(any(k.endswith('_USER_FrozenFM') for k in groups))
+        # The legacy bare primary key must NOT be present.
+        self.assertFalse(
+            any(k.split('_USER_')[0] == k and '_USER_' not in k
+                and k.count('_') == 1 for k in groups),
+        )
+
+    def test_two_claimers_two_groups(self):
+        rows = [
+            _make_primary_row(1, wr='90001', effective_user='A'),
+            _make_primary_row(2, wr='90001', effective_user='B'),
+        ]
+
+        def _resolve(variant, current, *, wr, week_ending, row_id, enabled):
+            return ResolveOutcome(
+                'use', 'Alice' if row_id == 1 else 'Bob', 'frozen', 'success'
+            )
+
+        with mock.patch('billing_audit.writer.resolve_claimer', side_effect=_resolve):
+            groups = gwp.group_source_rows(rows)
+        self.assertTrue(any(k.endswith('_USER_Alice') for k in groups))
+        self.assertTrue(any(k.endswith('_USER_Bob') for k in groups))
+
+    def test_no_history_falls_back_to_current(self):
+        rows = [_make_primary_row(1, effective_user='CurFM')]
+        with mock.patch(
+            'billing_audit.writer.resolve_claimer',
+            return_value=ResolveOutcome('use', 'CurFM', 'current', 'no_history'),
+        ):
+            groups = gwp.group_source_rows(rows)
+        self.assertTrue(any(k.endswith('_USER_CurFM') for k in groups))
+
+    def test_hold_outage_still_emits_under_current(self):
+        rows = [_make_primary_row(1, effective_user='CurFM')]
+        with mock.patch(
+            'billing_audit.writer.resolve_claimer',
+            return_value=ResolveOutcome('hold', None, None, 'fetch_failure'),
+        ), mock.patch(
+            'billing_audit.writer.record_attribution_hold'
+        ) as _rec:
+            groups = gwp.group_source_rows(rows)
+        # D never holds: a primary group IS emitted under current foreman.
+        self.assertTrue(any(k.endswith('_USER_CurFM') for k in groups))
+        # And record_attribution_hold is NEVER called for the primary path.
+        _rec.assert_not_called()
+
+    def test_kill_switch_off_emits_bare_legacy_key(self):
+        gwp.PRIMARY_CLAIM_ATTRIBUTION_ENABLED = False
+        rows = [_make_primary_row(1, wr='90001', effective_user='CurFM')]
+        # No mock needed — pre-pass is gated off, emission is legacy.
+        groups = gwp.group_source_rows(rows)
+        bare = [k for k in groups if '_USER_' not in k]
+        self.assertTrue(bare, f"expected a bare primary key, got {list(groups)}")
+        # bare key shape is {week}_{wr}
+        self.assertTrue(any(k.endswith('_90001') for k in bare))
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `pytest tests/test_primary_claim_attribution.py::TestPrimaryEmission -v`
+Expected: the ON tests FAIL (no `_USER_` keys yet); `test_kill_switch_off_emits_bare_legacy_key` PASSES already (legacy path unchanged).
+
+- [ ] **Step 3: Modify the emission branch**
+
+In `generate_weekly_pdfs.py`, find the production primary emission (inside `elif RES_GROUPING_MODE in ('helper', 'both'):`):
+
+```python
+                    if not is_subcontractor_row and not valid_helper_row:
+                        primary_key = f"{week_end_for_key}_{wr_key}"
+                        keys_to_add.append(('primary', primary_key, None))
+```
+
+Replace with:
+
+```python
+                    if not is_subcontractor_row and not valid_helper_row:
+                        # Subproject D (2026-05-25): partition the
+                        # production primary file by the FROZEN primary
+                        # claimer. Consume the pre-pass map. ``use`` ->
+                        # partition by claimer; ``hold`` (Supabase outage),
+                        # map miss, or disabled -> use the current
+                        # effective_user and STILL emit (D never holds —
+                        # operator decision for the core path). Empty
+                        # claimer -> 'Unknown Foreman' sentinel so the
+                        # _User_ suffix builder never gets an empty
+                        # identifier (mirrors B's Codex-P1 fix).
+                        if PRIMARY_CLAIM_ATTRIBUTION_ENABLED:
+                            _d_outcome = _primary_claimer_map.get(r.get('__row_id'))
+                            if _d_outcome is not None and _d_outcome.action == 'use':
+                                _d_claimer = (
+                                    _d_outcome.name or effective_user or 'Unknown Foreman'
+                                )
+                            else:
+                                # hold / map-miss / disabled / None -> current.
+                                _d_claimer = effective_user or 'Unknown Foreman'
+                            _d_claimer_sanitized = _RE_SANITIZE_IDENTIFIER.sub(
+                                '_', _d_claimer
+                            )[:50]
+                            primary_key = (
+                                f"{week_end_for_key}_{wr_key}_USER_"
+                                f"{_d_claimer_sanitized}"
+                            )
+                            keys_to_add.append(('primary', primary_key, _d_claimer))
+                            if primary_key not in groups:
+                                logging.info(
+                                    f"🧑 PRIMARY GROUP CREATED: WR={wr_key}, "
+                                    f"Week={week_end_for_key}"
+                                )
+                        else:
+                            # Kill switch OFF -> exact legacy bare primary.
+                            primary_key = f"{week_end_for_key}_{wr_key}"
+                            keys_to_add.append(('primary', primary_key, None))
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `pytest tests/test_primary_claim_attribution.py::TestPrimaryEmission tests/test_primary_claim_attribution.py::TestPrimaryPrePass -v`
+Expected: PASS (all TestPrimaryEmission + the previously-red TestPrimaryPrePass test).
+
+- [ ] **Step 5: Add a two-claimer distinct-filename E2E (round-trip) test**
+
+Append to `tests/test_primary_claim_attribution.py`:
+
+```python
+class TestPrimaryFilenameRoundTrip(unittest.TestCase):
+    """Task 2+4: two claimers on one WR+week produce two distinct
+    _User_ filenames that round-trip through build_group_identity as
+    distinct primary identities (coexistence; no cross-delete)."""
+
+    def test_distinct_identities_for_two_claimers(self):
+        a = gwp.build_group_identity(
+            "WR_90001_WeekEnding_041926_120000_User_Alice_abcdef0123456789.xlsx"
+        )
+        b = gwp.build_group_identity(
+            "WR_90001_WeekEnding_041926_120000_User_Bob_abcdef0123456789.xlsx"
+        )
+        self.assertEqual(a, ('90001', '041926', 'primary', 'Alice'))
+        self.assertEqual(b, ('90001', '041926', 'primary', 'Bob'))
+        self.assertNotEqual(a, b)  # distinct -> cleanup keeps both
+```
+
+- [ ] **Step 6: Run + commit**
+
+Run: `pytest tests/test_primary_claim_attribution.py -v`
+Expected: PASS.
+
+```bash
+python -m py_compile generate_weekly_pdfs.py
+git add generate_weekly_pdfs.py tests/test_primary_claim_attribution.py
+git commit -m "feat(billing): Subproject D — partition production primary by frozen claimer"
+```
+
+---
+
+## Task 5: Site (a) — main-loop identity (`history_key` / `file_identifier`)
+
+**Files:**
+- Modify: `generate_weekly_pdfs.py` (the primary `else` branch of the variant identity cascade ~line 8051-8057)
+- Test: `tests/test_primary_claim_attribution.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_primary_claim_attribution.py`:
+
+```python
+class TestSiteAMainLoopIdentity(unittest.TestCase):
+    """Task 5: main-loop primary identity derives from __current_foreman
+    when attribution is on (gated), legacy User field when off."""
+
+    def test_site_a_gated_primary_identity(self):
+        src = inspect.getsource(generate_weekly_pdfs)
+        # The primary identity branch must derive from __current_foreman
+        # gated on PRIMARY_CLAIM_ATTRIBUTION_ENABLED, and keep the legacy
+        # User-field path for the disabled case.
+        self.assertRegex(
+            src,
+            r"PRIMARY_CLAIM_ATTRIBUTION_ENABLED[\s\S]{0,300}"
+            r"__current_foreman[\s\S]{0,300}"
+            r"first_row\.get\('User'\)",
+        )
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pytest tests/test_primary_claim_attribution.py::TestSiteAMainLoopIdentity -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Modify the main-loop primary identity branch**
+
+In `generate_weekly_pdfs.py`, find the `else` branch (~line 8051):
+
+```python
+                else:
+                    # Legacy primary variant: identifier derived from the
+                    # row's ``User`` field.
+                    user_val = first_row.get('User')
+                    # PERFORMANCE: Use pre-compiled regex for identifier sanitization
+                    identifier = _RE_SANITIZE_IDENTIFIER.sub('_', user_val)[:50] if user_val else ''
+                    file_identifier = identifier
+```
+
+Replace with:
+
+```python
+                else:
+                    # Subproject D (2026-05-25): primary identity site
+                    # (Site 1 — main-loop identifier / history_key /
+                    # file_identifier). GATED on the kill switch (mirrors
+                    # the reduced_sub / vac_crew sites above): enabled mode
+                    # derives identifier == file_identifier from the FROZEN
+                    # claimer (__current_foreman, the partition key set in
+                    # group_source_rows' emission tuple) so the round-trip
+                    # with the _User_<claimer> filename + Sites 2 & 3
+                    # succeeds. Disabled mode preserves the EXACT legacy
+                    # ``User``-field path (identifier '' in production
+                    # because the User column is unpopulated) so a bare
+                    # primary attachment is not treated as stale.
+                    if PRIMARY_CLAIM_ATTRIBUTION_ENABLED:
+                        _pf = first_row.get('__current_foreman', '')
+                        identifier = (
+                            _RE_SANITIZE_IDENTIFIER.sub('_', _pf)[:50]
+                            if _pf else ''
+                        )
+                        file_identifier = identifier
+                    else:
+                        # Legacy primary variant: identifier derived from
+                        # the row's ``User`` field.
+                        user_val = first_row.get('User')
+                        # PERFORMANCE: Use pre-compiled regex for identifier sanitization
+                        identifier = _RE_SANITIZE_IDENTIFIER.sub('_', user_val)[:50] if user_val else ''
+                        file_identifier = identifier
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `pytest tests/test_primary_claim_attribution.py::TestSiteAMainLoopIdentity -v`
+Expected: PASS.
+
+- [ ] **Step 5: Syntax check + commit**
+
+```bash
+python -m py_compile generate_weekly_pdfs.py
+git add generate_weekly_pdfs.py tests/test_primary_claim_attribution.py
+git commit -m "feat(billing): Subproject D — Site 1 main-loop primary identity"
+```
+
+---
+
+## Task 6: Sites (b) `valid_wr_weeks` + (c) `current_keys`
+
+**Files:**
+- Modify: `generate_weekly_pdfs.py` (the `else` branch of the `valid_wr_weeks` builder ~line 8782-8785, and the `else` branch of the `current_keys` builder ~line 9010-9012)
+- Test: `tests/test_primary_claim_attribution.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_primary_claim_attribution.py`:
+
+```python
+class TestSitesBCIdentity(unittest.TestCase):
+    """Task 6: valid_wr_weeks (Site 2) and current_keys (Site 3) primary
+    branches derive from __current_foreman gated on the kill switch."""
+
+    def test_sites_b_and_c_gated_primary_identity(self):
+        src = inspect.getsource(generate_weekly_pdfs)
+        # Site 2 (valid_wr_weeks builder): the else branch builds file_id
+        # from __current_foreman gated on PRIMARY_CLAIM_ATTRIBUTION_ENABLED.
+        self.assertRegex(
+            src,
+            r"file_id = \(\s*_RE_SANITIZE_IDENTIFIER\.sub\('_', _pf\)\[:50\]"
+            r"\s*if \(PRIMARY_CLAIM_ATTRIBUTION_ENABLED and _pf\)",
+        )
+        # Site 3 (current_keys builder): the else branch builds _ident
+        # from __current_foreman gated on PRIMARY_CLAIM_ATTRIBUTION_ENABLED.
+        self.assertRegex(
+            src,
+            r"_ident = \(\s*_RE_SANITIZE_IDENTIFIER\.sub\('_', _pf\)\[:50\]"
+            r"\s*if \(PRIMARY_CLAIM_ATTRIBUTION_ENABLED and _pf\)",
+        )
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pytest tests/test_primary_claim_attribution.py::TestSitesBCIdentity -v`
+Expected: FAIL.
+
+- [ ] **Step 3a: Modify Site (b) — `valid_wr_weeks` else branch**
+
+In `generate_weekly_pdfs.py`, find (~line 8782):
+
+```python
+                else:
+                    user_val = group_rows[0].get('User')
+                    # PERFORMANCE: Use pre-compiled regex
+                    file_id = _RE_SANITIZE_IDENTIFIER.sub('_', user_val)[:50] if user_val else ''
+                valid_wr_weeks.add((wr, week_raw, variant, file_id))
+```
+
+Replace with:
+
+```python
+                else:
+                    # Subproject D (2026-05-25): primary identity site
+                    # (Site 2 — valid_wr_weeks). Mirror Site 1 so attachment
+                    # cleanup keeps the live per-claimer primary file.
+                    # Disabled mode preserves the legacy ``User``-field path.
+                    if PRIMARY_CLAIM_ATTRIBUTION_ENABLED:
+                        _pf = group_rows[0].get('__current_foreman', '')
+                        file_id = (
+                            _RE_SANITIZE_IDENTIFIER.sub('_', _pf)[:50]
+                            if (PRIMARY_CLAIM_ATTRIBUTION_ENABLED and _pf) else ''
+                        )
+                    else:
+                        user_val = group_rows[0].get('User')
+                        # PERFORMANCE: Use pre-compiled regex
+                        file_id = _RE_SANITIZE_IDENTIFIER.sub('_', user_val)[:50] if user_val else ''
+                valid_wr_weeks.add((wr, week_raw, variant, file_id))
+```
+
+- [ ] **Step 3b: Modify Site (c) — `current_keys` else branch**
+
+In `generate_weekly_pdfs.py`, find (~line 9010):
+
+```python
+                        else:
+                            _uv = group_rows[0].get('User')
+                            _ident = _RE_SANITIZE_IDENTIFIER.sub('_', _uv)[:50] if _uv else ''
+                        current_keys.add(f"{_wr}|{_week}|{_variant}|{_ident}")
+```
+
+Replace with:
+
+```python
+                        else:
+                            # Subproject D (2026-05-25): primary identity
+                            # site (Site 3 — current_keys). Must match the
+                            # history_key written at Site 1 byte-for-byte
+                            # (sanitized claimer when on, legacy User-field
+                            # when off) or the freshly-written entry is
+                            # treated as stale and deleted before save.
+                            if PRIMARY_CLAIM_ATTRIBUTION_ENABLED:
+                                _pf = group_rows[0].get('__current_foreman', '')
+                                _ident = (
+                                    _RE_SANITIZE_IDENTIFIER.sub('_', _pf)[:50]
+                                    if (PRIMARY_CLAIM_ATTRIBUTION_ENABLED and _pf) else ''
+                                )
+                            else:
+                                _uv = group_rows[0].get('User')
+                                _ident = _RE_SANITIZE_IDENTIFIER.sub('_', _uv)[:50] if _uv else ''
+                        current_keys.add(f"{_wr}|{_week}|{_variant}|{_ident}")
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `pytest tests/test_primary_claim_attribution.py::TestSitesBCIdentity -v`
+Expected: PASS.
+
+- [ ] **Step 5: Syntax check + commit**
+
+```bash
+python -m py_compile generate_weekly_pdfs.py
+git add generate_weekly_pdfs.py tests/test_primary_claim_attribution.py
+git commit -m "feat(billing): Subproject D — Sites 2 & 3 primary identity lockstep"
+```
+
+---
+
+## Task 7: WR_FILTER matcher — add `_USER_` clause to `_key_matches_wr`
+
+**Files:**
+- Modify: `generate_weekly_pdfs.py` (`_key_matches_wr` return expression ~line 5833-5846)
+- Test: `tests/test_primary_claim_attribution.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_primary_claim_attribution.py`:
+
+```python
+class TestWrFilterMatchesUserVariant(unittest.TestCase):
+    """Task 7: WR_FILTER (_key_matches_wr) retains _USER_ primary groups;
+    EXCLUDE_WRS (_key_matches_excluded_wr) already does."""
+
+    def setUp(self):
+        _ensure_smartsheet_mocked()
+        _reset_all()
+        self._saved = {
+            'attr': gwp.PRIMARY_CLAIM_ATTRIBUTION_ENABLED,
+            'avail': gwp.BILLING_AUDIT_AVAILABLE,
+            'mode': gwp.RES_GROUPING_MODE,
+            'sub': set(gwp._FOLDER_DISCOVERED_SUB_IDS),
+            'tm': gwp.TEST_MODE,
+            'wf': list(gwp.WR_FILTER),
+            'ex': list(gwp.EXCLUDE_WRS),
+        }
+        gwp.PRIMARY_CLAIM_ATTRIBUTION_ENABLED = True
+        gwp.BILLING_AUDIT_AVAILABLE = True
+        gwp.RES_GROUPING_MODE = 'both'
+        gwp._FOLDER_DISCOVERED_SUB_IDS.clear()
+
+    def tearDown(self):
+        gwp.PRIMARY_CLAIM_ATTRIBUTION_ENABLED = self._saved['attr']
+        gwp.BILLING_AUDIT_AVAILABLE = self._saved['avail']
+        gwp.RES_GROUPING_MODE = self._saved['mode']
+        gwp._FOLDER_DISCOVERED_SUB_IDS.clear()
+        gwp._FOLDER_DISCOVERED_SUB_IDS.update(self._saved['sub'])
+        gwp.TEST_MODE = self._saved['tm']
+        gwp.WR_FILTER = self._saved['wf']
+        gwp.EXCLUDE_WRS = self._saved['ex']
+
+    def test_wr_filter_retains_user_primary_group(self):
+        gwp.TEST_MODE = True
+        gwp.WR_FILTER = ['90001']
+        rows = [_make_primary_row(1, wr='90001', effective_user='CurFM')]
+        with mock.patch(
+            'billing_audit.writer.resolve_claimer',
+            return_value=ResolveOutcome('use', 'FrozenFM', 'frozen', 'success'),
+        ):
+            groups = gwp.group_source_rows(rows)
+        self.assertTrue(
+            any(k.endswith('_USER_FrozenFM') for k in groups),
+            f"WR_FILTER dropped the _USER_ primary group: {list(groups)}",
+        )
+
+    def test_exclude_wrs_drops_user_primary_group(self):
+        gwp.EXCLUDE_WRS = ['90001']
+        rows = [_make_primary_row(1, wr='90001', effective_user='CurFM')]
+        with mock.patch(
+            'billing_audit.writer.resolve_claimer',
+            return_value=ResolveOutcome('use', 'FrozenFM', 'frozen', 'success'),
+        ):
+            groups = gwp.group_source_rows(rows)
+        self.assertEqual(
+            [k for k in groups if k.endswith('_USER_FrozenFM')], [],
+            f"EXCLUDE_WRS failed to drop the _USER_ primary group: {list(groups)}",
+        )
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pytest tests/test_primary_claim_attribution.py::TestWrFilterMatchesUserVariant -v`
+Expected: `test_wr_filter_retains_user_primary_group` FAILS (matcher drops the `_USER_` group); `test_exclude_wrs_drops_user_primary_group` PASSES (exclude matcher already has the `_USER_` clause).
+
+- [ ] **Step 3: Add the `_USER_` clause to `_key_matches_wr`**
+
+In `generate_weekly_pdfs.py`, in `_key_matches_wr`'s return expression (~line 5833), find:
+
+```python
+            return (
+                suffix == wr
+                or suffix.startswith(f"{wr}_HELPER_")
+                or suffix == f"{wr}_VACCREW"
+                # Subproject C: per-claimer vac key {wr}_VACCREW_<claimer>
+                # (attribution on). Prefix-match so EXCLUDE_WRS / WR_FILTER
+                # cover both the legacy bare and the per-claimer shapes.
+                or suffix.startswith(f"{wr}_VACCREW_")
+                # Phase 1 subcontractor variants (REVIEW-CR-03).
+                or suffix == f"{wr}_REDUCEDSUB"
+                or suffix == f"{wr}_AEPBILLABLE"
+                or suffix.startswith(f"{wr}_REDUCEDSUB_HELPER_")
+                or suffix.startswith(f"{wr}_AEPBILLABLE_HELPER_")
+            )
+```
+
+Insert the `_USER_` clause after the `suffix == wr` line:
+
+```python
+            return (
+                suffix == wr
+                # Subproject D: per-claimer primary key {wr}_USER_<claimer>
+                # (attribution on). Mirror of the _key_matches_excluded_wr
+                # clause below — the two matchers MUST stay in sync.
+                or suffix.startswith(f"{wr}_USER_")
+                or suffix.startswith(f"{wr}_HELPER_")
+                or suffix == f"{wr}_VACCREW"
+                # Subproject C: per-claimer vac key {wr}_VACCREW_<claimer>
+                # (attribution on). Prefix-match so EXCLUDE_WRS / WR_FILTER
+                # cover both the legacy bare and the per-claimer shapes.
+                or suffix.startswith(f"{wr}_VACCREW_")
+                # Phase 1 subcontractor variants (REVIEW-CR-03).
+                or suffix == f"{wr}_REDUCEDSUB"
+                or suffix == f"{wr}_AEPBILLABLE"
+                or suffix.startswith(f"{wr}_REDUCEDSUB_HELPER_")
+                or suffix.startswith(f"{wr}_AEPBILLABLE_HELPER_")
+            )
+```
+
+> Also update the comment block above `_key_matches_wr` (the `# k format examples` list, ~line 5826) — change the parenthetical "minus the `_USER_` legacy clause, which has never been a WR_FILTER target" note to reflect that `_USER_` is now matched (Subproject D). Add a `MMDDYY_WR_USER_<name>  → primary (Subproject D)` line to the examples comment for both matchers if not already present.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `pytest tests/test_primary_claim_attribution.py::TestWrFilterMatchesUserVariant -v`
+Expected: PASS (both).
+
+- [ ] **Step 5: Syntax check + commit**
+
+```bash
+python -m py_compile generate_weekly_pdfs.py
+git add generate_weekly_pdfs.py tests/test_primary_claim_attribution.py
+git commit -m "feat(billing): Subproject D — WR_FILTER matcher covers _USER_ primary key"
+```
+
+---
+
+## Task 8: `_build_primary_wr_scope` helper
+
+**Files:**
+- Modify: `generate_weekly_pdfs.py` (new helper after `_build_vac_crew_wr_scope`, ~line 3303)
+- Test: `tests/test_primary_claim_attribution.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_primary_claim_attribution.py`:
+
+```python
+class TestBuildPrimaryWrScope(unittest.TestCase):
+    """Task 8: scope helper returns sanitized WRs with a partitioned
+    _USER_ primary group in this run."""
+
+    def test_scope_collects_partitioned_primary_wrs(self):
+        groups = {
+            '041926_90001_USER_Alice': [{'Work Request #': '90001'}],
+            '041926_90002_USER_Bob': [{'Work Request #': '90002'}],
+            '041926_90003_HELPER_Carol': [{'Work Request #': '90003'}],
+            '041926_90004_VACCREW_Dan': [{'Work Request #': '90004'}],
+            '041926_90005_REDUCEDSUB_USER_Eve': [{'Work Request #': '90005'}],
+            '041926_90006': [{'Work Request #': '90006'}],  # bare primary (OFF mode)
+        }
+        scope = gwp._build_primary_wr_scope(groups)
+        self.assertIn('90001', scope)
+        self.assertIn('90002', scope)
+        # Helper / vac / subcontractor / bare-primary groups are NOT scope.
+        self.assertNotIn('90003', scope)
+        self.assertNotIn('90004', scope)
+        self.assertNotIn('90005', scope)  # REDUCEDSUB_USER is B's, not D's
+        self.assertNotIn('90006', scope)
+
+    def test_empty_groups(self):
+        self.assertEqual(gwp._build_primary_wr_scope({}), set())
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pytest tests/test_primary_claim_attribution.py::TestBuildPrimaryWrScope -v`
+Expected: FAIL — `AttributeError: ... has no attribute '_build_primary_wr_scope'`.
+
+- [ ] **Step 3: Implement the helper**
+
+In `generate_weekly_pdfs.py`, immediately after the `_build_vac_crew_wr_scope` function ends (~line 3303, before `def _run_phase_1_1_hash_prune`), add:
+
+```python
+def _build_primary_wr_scope(groups: dict) -> set[str]:
+    """Return the set of sanitized WR tokens that have a partitioned
+    production-primary ``_USER_`` group in this run (Subproject D).
+
+    A group key is a partitioned primary iff it contains ``'_USER_'`` AND
+    is NOT a subcontractor primary variant (``'_REDUCEDSUB'`` /
+    ``'_AEPBILLABLE'`` — those carry ``_USER_`` too but are owned by
+    Subproject B and route through B's own scope/cleanup). Helper
+    (``_HELPER_``) and vac (``_VACCREW``) groups never match because they
+    do not contain ``_USER_``.
+
+    Shared by ``_run_subproject_d_hash_prune`` (hash-prune scope) and the
+    TARGET ``cleanup_untracked_sheet_attachments`` call site (bare-primary
+    migration scope). A single implementation prevents the scope-build
+    drift that the [2026-05-15 12:00] three-site invariant warns against.
+    """
+    _scope: set[str] = set()
+    for _key, _g_rows in groups.items():
+        if (
+            '_USER_' in _key
+            and '_REDUCEDSUB' not in _key
+            and '_AEPBILLABLE' not in _key
+            and _g_rows
+        ):
+            _g_wr_raw = _g_rows[0].get('Work Request #', '')
+            _g_wr = str(_g_wr_raw).split('.')[0]
+            _g_wr = _RE_SANITIZE_HELPER_NAME.sub('_', _g_wr)[:50]
+            if _g_wr:
+                _scope.add(_g_wr)
+    return _scope
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `pytest tests/test_primary_claim_attribution.py::TestBuildPrimaryWrScope -v`
+Expected: PASS.
+
+- [ ] **Step 5: Syntax check + commit**
+
+```bash
+python -m py_compile generate_weekly_pdfs.py
+git add generate_weekly_pdfs.py tests/test_primary_claim_attribution.py
+git commit -m "feat(billing): Subproject D — _build_primary_wr_scope helper"
+```
+
+---
+
+## Task 9: `_run_subproject_d_hash_prune` + wire into the prune call site
+
+**Files:**
+- Modify: `generate_weekly_pdfs.py` (new function after `_run_vac_crew_hash_prune` ~line 3589; call-site wiring ~line 7715)
+- Test: `tests/test_primary_claim_attribution.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_primary_claim_attribution.py`:
+
+```python
+class TestSubprojectDHashPrune(unittest.TestCase):
+    """Task 9: one-time prune of legacy bare-primary orphans, gated +
+    idempotent + migration-dirty bool."""
+
+    def setUp(self):
+        _ensure_smartsheet_mocked()
+        self._attr = gwp.PRIMARY_CLAIM_ATTRIBUTION_ENABLED
+        gwp.PRIMARY_CLAIM_ATTRIBUTION_ENABLED = True
+
+    def tearDown(self):
+        gwp.PRIMARY_CLAIM_ATTRIBUTION_ENABLED = self._attr
+
+    def _groups(self):
+        return {'041926_90001_USER_Alice': [{'Work Request #': '90001'}]}
+
+    def test_drops_bare_primary_orphan_for_in_scope_wr(self):
+        hist = {
+            '90001|041926|primary|': {'hash': 'x'},   # legacy bare orphan
+            '90001|041926|primary|Alice': {'hash': 'y'},  # new per-claimer (kept)
+            '90002|041926|primary|': {'hash': 'z'},   # out-of-scope (kept)
+        }
+        mutated = gwp._run_subproject_d_hash_prune(hist, self._groups())
+        self.assertTrue(mutated)
+        self.assertNotIn('90001|041926|primary|', hist)
+        self.assertIn('90001|041926|primary|Alice', hist)
+        self.assertIn('90002|041926|primary|', hist)
+        self.assertEqual(
+            hist['_subproject_d_prune_version'],
+            gwp.SUBPROJECT_D_HASH_PRUNE_VERSION,
+        )
+
+    def test_idempotent_second_run_is_noop(self):
+        hist = {'_subproject_d_prune_version': gwp.SUBPROJECT_D_HASH_PRUNE_VERSION}
+        mutated = gwp._run_subproject_d_hash_prune(hist, self._groups())
+        self.assertFalse(mutated)
+
+    def test_kill_switch_off_skips_and_no_sentinel_advance(self):
+        gwp.PRIMARY_CLAIM_ATTRIBUTION_ENABLED = False
+        hist = {'90001|041926|primary|': {'hash': 'x'}}
+        mutated = gwp._run_subproject_d_hash_prune(hist, self._groups())
+        self.assertFalse(mutated)
+        # OFF: the bare key is the ACTIVE legacy format — must NOT be dropped.
+        self.assertIn('90001|041926|primary|', hist)
+        self.assertNotIn('_subproject_d_prune_version', hist)
+
+    def test_call_site_wired_into_migration_dirty(self):
+        src = inspect.getsource(generate_weekly_pdfs)
+        self.assertRegex(
+            src,
+            r"if _run_subproject_d_hash_prune\(hash_history, groups\):"
+            r"\s*\n\s*_hash_history_migration_dirty = True",
+        )
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pytest tests/test_primary_claim_attribution.py::TestSubprojectDHashPrune -v`
+Expected: FAIL — function not defined.
+
+- [ ] **Step 3a: Implement `_run_subproject_d_hash_prune`**
+
+In `generate_weekly_pdfs.py`, immediately after `_run_vac_crew_hash_prune` ends (~line 3589, before `def load_billing_audit_row_cache`), add:
+
+```python
+def _run_subproject_d_hash_prune(hash_history: dict, groups: dict) -> bool:
+    """Subproject D (2026-05-25): idempotent one-time hash-history prune.
+
+    Drops LEGACY blank-identifier production-primary orphans — 4-part keys
+    ``wr|week|primary|`` with an EMPTY identifier — for WRs that have a
+    partitioned ``_USER_`` primary group in this run. D re-partitions the
+    production primary variant by frozen claimer (new keys carry a
+    non-empty identifier), so the blank-identifier entries are obsolete.
+    The normal stale-prune at the end of the run would clear them
+    eventually; this makes the migration deterministic on the first run
+    and survives interrupted / no-update runs.
+
+    Scope-building delegates to ``_build_primary_wr_scope`` (shared with
+    the TARGET cleanup call site — no drift, per the [2026-05-15 12:00]
+    three-site invariant). Sentinel key ``_subproject_d_prune_version`` is
+    DISTINCT from the Phase 1.1 / Subproject B / Subproject C sentinels so
+    all four migrations are independent. Mutates ``hash_history`` in place.
+    Dropping a hash entry costs at most one benign regeneration — never
+    data loss — so no live-identity exemption is needed on this drop path
+    (unlike the every-run attachment cleanup).
+
+    GATED on ``PRIMARY_CLAIM_ATTRIBUTION_ENABLED``: when OFF, the
+    blank-identifier ``wr|week|primary|`` key is the ACTIVE legacy format
+    (the kill-switch-OFF path emits the bare primary key), so pruning it
+    would delete valid current history and force regeneration churn —
+    breaking the exact-legacy contract. Skip entirely when the flag is
+    off, and do NOT advance the sentinel, so the one-time migration still
+    runs if attribution is later enabled. (Mirrors the Subproject C
+    ``_run_vac_crew_hash_prune`` kill-switch guard.)
+    """
+    if not PRIMARY_CLAIM_ATTRIBUTION_ENABLED:
+        return False
+    _persisted = hash_history.pop('_subproject_d_prune_version', 0)
+    if (
+        isinstance(_persisted, int)
+        and _persisted >= SUBPROJECT_D_HASH_PRUNE_VERSION
+    ):
+        hash_history['_subproject_d_prune_version'] = _persisted
+        return False
+
+    _scope = _build_primary_wr_scope(groups)
+    _orphans: list[str] = []
+    for _hk in list(hash_history.keys()):
+        if isinstance(_hk, str) and _hk.startswith('_'):
+            continue
+        _parts = str(_hk).split('|')
+        if len(_parts) != 4:
+            continue
+        _hk_wr, _hk_week, _hk_variant, _hk_ident = _parts
+        if (
+            _hk_wr in _scope
+            and _hk_variant == 'primary'
+            and _hk_ident == ''
+        ):
+            _orphans.append(_hk)
+    for _ok in _orphans:
+        del hash_history[_ok]
+    hash_history['_subproject_d_prune_version'] = SUBPROJECT_D_HASH_PRUNE_VERSION
+    if _orphans:
+        _wr_sample = sorted({k.split('|')[0] for k in _orphans})[:20]
+        logging.info(
+            f"🧹 Subproject D hash-history prune: dropped {len(_orphans)} "
+            f"legacy unpartitioned primary orphan(s) "
+            f"(affected WRs first 20: {_wr_sample})"
+        )
+    else:
+        logging.info(
+            "🧹 Subproject D hash-history prune: no legacy unpartitioned "
+            "primary orphans to drop"
+        )
+    return True
+```
+
+- [ ] **Step 3b: Register the PII log marker**
+
+The new INFO log body `"Subproject D hash-history prune"` embeds no PII (only counts + sanitized WR numbers), matching the B/C prune logs. Find the `_PII_LOG_MARKERS` list and confirm the B entry `"Subproject B hash-history prune"` is present; add a sibling entry `"Subproject D hash-history prune"` directly after the C/B prune markers for consistency with the [2026-05-15 12:00] rule 3 (explicit marker per new INFO group log). Search for `"Subproject B hash-history prune"` in the `_PII_LOG_MARKERS` definition and add:
+
+```python
+    "Subproject D hash-history prune",
+```
+
+- [ ] **Step 3c: Wire into the prune call site**
+
+In `generate_weekly_pdfs.py`, after the Subproject C prune block (~line 7715, the `try: if _run_vac_crew_hash_prune(...)` ... `except Exception as _vc_prune_exc:` block), add:
+
+```python
+        # Subproject D: one-time prune of legacy blank-identifier primary
+        # orphans (kill switch is PRIMARY_CLAIM_ATTRIBUTION_ENABLED + the
+        # version constant). Fail-safe — a failed prune must not break the
+        # run.
+        try:
+            if _run_subproject_d_hash_prune(hash_history, groups):
+                _hash_history_migration_dirty = True
+        except Exception as _d_prune_exc:
+            logging.warning(
+                f"⚠️ Subproject D hash-history prune failed; continuing "
+                f"with existing history: {_d_prune_exc!r}"
+            )
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `pytest tests/test_primary_claim_attribution.py::TestSubprojectDHashPrune -v`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Syntax check + commit**
+
+```bash
+python -m py_compile generate_weekly_pdfs.py
+git add generate_weekly_pdfs.py tests/test_primary_claim_attribution.py
+git commit -m "feat(billing): Subproject D — one-time bare-primary hash prune"
+```
+
+---
+
+## Task 10: `cleanup_untracked_sheet_attachments` — `primary_wr_scope` param, gate, TARGET call site
+
+**Files:**
+- Modify: `generate_weekly_pdfs.py` (function signature + docstring ~line 2760-2842; new gate in the attachment loop ~line 2963; TARGET call site ~line 8834)
+- Test: `tests/test_primary_claim_attribution.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_primary_claim_attribution.py`:
+
+```python
+class TestBarePrimaryCleanup(unittest.TestCase):
+    """Task 10: forced bare-primary attachment cleanup on TARGET, gated +
+    valid_wr_weeks-exempt."""
+
+    def setUp(self):
+        _ensure_smartsheet_mocked()
+
+    def _att(self, name):
+        a = mock.MagicMock()
+        a.name = name
+        a.id = name
+        return a
+
+    def _run(self, attachments, valid_wr_weeks, primary_wr_scope):
+        client = mock.MagicMock()
+        sheet = mock.MagicMock()
+        row = mock.MagicMock()
+        row.id = 1
+        sheet.rows = [row]
+        client.Attachments.list_row_attachments.return_value.data = attachments
+        deleted = []
+        client.Attachments.delete_attachment.side_effect = (
+            lambda sid, aid: deleted.append(aid)
+        )
+        gwp.cleanup_untracked_sheet_attachments(
+            client, 12345, valid_wr_weeks, False,
+            target_sheet=sheet,
+            primary_wr_scope=primary_wr_scope,
+        )
+        return deleted
+
+    def test_in_scope_bare_primary_deleted(self):
+        bare = self._att("WR_90001_WeekEnding_041926_120000_aaaaaaaaaaaaaaaa.xlsx")
+        deleted = self._run([bare], valid_wr_weeks=set(), primary_wr_scope={'90001'})
+        self.assertIn(bare.id, deleted)
+
+    def test_live_per_claimer_not_deleted(self):
+        live = self._att("WR_90001_WeekEnding_041926_120000_User_Alice_aaaaaaaaaaaaaaaa.xlsx")
+        # Per-claimer file is identity ('90001','041926','primary','Alice');
+        # it's in valid_wr_weeks this run and has a non-empty identifier.
+        vww = {('90001', '041926', 'primary', 'Alice')}
+        deleted = self._run([live], valid_wr_weeks=vww, primary_wr_scope={'90001'})
+        self.assertNotIn(live.id, deleted)
+
+    def test_overlapping_live_bare_exempt_via_valid_wr_weeks(self):
+        # A bare primary whose identity IS in valid_wr_weeks (e.g. OFF for
+        # those rows) must be exempt.
+        bare = self._att("WR_90001_WeekEnding_041926_120000_aaaaaaaaaaaaaaaa.xlsx")
+        vww = {('90001', '041926', 'primary', None)}
+        deleted = self._run([bare], valid_wr_weeks=vww, primary_wr_scope={'90001'})
+        self.assertNotIn(bare.id, deleted)
+
+    def test_out_of_scope_bare_primary_kept(self):
+        bare = self._att("WR_90099_WeekEnding_041926_120000_aaaaaaaaaaaaaaaa.xlsx")
+        deleted = self._run([bare], valid_wr_weeks=set(), primary_wr_scope={'90001'})
+        self.assertNotIn(bare.id, deleted)
+
+    def test_none_scope_is_noop(self):
+        bare = self._att("WR_90001_WeekEnding_041926_120000_aaaaaaaaaaaaaaaa.xlsx")
+        deleted = self._run([bare], valid_wr_weeks=set(), primary_wr_scope=None)
+        self.assertNotIn(bare.id, deleted)
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pytest tests/test_primary_claim_attribution.py::TestBarePrimaryCleanup -v`
+Expected: FAIL — `cleanup_untracked_sheet_attachments() got an unexpected keyword argument 'primary_wr_scope'`.
+
+- [ ] **Step 3a: Add the parameter to the signature**
+
+In `generate_weekly_pdfs.py`, in the `cleanup_untracked_sheet_attachments` signature (~line 2760-2772), add a new parameter after `vac_legacy_wr_scope`:
+
+```python
+    vac_legacy_wr_scope: set[str] | None = None,
+    primary_wr_scope: set[str] | None = None,
+):
+```
+
+- [ ] **Step 3b: Add the docstring entry**
+
+In the docstring, after the `vac_legacy_wr_scope:` paragraph (~line 2836), add:
+
+```python
+    primary_wr_scope: Subproject D (2026-05-25) one-time migration. When
+        provided, any attachment whose parsed ``wr`` is in this set, whose
+        parsed ``variant`` is ``'primary'``, and whose parsed ``identifier``
+        is empty (legacy unpartitioned bare ``primary``) is unconditionally
+        deleted — UNLESS its identity is in ``valid_wr_weeks`` (live-identity
+        exemption). Per-claimer files (non-empty identifier like
+        ``_User_Alice``) are never matched. When None (default), this gate
+        is skipped — byte-identical legacy behaviour for callers that do
+        not pass the parameter. Gated at the TARGET call site by
+        PRIMARY_CLAIM_ATTRIBUTION_ENABLED and
+        LEGACY_PRIMARY_PARTITION_CLEANUP_ENABLED. Non-subcontractor primary
+        files route to TARGET_SHEET_ID only — the PPP call site must NOT
+        receive this parameter.
+```
+
+- [ ] **Step 3c: Add the gate inside the attachment loop**
+
+In `generate_weekly_pdfs.py`, immediately after the `vac_legacy_wr_scope` gate block (the one ending `off_contract_attachments.append(att)` / `continue` ~line 2963) and BEFORE `identity_groups[ident].append(att)`, add:
+
+```python
+                    # Subproject D (2026-05-25): one-time migration —
+                    # delete LEGACY UNPARTITIONED bare ``primary``
+                    # attachments (parsed identifier == '') for in-scope
+                    # NON-subcontractor WRs. D re-partitions production
+                    # primary files by frozen claimer (``_User_<name>``),
+                    # so the old bare one-file-per-WR attachment is an
+                    # obsolete duplicate. The ``not _identifier`` check is
+                    # the precise legacy selector: new per-claimer files
+                    # carry a non-empty identifier and are NOT deleted here.
+                    # WR-01 live-identity exemption: an attachment whose
+                    # identity IS in ``valid_wr_weeks`` is kept — this
+                    # protects a legitimate bare-primary file the current
+                    # run produced (e.g. an overlapping WR still emitting
+                    # bare primary because attribution was disabled for
+                    # those rows) from an every-run delete/regenerate churn.
+                    if (
+                        primary_wr_scope is not None
+                        and wr in primary_wr_scope
+                        and variant == 'primary'
+                        and not _identifier
+                        and ident not in valid_wr_weeks
+                    ):
+                        off_contract_attachments.append(att)
+                        continue
+```
+
+- [ ] **Step 3d: Wire the TARGET call site**
+
+In `generate_weekly_pdfs.py`, find the `_vac_scope = (...)` block immediately before the TARGET `cleanup_untracked_sheet_attachments(...)` call (~line 8828-8832) and add after it:
+
+```python
+            # Subproject D (2026-05-25): build the non-subcontractor
+            # primary WR scope for legacy bare-primary cleanup on TARGET.
+            # Gated on BOTH the attribution kill switch (the partitioned
+            # _USER_ groups only exist when attribution is on) AND the
+            # cleanup kill switch. primary files route to TARGET only —
+            # do NOT pass this to PPP.
+            _primary_scope = (
+                _build_primary_wr_scope(groups)
+                if (
+                    PRIMARY_CLAIM_ATTRIBUTION_ENABLED
+                    and LEGACY_PRIMARY_PARTITION_CLEANUP_ENABLED
+                )
+                else None
+            )
+```
+
+Then in the TARGET `cleanup_untracked_sheet_attachments(...)` call (~line 8834), add the new kwarg after `vac_legacy_wr_scope=_vac_scope,`:
+
+```python
+                    vac_legacy_wr_scope=_vac_scope,
+                    primary_wr_scope=_primary_scope,
+                )
+```
+
+> Do NOT add `primary_wr_scope` to the PPP call site (~line 8908). Non-subcontractor primary files never route to PPP.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `pytest tests/test_primary_claim_attribution.py::TestBarePrimaryCleanup -v`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Syntax check + commit**
+
+```bash
+python -m py_compile generate_weekly_pdfs.py
+git add generate_weekly_pdfs.py tests/test_primary_claim_attribution.py
+git commit -m "feat(billing): Subproject D — forced bare-primary cleanup on TARGET"
+```
+
+---
+
+## Task 11: `build_group_identity` round-trip regression + production-invariants source-grep
+
+No production code change — the parser already handles `_User_<name>`. This task locks the contract and the four-site lockstep against silent regression.
+
+**Files:**
+- Test: `tests/test_primary_claim_attribution.py`
+
+- [ ] **Step 1: Write the tests**
+
+Append to `tests/test_primary_claim_attribution.py`:
+
+```python
+class TestBuildGroupIdentityPrimaryUserRoundTrip(unittest.TestCase):
+    """Task 11: parser round-trips D's _User_<claimer> primary filename."""
+
+    def test_plain_claimer(self):
+        self.assertEqual(
+            gwp.build_group_identity(
+                "WR_90001_WeekEnding_041926_120000_User_Alice_aaaaaaaaaaaaaaaa.xlsx"
+            ),
+            ('90001', '041926', 'primary', 'Alice'),
+        )
+
+    def test_underscored_claimer(self):
+        self.assertEqual(
+            gwp.build_group_identity(
+                "WR_90001_WeekEnding_041926_120000_User_Jane_Smith_aaaaaaaaaaaaaaaa.xlsx"
+            ),
+            ('90001', '041926', 'primary', 'Jane_Smith'),
+        )
+
+    def test_bare_primary_still_parses(self):
+        # OFF-mode legacy bare primary -> identifier None.
+        self.assertEqual(
+            gwp.build_group_identity(
+                "WR_90001_WeekEnding_041926_120000_aaaaaaaaaaaaaaaa.xlsx"
+            ),
+            ('90001', '041926', 'primary', None),
+        )
+
+
+class TestSubprojectDProductionInvariants(unittest.TestCase):
+    """Task 11: source-grep guards for the four-site lockstep + matcher
+    mirror + filename suffix + prune-kill-switch gate."""
+
+    @classmethod
+    def setUpClass(cls):
+        with open(inspect.getsourcefile(generate_weekly_pdfs), encoding='utf-8') as f:
+            cls.src = f.read()
+
+    def test_filename_suffix_user_gated(self):
+        self.assertRegex(
+            self.src,
+            r"PRIMARY_CLAIM_ATTRIBUTION_ENABLED and _pf[\s\S]{0,200}_User_\{",
+        )
+
+    def test_wr_filter_matcher_has_user_clause(self):
+        # Both matchers must carry the _USER_ prefix clause (count >= 2).
+        self.assertGreaterEqual(
+            self.src.count('startswith(f"{wr}_USER_")'), 2,
+            "both _key_matches_wr and _key_matches_excluded_wr must match _USER_",
+        )
+
+    def test_prune_gated_on_kill_switch(self):
+        self.assertRegex(
+            self.src,
+            r"def _run_subproject_d_hash_prune[\s\S]{0,400}"
+            r"if not PRIMARY_CLAIM_ATTRIBUTION_ENABLED:\s*\n\s*return False",
+        )
+
+    def test_prune_wired_into_call_site(self):
+        self.assertIn("_run_subproject_d_hash_prune(hash_history, groups)", self.src)
+
+    def test_cleanup_has_primary_wr_scope_param(self):
+        self.assertIn("primary_wr_scope: set[str] | None = None", self.src)
+```
+
+- [ ] **Step 2: Run to verify they pass**
+
+Run: `pytest tests/test_primary_claim_attribution.py::TestBuildGroupIdentityPrimaryUserRoundTrip tests/test_primary_claim_attribution.py::TestSubprojectDProductionInvariants -v`
+Expected: PASS (all). If any source-grep fails, an earlier task's edit drifted from the plan — fix the earlier edit, do not weaken the test.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_primary_claim_attribution.py
+git commit -m "test(billing): Subproject D — parser round-trip + production invariants"
+```
+
+---
+
+## Task 12: Workflow pin + environment.md documentation
+
+**Files:**
+- Modify: `.github/workflows/weekly-excel-generation.yml` (env block ~line 393, after `VAC_CREW_LEGACY_CLEANUP_ENABLED: '1'`)
+- Modify: `website/docs/reference/environment.md` (after the `VAC_CREW_LEGACY_CLEANUP_ENABLED` section ~line 420+)
+
+- [ ] **Step 1: Pin both env vars in the workflow**
+
+In `.github/workflows/weekly-excel-generation.yml`, after the `VAC_CREW_LEGACY_CLEANUP_ENABLED: '1'` line (~line 393), add:
+
+```yaml
+
+          # Sub-project D (2026-05-25): kill switch for per-claimer
+          # partitioning of the PRODUCTION primary Excel files by frozen
+          # primary foreman from billing_audit.attribution_snapshot. Set
+          # to '0' to preserve legacy one-file-per-WR bare primary
+          # behavior. Unlike Subproject B, the core primary path never
+          # holds on a Supabase outage — it falls back to the current
+          # foreman and still generates. Living Ledger [2026-05-25].
+          PRIMARY_CLAIM_ATTRIBUTION_ENABLED: '1'
+          # Sub-project D (2026-05-25): kill switch for the one-time
+          # removal of legacy UNPARTITIONED bare primary attachments (no
+          # _User_ token) on TARGET_SHEET_ID for non-subcontractor WRs.
+          # Set to '0' to skip the destructive cleanup (legacy duplicates
+          # persist until removed manually). Separate from
+          # PRIMARY_CLAIM_ATTRIBUTION_ENABLED (which gates attribution
+          # resolution, NOT this cleanup). Living Ledger [2026-05-25].
+          LEGACY_PRIMARY_PARTITION_CLEANUP_ENABLED: '1'
+```
+
+- [ ] **Step 2: Document both env vars**
+
+In `website/docs/reference/environment.md`, after the `VAC_CREW_LEGACY_CLEANUP_ENABLED` section (find the `### `VAC_CREW_LEGACY_CLEANUP_ENABLED`` heading and the end of its body), add two new sections that mirror the C sections' structure:
+
+```markdown
+### `PRIMARY_CLAIM_ATTRIBUTION_ENABLED`
+
+**Default:** `1` (enabled). Truthy values: `1`, `true`, `yes`, `on`.
+
+Sub-project D. When enabled, the production primary Excel files (every
+non-subcontractor WR) are partitioned by the **frozen primary foreman**
+who claimed each line item — read from `billing_audit.attribution_snapshot`
+via `resolve_claimer('primary', …)` — and named
+`WR_..._WeekEnding_..._User_<claimer>_<hash>.xlsx`. A WR+week claimed by
+two foremen produces two files, one per claimer.
+
+Unlike Sub-project B (subcontractor primary), the core primary path
+**never holds** on a Supabase outage: if attribution can't be read
+(`fetch_failure`), or there is no frozen row yet (`no_history`), the row
+falls back to the **current** foreman and the file is still generated.
+This is deliberate — D covers every non-subcontractor WR, so holding on an
+outage would suppress all primary billing for that run.
+
+Set to `0` to revert to the legacy one-file-per-WR bare primary behavior
+(`WR_..._WeekEnding_..._<hash>.xlsx`). The resolved value is printed at
+startup as `📋 PRIMARY_CLAIM_ATTRIBUTION_ENABLED=<bool>`. Pinned to `1`
+in the `weekly-excel-generation.yml` `env:` block.
+
+### `LEGACY_PRIMARY_PARTITION_CLEANUP_ENABLED`
+
+**Default:** `1` (enabled). Truthy values: `1`, `true`, `yes`, `on`.
+
+Sub-project D one-time migration. When enabled, the legacy UNPARTITIONED
+bare primary attachments (no `_User_` token) on `TARGET_SHEET_ID` for
+non-subcontractor WRs that now produce a partitioned `_User_<claimer>`
+file are deleted — UNLESS the bare file's identity is live this run
+(`valid_wr_weeks` exemption). A matching one-time hash-history prune
+(`_subproject_d_prune_version` sentinel) drops the stale
+`{wr}|{week}|primary|` entries.
+
+**Separate from `PRIMARY_CLAIM_ATTRIBUTION_ENABLED`,** which gates
+attribution resolution, NOT this cleanup. Set to `0` to skip the
+destructive cleanup (legacy bare-primary duplicates persist until removed
+manually). The resolved value is printed at startup as
+`📋 LEGACY_PRIMARY_PARTITION_CLEANUP_ENABLED=<bool>`. Pinned to `1` in the
+`weekly-excel-generation.yml` `env:` block alongside
+`PRIMARY_CLAIM_ATTRIBUTION_ENABLED`.
+```
+
+- [ ] **Step 3: Validate docs build**
+
+```bash
+cd website && npm run typecheck && npm run build && cd ..
+```
+Expected: build succeeds, no broken links.
+
+> If `npm` is unavailable in the execution environment, skip the build but visually confirm the two new sections render as valid Markdown (headings, code fences balanced).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/weekly-excel-generation.yml website/docs/reference/environment.md
+git commit -m "docs(billing): Subproject D — pin + document primary attribution env vars"
+```
+
+---
+
+## Task 13: Living Ledger entry + full-suite verification
+
+**Files:**
+- Modify: `CLAUDE.md` (append to the Living Ledger section at the bottom)
+
+- [ ] **Step 1: Run the full suite (baseline gate)**
+
+Run: `pytest tests/`
+Expected: all green; net new D tests added (target ≥ 30 new test methods); total should be ~844+ passed (was 814), 0 failed.
+If anything is red, fix the offending task's code before proceeding — do NOT write the ledger entry on a red suite.
+
+- [ ] **Step 2: Syntax + smoke check**
+
+```bash
+python -m py_compile generate_weekly_pdfs.py
+TEST_MODE=true SKIP_UPLOAD=true python generate_weekly_pdfs.py
+```
+Expected: `py_compile` silent (success); `TEST_MODE` run completes without traceback and the startup banner shows
+`📋 PRIMARY_CLAIM_ATTRIBUTION_ENABLED=True` and
+`📋 LEGACY_PRIMARY_PARTITION_CLEANUP_ENABLED=True`.
+
+> On Windows PowerShell, set env vars inline differently: `$env:TEST_MODE='true'; $env:SKIP_UPLOAD='true'; python generate_weekly_pdfs.py` (then clear them).
+
+- [ ] **Step 3: Append the Living Ledger entry**
+
+In `CLAUDE.md`, append a new dated entry to the Living Ledger (use the actual completion timestamp). The entry MUST cover: the goal (production primary partitioned by frozen claimer → `_User_<claimer>`); the no-HOLD operator decision and WHY (core path covers every WR; HOLD would suppress all primary billing on outage); the two kill switches; the corrected spec finding (generate_excel primary filename branch needed the `_User_` suffix — it was `''` unconditionally); the four-site lockstep + the WR_FILTER matcher mirror; the migration (forced bare-primary TARGET cleanup + one-time prune, distinct `_subproject_d_prune_version` sentinel, gated on the attribution kill switch); and the regression test file `tests/test_primary_claim_attribution.py`. Follow the prose style of the existing `[2026-05-21 …]` Subproject B/C entries.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs(billing): Living Ledger — Subproject D primary claim attribution"
+```
+
+- [ ] **Step 5: Final full-suite confirmation before review**
+
+Run: `pytest tests/`
+Expected: green. The branch is now ready for `superpowers:finishing-a-development-branch` (PR + cross-AI review).
+
+---
+
+## Self-review checklist (completed during plan authoring)
+
+- **Spec coverage:** Every spec section maps to a task — config/kill switches (T1), filename suffix correction (T2), pre-pass (T3), emission partition (T4), four-site lockstep sites a/b/c (T5/T6; parser is no-change, regression in T11), WR matcher mirror (T7), migration scope helper (T8) + hash prune (T9) + forced bare-primary cleanup (T10), no-HOLD policy (T3/T4 emission consume `hold` as current), workflow pin + docs (T12), ledger (T13). No gaps.
+- **Placeholder scan:** No TBD/TODO; every code step shows complete code; every test step shows real assertions.
+- **Type/name consistency:** `_primary_claimer_map`, `_build_primary_wr_scope`, `_run_subproject_d_hash_prune`, `_subproject_d_prune_version`, `SUBPROJECT_D_HASH_PRUNE_VERSION`, `PRIMARY_CLAIM_ATTRIBUTION_ENABLED`, `LEGACY_PRIMARY_PARTITION_CLEANUP_ENABLED`, `primary_wr_scope`, `_User_<claimer>` token, `_RE_SANITIZE_IDENTIFIER` — used identically across all tasks. `resolve_claimer('primary', …)` matches `ROLE_BY_VARIANT['primary']`.

--- a/docs/superpowers/specs/2026-05-25-subproject-d-primary-claim-attribution-design.md
+++ b/docs/superpowers/specs/2026-05-25-subproject-d-primary-claim-attribution-design.md
@@ -1,0 +1,344 @@
+# Sub-project D — Primary-Workflow Primary Claim Attribution (Design)
+
+**Date:** 2026-05-25
+**Status:** Approved (brainstorming complete; awaiting implementation plan)
+**Author:** Claude Code session (brainstorming skill)
+**Branch:** `feat/subproject-d-primary-claim-attribution`
+
+## Context
+
+This is the fourth consumer in the "universal per-line-item claim
+attribution" effort. Every Excel file is partitioned by the FROZEN
+foreman/helper/vac-crew member who actually claimed each line item,
+sourced from `billing_audit.attribution_snapshot` via Foundation A's
+`resolve_claimer`. Sequencing A → B → C → D → E:
+
+- **Foundation A** (read layer + HOLD contract): SHIPPED.
+- **Phase 1.1** (subcontractor helper-shadow): SHIPPED.
+- **Sub-project B** (subcontractor PRIMARY → `_ReducedSub_User_<name>` /
+  `_AEPBillable_User_<name>`): MERGED (#215) + helper-exclusion hotfix (#216).
+- **Sub-project C** (vac_crew → `_VacCrew_<name>`, all sheets): MERGED (#219).
+- **Sub-project D** (primary-workflow NON-subcontractor primary
+  partitioning): **THIS DOCUMENT.** Highest blast radius — touches the
+  core primary grouping and the largest attachment migration.
+- **Sub-project E** (Supabase hash-store migration + strip
+  `_<hash>`/`_<timestamp>` tokens from filenames): NOT STARTED, last.
+
+D is the core primary path: every non-subcontractor WR currently produces
+exactly one bare primary Excel file on `TARGET_SHEET_ID`. With D enabled,
+each becomes one-or-more `_User_<claimer>` files (one per frozen claimer),
+and the legacy bare file must be migrated away.
+
+## Goal
+
+Partition the production primary Excel files by the FROZEN primary foreman
+who claimed each line item. A WR+week whose rows were claimed by two
+different foremen produces two files, one per claimer, each containing only
+that claimer's completed line items. When attribution is unavailable
+(no frozen row yet, kill switch off, or Supabase outage), fall back to the
+current foreman and still generate — the core primary path never withholds
+billing output.
+
+## Key codebase findings (verified against the C-merged base, commit 8f546ae)
+
+These are the facts the design relies on. All line numbers are
+approximate and will drift; they are anchors, not contracts.
+
+1. **Foundation A is D-ready.** `billing_audit/writer.py`
+   `ROLE_BY_VARIANT['primary'] = 'primary_foreman'`. Passing variant
+   `'primary'` to `resolve_claimer` resolves the `primary_foreman` column.
+   No `billing_audit/` change is needed (honors invariant #8).
+2. **Emission foreman propagates to `__current_foreman`.** In
+   `group_source_rows` (~line 5746-5750) the `keys_to_add` loop sets
+   `r_copy['__current_foreman'] = current_foreman or effective_user`.
+   Whatever foreman D puts in the emission tuple's 3rd element becomes the
+   group's `__current_foreman`.
+3. **The parser already supports D's filename.** `build_group_identity`
+   (~line 2710-2714) parses `..._User_<name>_<hash>` → `('primary', wr,
+   week, name)` — the decommissioned activity-log "Primary+User" variant.
+   D needs ZERO parser changes.
+4. **The legacy `User` column is never populated in production.** Only
+   `__effective_user` is set (~line 4620). `first_row.get('User')` (the
+   legacy primary identifier source at ~line 8054) returns `None` in
+   practice, so today's primary files are BARE
+   (`WR_{wr}_WeekEnding_{MMDDYY}_{ts}_{hash}.xlsx`) with history key
+   `{wr}|{week}|primary|` (empty identifier). The migration is therefore a
+   clean bare → `_User_<claimer>` transition, with no real-world
+   `User`-tag collision.
+5. **`generate_excel` primary display is already D-ready.** The primary
+   `else` branch (~line 6408) sets `display_foreman = current_foreman`,
+   which is `__current_foreman` — the partition-key claimer when D is on,
+   or `effective_user` when off. No `generate_excel` change is needed.
+6. **WR matchers asymmetry.** `_key_matches_excluded_wr` (EXCLUDE_WRS,
+   ~line 5886) already has `or suffix.startswith(f"{wr}_USER_")`.
+   `_key_matches_wr` (WR_FILTER, ~line 5833) does NOT. D must add the
+   `_USER_` clause to `_key_matches_wr`. Both keep `suffix == wr` for the
+   OFF/legacy bare key.
+
+## Architecture
+
+### Scope
+
+**In scope.** Only the production primary emission:
+`RES_GROUPING_MODE in ('helper', 'both')`, `not is_subcontractor_row`,
+`not valid_helper_row` — the branch at ~line 5303-5305 that today emits
+`('primary', f"{week_end_for_key}_{wr_key}", None)`.
+
+**Out of scope.**
+- `RES_GROUPING_MODE == 'primary'` legacy mode (non-production; it lumps
+  helper + subcontractor rows into one primary file per WR, where
+  partitioning by `primary_foreman` would be semantically wrong). Stays
+  bare/legacy.
+- Subcontractor primary rows — Sub-project B already owns them via
+  `_ReducedSub_User_` / `_AEPBillable_User_`; the bare primary for sub
+  rows is already suppressed.
+- Helper rows — excluded from primary by the existing `valid_helper_row`
+  cascade.
+- VAC crew — Sub-project C owns `_VacCrew_<name>`.
+
+### Filename / key / identity shapes
+
+| State | Group key | Filename | Identity tuple |
+|-------|-----------|----------|----------------|
+| D ON  | `{week}_{wr}_USER_{sanitized_claimer}` | `WR_{wr}_WeekEnding_{MMDDYY}_{ts}_User_{claimer}_{hash}.xlsx` | `(wr, week, 'primary', claimer)` |
+| D OFF | `{week}_{wr}` | `WR_{wr}_WeekEnding_{MMDDYY}_{ts}_{hash}.xlsx` | `(wr, week, 'primary', None)` |
+
+`build_group_identity` already parses both shapes (finding #3).
+
+### Partition model — fallback-to-current, never HOLD
+
+D reuses Foundation A's `resolve_claimer('primary', …)` in a parallel
+pre-pass (Approach 1). Consumption at emission:
+
+- `action == 'use'` → frozen claimer (`outcome.name`), or `no_history`
+  collapses to the current `effective_user` inside `resolve_claimer`.
+- `action == 'hold'` (Supabase `fetch_failure`) → **use current
+  `effective_user` and still generate.** D does NOT defer, does NOT call
+  `record_attribution_hold`, and emits no end-of-run hold summary.
+- map-miss / disabled / any pre-pass fault → use current `effective_user`.
+
+Empty resolved claimer → `'Unknown Foreman'` sentinel (mirrors B's
+Codex-P1 fix) so the `_USER_` suffix builder never receives an empty
+identifier.
+
+**Rationale for no-HOLD (operator-chosen).** D covers EVERY
+non-subcontractor WR. Under HOLD, a full Supabase outage would suppress
+ALL primary billing files for that run. The core primary path prioritizes
+availability: it always emits, attributing to the current foreman when the
+frozen claimer can't be read. This deliberately differs from B (sub
+primary HOLDs) — B's blast radius is limited to subcontractor WRs.
+
+### Configuration — two new default-on, workflow-pinned kill switches
+
+- **`PRIMARY_CLAIM_ATTRIBUTION_ENABLED`** (default `'1'`; truthy
+  `1`/`true`/`yes`/`on`). Gates the partitioning AND all four identity
+  surfaces (pre-pass, emission, main-loop site a, sites b/c). OFF ⇒
+  byte-identical legacy bare primary at every surface.
+- **`LEGACY_PRIMARY_PARTITION_CLEANUP_ENABLED`** (default `'1'`). Gates
+  the destructive migration (forced bare-primary attachment cleanup +
+  one-time hash prune). OFF ⇒ TARGET cleanup byte-identical to today.
+
+Both are pinned in `.github/workflows/weekly-excel-generation.yml` and
+documented in `website/docs/reference/environment.md` (invariant #9).
+
+## Components / change surface
+
+All emission/identity changes are gated on
+`PRIMARY_CLAIM_ATTRIBUTION_ENABLED`; OFF reproduces exact legacy behavior.
+
+### 1. Pre-pass (`group_source_rows`)
+
+Add `_primary_claimer_map: dict` keyed by `__row_id`, beside B's
+`_sub_primary_claimer_map` and C's `_vac_crew_claimer_map` (~line 5077).
+
+- Guard: `BILLING_AUDIT_AVAILABLE and PRIMARY_CLAIM_ATTRIBUTION_ENABLED`.
+- Eligible rows: completed (`is_checked(Units Completed?)`), has
+  `Work Request #` + parseable `Weekly Reference Logged Date`,
+  `not r.get('__is_vac_crew')`, AND `not is_subcontractor`
+  (`__source_sheet_id is not None and __source_sheet_id in
+  _FOLDER_DISCOVERED_SUB_IDS` ⇒ excluded). `__row_id` must be `int`.
+- Bounded `ThreadPoolExecutor(max_workers=min(PARALLEL_WORKERS, n))`;
+  single-row groups skip the executor (invariant #7).
+- Per row: `resolve_claimer('primary', effective_user, wr=…,
+  week_ending=<date>, row_id=…, enabled=PRIMARY_CLAIM_ATTRIBUTION_ENABLED)`.
+- Outer try/except → on failure, `_primary_claimer_map = {}` (all rows
+  fall back to current at emission).
+
+### 2. Emission (production primary branch, ~line 5303-5305)
+
+Replace the single `('primary', f"{week}_{wr}", None)` append with a
+kill-switch branch:
+
+- **ON:** read `_primary_claimer_map.get(r.get('__row_id'))`.
+  - `outcome.action == 'use'` → `claimer = outcome.name or effective_user
+    or 'Unknown Foreman'`.
+  - else (`hold` / miss / disabled / `None`) → `claimer = effective_user
+    or 'Unknown Foreman'`.
+  - `claimer_sanitized = _RE_SANITIZE_IDENTIFIER.sub('_', claimer)[:50]`.
+  - Emit `('primary', f"{week_end_for_key}_{wr_key}_USER_{claimer_sanitized}",
+    claimer)`. Log `🧑 PRIMARY GROUP CREATED` once per new key.
+- **OFF:** emit legacy `('primary', f"{week_end_for_key}_{wr_key}", None)`.
+
+### 3. Site (a) — main-loop identity (~line 8051-8057, primary `else`)
+
+- **ON:** `_pf = first_row.get('__current_foreman', '')`;
+  `identifier = file_identifier = _RE_SANITIZE_IDENTIFIER.sub('_', _pf)[:50]
+  if _pf else ''`.
+- **OFF:** legacy `first_row.get('User')` path unchanged.
+- `history_key = f"{wr_num}|{week_raw}|{variant}|{identifier}"` (unchanged
+  shape — identifier now carries the claimer when ON).
+
+### 4. Sites (b) `valid_wr_weeks` (~line 8786) and (c) `current_keys` (~8994-9013)
+
+Both already branch per-variant for vac_crew / reduced_sub / aep_billable.
+Add the same ON-gated primary derivation: `_pf =
+group_rows[0].get('__current_foreman', '')`; `file_id` /`_ident` =
+sanitized `_pf` when `PRIMARY_CLAIM_ATTRIBUTION_ENABLED and _pf` else `''`.
+This keeps the 4-tuple (site b) and pipe-key (site c) byte-identical to
+site (a) and to the `_User_<name>` filename — the four-site lockstep
+(invariant #1).
+
+### 5. WR matchers (`group_source_rows`, ~line 5833 / 5886)
+
+- `_key_matches_wr` (WR_FILTER): add `or suffix.startswith(f"{wr}_USER_")`.
+- `_key_matches_excluded_wr` (EXCLUDE_WRS): already has it — no change.
+- Both retain `suffix == wr` so the OFF/legacy bare key still matches.
+  (Invariant #3 — mirror-matcher rule.)
+
+### 6. `generate_excel`
+
+No change (finding #5).
+
+## Migration (gated on `LEGACY_PRIMARY_PARTITION_CLEANUP_ENABLED`)
+
+### 7a. Forced bare-primary attachment cleanup on TARGET_SHEET_ID
+
+- New shared helper `_build_primary_wr_scope(groups) -> set[str]`: the set
+  of WR numbers that have a partitioned `{week}_{wr}_USER_{claimer}`
+  primary group in this run (i.e., WRs whose bare predecessor should be
+  cleaned).
+- Add `primary_wr_scope: set[str] | None = None` param to
+  `cleanup_untracked_sheet_attachments` (alongside `sub_wr_scope` /
+  `sub_legacy_primary_variants`).
+- At the TARGET call site only: for an attachment whose parsed identity is
+  `(wr, week, 'primary', None | '')` (bare) AND `wr in primary_wr_scope`:
+  delete it unconditionally (regardless of `KEEP_HISTORICAL_WEEKS`)
+  **UNLESS** that identity is in `valid_wr_weeks` (live-identity
+  exemption). The exemption protects a bare-primary file the current run
+  legitimately produced (e.g., an overlapping WR still emitting bare
+  primary because attribution was disabled for those specific rows).
+- Gated on `PRIMARY_CLAIM_ATTRIBUTION_ENABLED and
+  LEGACY_PRIMARY_PARTITION_CLEANUP_ENABLED`. OFF ⇒ no behavior change.
+- The PPP sheet (`SUBCONTRACTOR_PPP_SHEET_ID`) is NOT in scope — D is
+  non-subcontractor only; pass `primary_wr_scope=None` for PPP.
+
+### 7b. One-time hash-history prune
+
+- New `_run_subproject_d_hash_prune(hash_history, groups) -> bool`.
+- New `SUBPROJECT_D_HASH_PRUNE_VERSION = 1` constant + `_subproject_d_prune_version`
+  sentinel persisted in `hash_history.json` (distinct from the
+  Phase-1.1 / B / C sentinels).
+- Drops legacy empty-identifier primary history keys `{wr}|{week}|primary|`
+  for WRs in `_build_primary_wr_scope(groups)`.
+- **Gated on `PRIMARY_CLAIM_ATTRIBUTION_ENABLED`** (invariant #5 — OFF must
+  not delete now-active legacy keys; when OFF the bare key is the live key).
+- Returns a "mutated" bool (True when it ran the body / advanced the
+  sentinel; False on the idempotent early-return) that is OR'd into
+  `_hash_history_migration_dirty`, so the sentinel persists even on a
+  no-update run (B's Codex-P2 fix).
+- Benign drop-path: a dropped hash costs at most one regeneration, never
+  data loss — so no live-identity exemption is needed. Scoped to in-scope
+  WRs to avoid touching legacy `primary`-mode keys for unrelated WRs.
+
+### Why both 7a and 7b
+
+They are independent surfaces. Without 7a, every migrated WR keeps a
+duplicate-looking bare file on TARGET forever. Without 7b, the stale
+history key lingers harmlessly but accumulates.
+
+## Error handling & edge cases
+
+- **Pre-pass failure** (any exception) → empty `_primary_claimer_map` →
+  all rows use-current at emission. A plumbing fault can never suppress a
+  primary file.
+- **Empty claimer** → `'Unknown Foreman'` sentinel before the `_USER_`
+  suffix is built.
+- **Thread safety** — reuse B/C's bounded executor + memoized,
+  thread-safe `billing_audit` client; per-op counters already lock-guarded.
+- **No HOLD path** — `action == 'hold'` consumed as use-current;
+  `record_attribution_hold` never called for `'primary'`.
+- **Two claimers, same WR+week** → two coexisting `_User_<a>` / `_User_<b>`
+  files. The claimer is in the identity tuple, so they are distinct
+  identities; the per-identity cleanup keeps both and never cross-deletes
+  (Foundation A invariant #2).
+- **D OFF** → byte-identical legacy at every surface: bare `{week}_{wr}`
+  key, `''` identifier, bare filename, `{wr}|{week}|primary|` history key,
+  no migration cleanup, no prune.
+- **Mixed attribution state on one WR** (some rows partitioned, an
+  overlapping bare file still live) → `valid_wr_weeks` exemption protects
+  the live bare file from 7a.
+- **WR_FILTER / EXCLUDE_WRS** now both match `{wr}_USER_<name>`.
+
+## Testing strategy
+
+TDD red→green throughout. New file
+`tests/test_primary_claim_attribution.py`, plus targeted extensions to
+existing suites.
+
+- **End-to-end `group_source_rows`** (synthetic rows + mocked
+  `resolve_claimer`): partition-by-claimer; two-claimer coexistence; OFF
+  byte-identical bare key; fall-back-on-`hold` still emits under current
+  foreman with NO hold recorded.
+- **`build_group_identity`** `_User_<name>` primary round-trip regression
+  (claimer names with underscores; a claimer literally named with a
+  `Helper`/`VacCrew` substring still parses as `primary`).
+- **WR matchers** — both `_key_matches_wr` and `_key_matches_excluded_wr`
+  match `{wr}_USER_<name>` and still match the bare `{wr}`.
+- **Four-site source-grep invariants** (the `TestProductionCodeSiteInvariants`
+  pattern): assert each of the four identity sites + both matchers carry
+  the primary `__current_foreman` / `_USER_` derivation, gated on the kill
+  switch.
+- **Migration:**
+  - 7a forced bare-primary cleanup E2E: in-scope bare deleted; live
+    per-claimer `_User_` file NOT deleted; overlapping live bare exempt via
+    `valid_wr_weeks`; OFF ⇒ no deletion.
+  - 7b prune idempotency + version sentinel + kill-switch gating
+    (OFF ⇒ no prune) + migration-dirty save on a no-update run + scope
+    discipline (unrelated WRs untouched).
+- **Pre-pass concurrency** — N concurrent resolves preserve counter
+  accuracy / no silent drops / no exceptions.
+- **Living-Ledger-entry-present** test.
+- **Verification gate:** `pytest tests/` green (baseline 814 passed /
+  26 skipped / 60 subtests), `python -m py_compile generate_weekly_pdfs.py`,
+  and a `TEST_MODE=true` smoke run.
+
+## Invariants honored (from the handoff)
+
+1. **CR-01 four-site lockstep** — claimer identifier byte-identical at
+   main-loop `identifier`/`file_identifier`/`history_key`,
+   `valid_wr_weeks`, `current_keys`, and the `build_group_identity` parser
+   (parser already conformant — finding #3).
+2. **Kill-switch gates all identity surfaces** — OFF reproduces exact
+   legacy.
+3. **Mirror-matcher rule** — extend `_key_matches_wr` for `_USER_`
+   (`_key_matches_excluded_wr` already done).
+4. **Mutual exclusion** — D's emission is already scoped to
+   `not is_subcontractor_row and not valid_helper_row`; vac/helper/sub do
+   not double-emit primary.
+5. **One-time prune** — distinct version sentinel; gated on the kill
+   switch (OFF doesn't delete now-active legacy keys); returns a "mutated"
+   bool wired into `_hash_history_migration_dirty`.
+6. **HOLD policy** — D deliberately does NOT hold (operator decision for
+   the core path); fall-back-to-current + generate.
+7. **Per-row attribution I/O in a bounded pre-pass**, never the hot loop.
+8. **`billing_audit/` not modified** — `resolve_claimer('primary', …)` is
+   already supported.
+9. **New kill switches workflow-pinned + documented.**
+
+## Out of scope / explicitly deferred
+
+- Sub-project E (Supabase hash-store migration + stripping
+  `_<hash>`/`_<timestamp>` filename tokens). Until E ships, the hash stays
+  in filenames.
+- `RES_GROUPING_MODE == 'primary'` legacy-mode partitioning.
+- Any `billing_audit/` schema or reader change.

--- a/docs/superpowers/specs/2026-05-25-subproject-d-primary-claim-attribution-design.md
+++ b/docs/superpowers/specs/2026-05-25-subproject-d-primary-claim-attribution-design.md
@@ -65,10 +65,20 @@ approximate and will drift; they are anchors, not contracts.
    `{wr}|{week}|primary|` (empty identifier). The migration is therefore a
    clean bare → `_User_<claimer>` transition, with no real-world
    `User`-tag collision.
-5. **`generate_excel` primary display is already D-ready.** The primary
-   `else` branch (~line 6408) sets `display_foreman = current_foreman`,
-   which is `__current_foreman` — the partition-key claimer when D is on,
-   or `effective_user` when off. No `generate_excel` change is needed.
+5. **`generate_excel` primary DISPLAY is D-ready, but the FILENAME suffix
+   is NOT.** The primary display branch (~line 6408) sets
+   `display_foreman = current_foreman` (= `__current_foreman`, the
+   partition-key claimer when on / `effective_user` when off) — no change
+   needed. HOWEVER, the filename-suffix branch (~line 6221-6223) sets
+   `variant_suffix = ''` UNCONDITIONALLY for the primary variant — it
+   ignores the identifier entirely. Without a fix, every per-claimer
+   primary group would generate to the SAME bare filename
+   `WR_..._WeekEnding_..._{ts}_{hash}.xlsx` (collision/overwrite) and the
+   `_User_<claimer>` identity would never round-trip. **D MUST modify this
+   branch** to emit `_User_{sanitized_claimer}` when
+   `PRIMARY_CLAIM_ATTRIBUTION_ENABLED and __current_foreman`, mirroring the
+   `vac_crew` branch at ~line 6205-6220. (The decommissioned activity-log
+   path that the parser still reads no longer has a live filename builder.)
 6. **WR matchers asymmetry.** `_key_matches_excluded_wr` (EXCLUDE_WRS,
    ~line 5886) already has `or suffix.startswith(f"{wr}_USER_")`.
    `_key_matches_wr` (WR_FILTER, ~line 5833) does NOT. D must add the
@@ -207,7 +217,16 @@ site (a) and to the `_User_<name>` filename — the four-site lockstep
 
 ### 6. `generate_excel`
 
-No change (finding #5).
+- **Filename suffix (~line 6221-6223) — REQUIRED change.** Replace the
+  unconditional `variant_suffix = ''` for the primary variant with:
+  when `PRIMARY_CLAIM_ATTRIBUTION_ENABLED and first_row.get('__current_foreman')`,
+  set `variant_suffix = f"_User_{_RE_SANITIZE_IDENTIFIER.sub('_', _pf)[:50]}"`;
+  else `variant_suffix = ''`. Mirrors the `vac_crew` branch exactly. OFF ⇒
+  bare suffix (legacy), so byte-identical. This is what produces the
+  `_User_<claimer>` filename that `build_group_identity` round-trips and
+  that distinguishes per-claimer files on disk / on the sheet.
+- **Display foreman — no change.** The primary display branch already uses
+  `current_foreman` (the claimer when on, `effective_user` when off).
 
 ## Migration (gated on `LEGACY_PRIMARY_PARTITION_CLEANUP_ENABLED`)
 

--- a/docs/superpowers/specs/2026-05-25-subproject-d-primary-claim-attribution-design.md
+++ b/docs/superpowers/specs/2026-05-25-subproject-d-primary-claim-attribution-design.md
@@ -105,7 +105,12 @@ approximate and will drift; they are anchors, not contracts.
 - `RES_GROUPING_MODE == 'primary'` legacy mode (non-production; it lumps
   helper + subcontractor rows into one primary file per WR, where
   partitioning by `primary_foreman` would be semantically wrong). Stays
-  bare/legacy.
+  bare/legacy. **Enforced (PR #223 Codex-P1 follow-up):** the pre-pass,
+  emission, the `generate_excel` filename suffix, AND all three identity
+  sites (`history_key`/`file_identifier`, `valid_wr_weeks`, `current_keys`)
+  are each gated on `RES_GROUPING_MODE in ('helper', 'both')` — not just on
+  `PRIMARY_CLAIM_ATTRIBUTION_ENABLED` — so every surface is consistently
+  bare in primary mode. See Living Ledger `[2026-05-25 18:15]`.
 - Subcontractor primary rows — Sub-project B already owns them via
   `_ReducedSub_User_` / `_AEPBillable_User_`; the bare primary for sub
   rows is already suppressed.

--- a/docs/superpowers/specs/2026-05-25-subproject-d-primary-claim-attribution-design.md
+++ b/docs/superpowers/specs/2026-05-25-subproject-d-primary-claim-attribution-design.md
@@ -54,9 +54,16 @@ approximate and will drift; they are anchors, not contracts.
    Whatever foreman D puts in the emission tuple's 3rd element becomes the
    group's `__current_foreman`.
 3. **The parser already supports D's filename.** `build_group_identity`
-   (~line 2710-2714) parses `..._User_<name>_<hash>` → `('primary', wr,
-   week, name)` — the decommissioned activity-log "Primary+User" variant.
-   D needs ZERO parser changes.
+   parses `..._User_<name>_<hash>` → `('primary', wr, week, name)` — the
+   decommissioned activity-log "Primary+User" variant. D's *core* work
+   needed no parser change. **(Updated post-implementation:** the final
+   review surfaced a latent bug — when a claimer NAME contains a reserved
+   token (e.g. "Pat Helper"), the old fixed-order variant scan misparsed
+   `_User_Pat_Helper` as `helper`. So D ultimately *did* harden the parser:
+   `build_group_identity` now dispatches on the EARLIEST reserved-token
+   position. See the post-merge fix commit + the Living Ledger entry. The
+   "ZERO parser changes" framing held only for the originally-produced
+   filenames, not for reserved-token-in-name edge cases.)**
 4. **The legacy `User` column is never populated in production.** Only
    `__effective_user` is set (~line 4620). `first_row.get('User')` (the
    legacy primary identifier source at ~line 8054) returns `None` in

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -1041,6 +1041,13 @@ _PII_LOG_MARKERS: tuple[str, ...] = (
     "_REDUCEDSUB_HELPER_",
     "AEP BILLABLE GROUP CREATED",
     "REDUCED SUB GROUP CREATED",
+    # Subproject D (Task 4 review fix / [2026-05-25]): the new
+    # PRIMARY GROUP CREATED INFO log embeds WR= and Week= row PII
+    # (see the ``🧑 PRIMARY GROUP CREATED`` log in
+    # ``group_source_rows``). Explicit marker per the
+    # [2026-04-20 12:00] / [2026-05-15 12:00] ledger rules —
+    # mirrors the five sibling GROUP CREATED markers above.
+    "PRIMARY GROUP CREATED",
     # Phase 01 gap closure (REVIEW-WR-04 / Living Ledger 2026-04-20
     # 12:00): the new helper-shadow GROUP CREATED logs already match
     # against the substring "HELPER GROUP CREATED" by accident — the

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -577,7 +577,8 @@ PRIMARY_CLAIM_ATTRIBUTION_ENABLED = os.getenv(
 
 # Subproject D (2026-05-25): default-ON kill switch for the one-time
 # removal of legacy UNPARTITIONED bare ``primary`` attachments (no
-# ``_User_`` token, parsed identifier == '') on TARGET_SHEET_ID for
+# ``_User_`` token; ``build_group_identity`` parses these to
+# ``identifier=None``) on TARGET_SHEET_ID for
 # non-subcontractor WRs, once those files are re-partitioned by frozen
 # primary claimer. Set to '0' to skip the destructive cleanup (legacy
 # duplicates then persist until removed manually). Separate from
@@ -3036,7 +3037,9 @@ def cleanup_untracked_sheet_attachments(
                         continue
                     # Subproject D (2026-05-25): one-time migration —
                     # delete LEGACY UNPARTITIONED bare ``primary``
-                    # attachments (parsed identifier == '') for in-scope
+                    # attachments (``build_group_identity`` parses a bare
+                    # primary to ``identifier=None``; the ``not _identifier``
+                    # gate below matches None and '') for in-scope
                     # NON-subcontractor WRs. D re-partitions production
                     # primary files by frozen claimer (``_User_<name>``),
                     # so the old bare one-file-per-WR attachment is an
@@ -3403,12 +3406,23 @@ def _build_primary_wr_scope(groups: dict) -> set[str]:
     """Return the set of sanitized WR tokens that have a partitioned
     production-primary ``_USER_`` group in this run (Subproject D).
 
-    A group key is a partitioned primary iff it contains ``'_USER_'`` AND
-    is NOT a subcontractor primary variant (``'_REDUCEDSUB'`` /
-    ``'_AEPBILLABLE'`` — those carry ``_USER_`` too but are owned by
-    Subproject B and route through B's own scope/cleanup). Helper
-    (``_HELPER_``) and vac (``_VACCREW``) groups never match because they
-    do not contain ``_USER_``.
+    A group qualifies iff its authoritative ``__variant`` field (set at
+    emission) is ``'primary'`` AND its key carries the ``_USER_`` partition
+    token. The ``__variant`` gate — NOT a key substring scan — is what
+    excludes helper / vac_crew / subcontractor groups, so a claimer,
+    helper, or vac-crew name (or a pathological WR token) that itself
+    contains a reserved word cannot false-positive into D's scope (Codex
+    PR #223 P1). For example a helper literally named "USER" produces a
+    key ``..._HELPER_USER_...`` whose ``_USER_`` substring the prior
+    implementation mis-bucketed as a primary group; the ``__variant ==
+    'primary'`` gate now rejects it. Conversely a genuine primary claimer
+    named "ReducedSub"/"AEPBillable" (key ``..._USER_ReducedSub``) is
+    correctly INCLUDED, whereas the prior ``'_REDUCEDSUB' not in _key``
+    substring exclusion wrongly dropped it. The ``'_USER_' in _key`` clause
+    then distinguishes a PARTITIONED primary (Subproject D ``_USER_`` group)
+    from a bare primary (OFF mode / legacy ``RES_GROUPING_MODE='primary'``).
+    Both call sites gate on ``PRIMARY_CLAIM_ATTRIBUTION_ENABLED``, so in
+    production ``'both'`` mode every primary group is the partitioned form.
 
     Shared by ``_run_subproject_d_hash_prune`` (hash-prune scope) and the
     TARGET ``cleanup_untracked_sheet_attachments`` call site (bare-primary
@@ -3417,12 +3431,9 @@ def _build_primary_wr_scope(groups: dict) -> set[str]:
     """
     _scope: set[str] = set()
     for _key, _g_rows in groups.items():
-        if (
-            '_USER_' in _key
-            and '_REDUCEDSUB' not in _key
-            and '_AEPBILLABLE' not in _key
-            and _g_rows
-        ):
+        if not _g_rows:
+            continue
+        if _g_rows[0].get('__variant') == 'primary' and '_USER_' in _key:
             _g_wr_raw = _g_rows[0].get('Work Request #', '')
             _g_wr = str(_g_wr_raw).split('.')[0]
             _g_wr = _RE_SANITIZE_HELPER_NAME.sub('_', _g_wr)[:50]

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -2830,6 +2830,7 @@ def cleanup_untracked_sheet_attachments(
     sub_offcontract_variants: set[str] | None = None,
     sub_legacy_primary_variants: set[str] | None = None,
     vac_legacy_wr_scope: set[str] | None = None,
+    primary_wr_scope: set[str] | None = None,
 ):
     """Prune only older variants for identities processed this run (VARIANT-AWARE).
 
@@ -2897,6 +2898,20 @@ def cleanup_untracked_sheet_attachments(
         Gated at the TARGET call site by VAC_CREW_LEGACY_CLEANUP_ENABLED.
         vac_crew files route to TARGET_SHEET_ID only (never PPP); the
         PPP call site must NOT receive this parameter.
+
+    primary_wr_scope: Subproject D (2026-05-25) one-time migration. When
+        provided, any attachment whose parsed ``wr`` is in this set, whose
+        parsed ``variant`` is ``'primary'``, and whose parsed ``identifier``
+        is empty (legacy unpartitioned bare ``primary``) is unconditionally
+        deleted — UNLESS its identity is in ``valid_wr_weeks`` (live-identity
+        exemption). Per-claimer files (non-empty identifier like
+        ``_User_Alice``) are never matched. When None (default), this gate
+        is skipped — byte-identical legacy behaviour for callers that do
+        not pass the parameter. Gated at the TARGET call site by
+        PRIMARY_CLAIM_ATTRIBUTION_ENABLED and
+        LEGACY_PRIMARY_PARTITION_CLEANUP_ENABLED. Non-subcontractor primary
+        files route to TARGET_SHEET_ID only — the PPP call site must NOT
+        receive this parameter.
 
     CRITICAL: Identity includes variant dimension to prevent primary/helper cross-deletion.
               Each (wr, week, variant, identifier) is treated as independent.
@@ -3017,6 +3032,30 @@ def cleanup_untracked_sheet_attachments(
                         vac_legacy_wr_scope is not None
                         and wr in vac_legacy_wr_scope
                         and variant == 'vac_crew'
+                        and not _identifier
+                        and ident not in valid_wr_weeks
+                    ):
+                        off_contract_attachments.append(att)
+                        continue
+                    # Subproject D (2026-05-25): one-time migration —
+                    # delete LEGACY UNPARTITIONED bare ``primary``
+                    # attachments (parsed identifier == '') for in-scope
+                    # NON-subcontractor WRs. D re-partitions production
+                    # primary files by frozen claimer (``_User_<name>``),
+                    # so the old bare one-file-per-WR attachment is an
+                    # obsolete duplicate. The ``not _identifier`` check is
+                    # the precise legacy selector: new per-claimer files
+                    # carry a non-empty identifier and are NOT deleted here.
+                    # WR-01 live-identity exemption: an attachment whose
+                    # identity IS in ``valid_wr_weeks`` is kept — this
+                    # protects a legitimate bare-primary file the current
+                    # run produced (e.g. an overlapping WR still emitting
+                    # bare primary because attribution was disabled for
+                    # those rows) from an every-run delete/regenerate churn.
+                    if (
+                        primary_wr_scope is not None
+                        and wr in primary_wr_scope
+                        and variant == 'primary'
                         and not _identifier
                         and ident not in valid_wr_weeks
                     ):
@@ -9165,6 +9204,20 @@ def main():  # pyright: ignore[reportGeneralTypeIssues]
                 if VAC_CREW_LEGACY_CLEANUP_ENABLED
                 else None
             )
+            # Subproject D (2026-05-25): build the non-subcontractor
+            # primary WR scope for legacy bare-primary cleanup on TARGET.
+            # Gated on BOTH the attribution kill switch (the partitioned
+            # _USER_ groups only exist when attribution is on) AND the
+            # cleanup kill switch. primary files route to TARGET only —
+            # do NOT pass this to PPP.
+            _primary_scope = (
+                _build_primary_wr_scope(groups)
+                if (
+                    PRIMARY_CLAIM_ATTRIBUTION_ENABLED
+                    and LEGACY_PRIMARY_PARTITION_CLEANUP_ENABLED
+                )
+                else None
+            )
             with sentry_sdk.start_span(op="smartsheet.cleanup", name="Cleanup untracked sheet attachments"):
                 cleanup_untracked_sheet_attachments(
                     client, TARGET_SHEET_ID, valid_wr_weeks, TEST_MODE,
@@ -9176,6 +9229,7 @@ def main():  # pyright: ignore[reportGeneralTypeIssues]
                     sub_offcontract_variants=(_target_offcontract or None),
                     sub_legacy_primary_variants=_target_legacy_primary,
                     vac_legacy_wr_scope=_vac_scope,
+                    primary_wr_scope=_primary_scope,
                 )
 
             # Phase 01 gap closure (REVIEW-WR-01): parallel cleanup pass

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -2695,51 +2695,52 @@ def build_group_identity(filename: str) -> tuple[str, str, str, str | None] | No
     identifier = None
     tail = parts[we_idx + 2:]
 
-    # Per Phase 01 Plan 02 D-09 (variant-first, helper-second) and
-    # D-10 (tail-scoped detection): the new subcontractor variants
-    # MUST be checked BEFORE the existing ``Helper`` / ``VacCrew``
-    # / ``User`` branches so that ``..._AEPBillable_Helper_<name>_<hash>``
-    # parses as ``aep_billable_helper`` (not plain ``helper`` with
-    # the AEPBillable token silently lost). The check operates on
-    # the post-``WeekEnding`` ``tail`` slice only, so a sanitized
-    # WR# that happens to contain ``AEPBillable`` / ``ReducedSub``
-    # in its body cannot false-positive the variant — covered by
-    # the negative tests in TestBuildGroupIdentityWithUnderscoresInWr.
-    if 'AEPBillable' in tail:
+    # Reserved-token precedence (ledger [2026-05-21 13:20], generalized to
+    # the bare ``_User_`` shape by Subproject D 2026-05-25): the variant is
+    # determined by the EARLIEST reserved marker token in ``tail``, NOT by a
+    # fixed check order. A claimer / helper / vac-crew name can itself contain
+    # a reserved word (e.g. a foreman literally named "Pat Helper" →
+    # ``_User_Pat_Helper_<hash>``); a fixed AEPBillable→ReducedSub→VacCrew→
+    # Helper→User order would misclassify it (here, as ``helper`` with the
+    # ``User`` token lost). Dispatching on the earliest-position marker fixes
+    # this for ALL bare shapes while preserving the two-level
+    # ``_AEPBillable_User_`` / ``_ReducedSub_Helper_`` handling (AEPBillable /
+    # ReducedSub are always the earliest token in those filenames). The scan
+    # operates on the post-``WeekEnding`` ``tail`` slice only, so a sanitized
+    # WR# containing a reserved word in its body cannot false-positive the
+    # variant — covered by the negative tests in
+    # TestBuildGroupIdentityWithUnderscoresInWr.
+    _reserved_positions = {
+        _tok: tail.index(_tok)
+        for _tok in ('AEPBillable', 'ReducedSub', 'VacCrew', 'Helper', 'User')
+        if _tok in tail
+    }
+    _first_marker = (
+        min(_reserved_positions, key=_reserved_positions.get)
+        if _reserved_positions else None
+    )
+    if _first_marker == 'AEPBillable':
         aep_idx_rel = tail.index('AEPBillable')
         post_aep = tail[aep_idx_rel + 1:]
         if post_aep and post_aep[0] == 'User':
-            # Subproject B: _AEPBillable_User_<claimer>_<hash>. The reserved
-            # 'User' token marks a primary-claimer identifier. It MUST be
-            # checked BEFORE the 'Helper' scan (Codex P2): a primary claimer
-            # whose NAME contains the 'Helper' token (e.g. a foreman named
-            # 'Pat Helper' → 'Pat_Helper') would otherwise be misclassified
-            # as an aep_billable_helper variant, breaking identity round-trip
-            # and causing cleanup/hash churn. Span-join so an underscored
-            # claimer name survives intact. A dangling 'User' with no name
-            # before the hash yields '' (legacy shape).
+            # Subproject B: _AEPBillable_User_<claimer>_<hash>. Reserved 'User'
+            # token marks a primary-claimer identifier. Span-join so an
+            # underscored claimer name survives; dangling 'User' -> '' (legacy).
             variant = 'aep_billable'
             identifier = '_'.join(post_aep[1:-1])
         elif 'Helper' in post_aep:
             variant = 'aep_billable_helper'
             helper_idx_rel = post_aep.index('Helper')
             if helper_idx_rel + 1 < len(post_aep):
-                # Join all parts between Helper and hash (last part)
-                # so underscored helper names like ``Jane_Smith``
-                # survive intact (round-7 span-join discipline).
                 identifier = '_'.join(post_aep[helper_idx_rel + 1:-1])
         else:
-            # Legacy unpartitioned _AEPBillable_<hash> (no User token).
+            # Legacy unpartitioned _AEPBillable_<hash> (no User/Helper token).
             variant = 'aep_billable'
             identifier = ''
-    elif 'ReducedSub' in tail:
+    elif _first_marker == 'ReducedSub':
         rs_idx_rel = tail.index('ReducedSub')
         post_rs = tail[rs_idx_rel + 1:]
         if post_rs and post_rs[0] == 'User':
-            # Subproject B: _ReducedSub_User_<claimer>_<hash>. Reserved 'User'
-            # token checked BEFORE the 'Helper' scan (Codex P2) so a claimer
-            # name containing 'Helper' isn't misclassified as a helper variant.
-            # A dangling 'User' with no name before the hash yields '' (legacy shape).
             variant = 'reduced_sub'
             identifier = '_'.join(post_rs[1:-1])
         elif 'Helper' in post_rs:
@@ -2748,27 +2749,23 @@ def build_group_identity(filename: str) -> tuple[str, str, str, str | None] | No
             if helper_idx_rel + 1 < len(post_rs):
                 identifier = '_'.join(post_rs[helper_idx_rel + 1:-1])
         else:
-            # Legacy unpartitioned _ReducedSub_<hash> (no User token).
+            # Legacy unpartitioned _ReducedSub_<hash> (no User/Helper token).
             variant = 'reduced_sub'
             identifier = ''
-    elif 'VacCrew' in tail:
-        # Subproject C: _VacCrew_<name>_<hash>. Checked BEFORE the 'Helper'
-        # scan so a crew name containing the 'Helper' token isn't
-        # misclassified as a helper variant (B round-7 lesson). Span-join so
-        # an underscored name survives. Legacy _VacCrew (no name) -> ''.
+    elif _first_marker == 'VacCrew':
+        # Subproject C: _VacCrew_<name>_<hash>. Span-join so an underscored
+        # name survives. Legacy _VacCrew (no name) -> ''.
         variant = 'vac_crew'
         vac_idx_rel = tail.index('VacCrew')
         identifier = ''  # legacy _VacCrew (no name) -> '' per identity contract
         if vac_idx_rel + 1 < len(tail):
             identifier = '_'.join(tail[vac_idx_rel + 1:-1])
-    elif 'Helper' in tail:
+    elif _first_marker == 'Helper':
         variant = 'helper'
         helper_idx_rel = tail.index('Helper')
         if helper_idx_rel + 1 < len(tail):
-            # Join all parts between Helper and hash (last part)
-            # Format: ...Helper_{name}_{hash} or ...Helper_{name}_part2_{hash}
             identifier = '_'.join(tail[helper_idx_rel + 1:-1])
-    elif 'User' in tail:
+    elif _first_marker == 'User':
         variant = 'primary'
         user_idx_rel = tail.index('User')
         if user_idx_rel + 1 < len(tail):
@@ -5363,7 +5360,11 @@ def group_source_rows(rows):
     # availability). resolve_claimer is still called so frozen attribution
     # is used whenever Supabase is healthy.
     _primary_claimer_map: dict = {}
-    if BILLING_AUDIT_AVAILABLE and PRIMARY_CLAIM_ATTRIBUTION_ENABLED:
+    if (
+        BILLING_AUDIT_AVAILABLE
+        and PRIMARY_CLAIM_ATTRIBUTION_ENABLED
+        and RES_GROUPING_MODE in ('helper', 'both')
+    ):
         _d_pre_rows = []
         for _r in rows:
             _rid = _r.get('__row_id')

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -8234,10 +8234,10 @@ def main():  # pyright: ignore[reportGeneralTypeIssues]
                     # switch: enabled → frozen claimer (__current_foreman);
                     # disabled → legacy ``User`` field ('' in production).
                     if PRIMARY_CLAIM_ATTRIBUTION_ENABLED:
-                        __current_foreman = first_row.get('__current_foreman', '')
+                        _pf = first_row.get('__current_foreman', '')
                         identifier = (
-                            _RE_SANITIZE_IDENTIFIER.sub('_', __current_foreman)[:50]
-                            if __current_foreman else ''
+                            _RE_SANITIZE_IDENTIFIER.sub('_', _pf)[:50]
+                            if _pf else ''
                         )
                         file_identifier = identifier
                     else:
@@ -8972,9 +8972,20 @@ def main():  # pyright: ignore[reportGeneralTypeIssues]
                         if _b_claimer else ''
                     )
                 else:
-                    user_val = group_rows[0].get('User')
-                    # PERFORMANCE: Use pre-compiled regex
-                    file_id = _RE_SANITIZE_IDENTIFIER.sub('_', user_val)[:50] if user_val else ''
+                    # Subproject D (2026-05-25): primary identity site
+                    # (Site 2 — valid_wr_weeks). Mirror Site 1 so attachment
+                    # cleanup keeps the live per-claimer primary file.
+                    # Disabled mode preserves the legacy ``User``-field path.
+                    if PRIMARY_CLAIM_ATTRIBUTION_ENABLED:
+                        _pf = group_rows[0].get('__current_foreman', '')
+                        file_id = (
+                            _RE_SANITIZE_IDENTIFIER.sub('_', _pf)[:50]
+                            if (PRIMARY_CLAIM_ATTRIBUTION_ENABLED and _pf) else ''
+                        )
+                    else:
+                        user_val = group_rows[0].get('User')
+                        # PERFORMANCE: Use pre-compiled regex
+                        file_id = _RE_SANITIZE_IDENTIFIER.sub('_', user_val)[:50] if user_val else ''
                 valid_wr_weeks.add((wr, week_raw, variant, file_id))
         if not TEST_MODE:
             # Invalidate stale attachment cache after upload phase — uploads added/deleted attachments
@@ -9200,8 +9211,21 @@ def main():  # pyright: ignore[reportGeneralTypeIssues]
                                 if _b_claimer else ''
                             )
                         else:
-                            _uv = group_rows[0].get('User')
-                            _ident = _RE_SANITIZE_IDENTIFIER.sub('_', _uv)[:50] if _uv else ''
+                            # Subproject D (2026-05-25): primary identity
+                            # site (Site 3 — current_keys). Must match the
+                            # history_key written at Site 1 byte-for-byte
+                            # (sanitized claimer when on, legacy User-field
+                            # when off) or the freshly-written entry is
+                            # treated as stale and deleted before save.
+                            if PRIMARY_CLAIM_ATTRIBUTION_ENABLED:
+                                _pf = group_rows[0].get('__current_foreman', '')
+                                _ident = (
+                                    _RE_SANITIZE_IDENTIFIER.sub('_', _pf)[:50]
+                                    if (PRIMARY_CLAIM_ATTRIBUTION_ENABLED and _pf) else ''
+                                )
+                            else:
+                                _uv = group_rows[0].get('User')
+                                _ident = _RE_SANITIZE_IDENTIFIER.sub('_', _uv)[:50] if _uv else ''
                         current_keys.add(f"{_wr}|{_week}|{_variant}|{_ident}")
                 stale_keys = [k for k in hash_history if k not in current_keys]
                 if stale_keys:

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -5191,6 +5191,80 @@ def group_source_rows(rows):
                 )
                 _vac_crew_claimer_map = {}
 
+    # Subproject D (2026-05-25): resolve the FROZEN primary claimer for
+    # every completed NON-subcontractor, non-vac primary row BEFORE the
+    # grouping loop, so no per-row Supabase round-trip runs inside the
+    # hot loop (honors [2026-04-25 14:00] latency lesson). The map is
+    # keyed by __row_id and consumed by the production primary emission
+    # branch. A row absent from the map (attribution disabled, pre-pass
+    # skipped, missing __row_id, or unexpected per-row error) resolves to
+    # use-current at emission. Unlike B/C, a ``hold`` outcome (Supabase
+    # outage) is ALSO consumed as use-current at emission — D never
+    # defers a primary file (operator decision: the core path prioritizes
+    # availability). resolve_claimer is still called so frozen attribution
+    # is used whenever Supabase is healthy.
+    _primary_claimer_map: dict = {}
+    if BILLING_AUDIT_AVAILABLE and PRIMARY_CLAIM_ATTRIBUTION_ENABLED:
+        _d_pre_rows = []
+        for _r in rows:
+            _rid = _r.get('__row_id')
+            if not isinstance(_rid, int):
+                continue
+            if _r.get('__is_vac_crew'):
+                continue
+            _sid = _r.get('__source_sheet_id')
+            if _sid is not None and _sid in _FOLDER_DISCOVERED_SUB_IDS:
+                continue  # subcontractor rows are Sub-project B's domain
+            _wr_raw = _r.get('Work Request #')
+            _ld = _r.get('Weekly Reference Logged Date')
+            if not _wr_raw or not _ld or not is_checked(_r.get('Units Completed?')):
+                continue
+            _we = excel_serial_to_date(_ld)
+            if _we is None:
+                continue
+            _d_pre_rows.append((
+                _rid,
+                str(_wr_raw).split('.')[0],
+                _we.date() if isinstance(_we, datetime.datetime) else _we,
+                _r.get('__effective_user', 'Unknown Foreman'),
+            ))
+        if _d_pre_rows:
+            try:
+                from billing_audit.writer import resolve_claimer as _resolve_claimer_primary
+
+                def _resolve_one_primary(_item):
+                    _rid, _wr, _we_date, _eu = _item
+                    return _rid, _resolve_claimer_primary(
+                        'primary', _eu,
+                        wr=_wr, week_ending=_we_date, row_id=_rid,
+                        enabled=PRIMARY_CLAIM_ATTRIBUTION_ENABLED,
+                    )
+
+                if len(_d_pre_rows) <= 1:
+                    for _item in _d_pre_rows:
+                        _rid, _out = _resolve_one_primary(_item)
+                        _primary_claimer_map[_rid] = _out
+                else:
+                    _workers = min(PARALLEL_WORKERS, len(_d_pre_rows))
+                    with ThreadPoolExecutor(max_workers=_workers) as _ex:
+                        _futs = [_ex.submit(_resolve_one_primary, _it) for _it in _d_pre_rows]
+                        for _fut in as_completed(_futs):
+                            try:
+                                _rid, _out = _fut.result()
+                                _primary_claimer_map[_rid] = _out
+                            except Exception:
+                                logging.exception(
+                                    "⚠️ Subproject D attribution pre-pass: "
+                                    "unexpected error for one row (treating "
+                                    "as use-current)"
+                                )
+            except Exception:
+                logging.exception(
+                    "⚠️ Subproject D attribution pre-pass failed; falling "
+                    "back to current foreman for all primary rows"
+                )
+                _primary_claimer_map = {}
+
     for r in rows:
         wr = r.get('Work Request #')
         log_date_str = r.get('Weekly Reference Logged Date')

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -6147,7 +6147,7 @@ def group_source_rows(rows):
     if WR_FILTER and TEST_MODE:
         before = len(groups)
         def _key_matches_wr(k: str, wr: str) -> bool:
-            # k format examples (all nine shapes emitted by group_source_rows):
+            # k format examples (all eleven shapes emitted by group_source_rows):
             #   MMDDYY_WR                                   → primary
             #   MMDDYY_WR_USER_<name>                       → primary (Subproject D)
             #   MMDDYY_WR_HELPER_<name>                     → helper
@@ -6157,6 +6157,8 @@ def group_source_rows(rows):
             #   MMDDYY_WR_AEPBILLABLE                       → aep_billable (Phase 1)
             #   MMDDYY_WR_REDUCEDSUB_HELPER_<name>          → reduced_sub_helper  (Phase 1)
             #   MMDDYY_WR_AEPBILLABLE_HELPER_<name>         → aep_billable_helper (Phase 1)
+            #   MMDDYY_WR_REDUCEDSUB_USER_<claimer>         → reduced_sub  (Subproject B)
+            #   MMDDYY_WR_AEPBILLABLE_USER_<claimer>        → aep_billable (Subproject B)
             #
             # Phase 01 gap closure (REVIEW-CR-03): mirror of the
             # ``_key_matches_excluded_wr`` fix immediately below. Without the
@@ -6189,6 +6191,13 @@ def group_source_rows(rows):
                 or suffix == f"{wr}_AEPBILLABLE"
                 or suffix.startswith(f"{wr}_REDUCEDSUB_HELPER_")
                 or suffix.startswith(f"{wr}_AEPBILLABLE_HELPER_")
+                # Subproject B: per-claimer subcontractor primary keys
+                # {wr}_REDUCEDSUB_USER_<claimer> / {wr}_AEPBILLABLE_USER_<claimer>
+                # (attribution on — the production default). Prefix-match so
+                # WR_FILTER / EXCLUDE_WRS cover the partitioned shape, not just
+                # the bare _REDUCEDSUB / _AEPBILLABLE. Mirror in BOTH matchers.
+                or suffix.startswith(f"{wr}_REDUCEDSUB_USER_")
+                or suffix.startswith(f"{wr}_AEPBILLABLE_USER_")
             )
 
         groups = {k: v for k, v in groups.items() if any(_key_matches_wr(k, wr) for wr in WR_FILTER)}
@@ -6204,7 +6213,7 @@ def group_source_rows(rows):
         logging.info(f"🔍 Sample group keys: {sample_keys}")
         
         def _key_matches_excluded_wr(k: str, wr: str) -> bool:
-            # k format examples (all nine shapes emitted by group_source_rows):
+            # k format examples (all eleven shapes emitted by group_source_rows):
             #   MMDDYY_WR                                   → primary
             #   MMDDYY_WR_USER_<name>                       → primary (Subproject D)
             #   MMDDYY_WR_HELPER_<name>                     → helper
@@ -6214,6 +6223,8 @@ def group_source_rows(rows):
             #   MMDDYY_WR_AEPBILLABLE                       → aep_billable (Phase 1)
             #   MMDDYY_WR_REDUCEDSUB_HELPER_<name>          → reduced_sub_helper  (Phase 1)
             #   MMDDYY_WR_AEPBILLABLE_HELPER_<name>         → aep_billable_helper (Phase 1)
+            #   MMDDYY_WR_REDUCEDSUB_USER_<claimer>         → reduced_sub  (Subproject B)
+            #   MMDDYY_WR_AEPBILLABLE_USER_<claimer>        → aep_billable (Subproject B)
             #
             # Phase 01 gap closure (REVIEW-CR-02): before this fix the matcher
             # only recognized the first four shapes, so EXCLUDE_WRS=<wr>
@@ -6241,6 +6252,14 @@ def group_source_rows(rows):
                 or suffix == f"{wr}_AEPBILLABLE"
                 or suffix.startswith(f"{wr}_REDUCEDSUB_HELPER_")
                 or suffix.startswith(f"{wr}_AEPBILLABLE_HELPER_")
+                # Subproject B: per-claimer subcontractor primary keys
+                # {wr}_REDUCEDSUB_USER_<claimer> / {wr}_AEPBILLABLE_USER_<claimer>
+                # (attribution on — the production default). EXCLUDE_WRS is
+                # production-active, so without these the operator's "do not
+                # bill yet" intent silently failed for partitioned sub primary
+                # files. Mirror of _key_matches_wr — the two MUST stay in sync.
+                or suffix.startswith(f"{wr}_REDUCEDSUB_USER_")
+                or suffix.startswith(f"{wr}_AEPBILLABLE_USER_")
             )
         
         # Remove groups that match any excluded WR

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -3357,6 +3357,38 @@ def _build_vac_crew_wr_scope(groups: dict) -> set[str]:
     return _scope
 
 
+def _build_primary_wr_scope(groups: dict) -> set[str]:
+    """Return the set of sanitized WR tokens that have a partitioned
+    production-primary ``_USER_`` group in this run (Subproject D).
+
+    A group key is a partitioned primary iff it contains ``'_USER_'`` AND
+    is NOT a subcontractor primary variant (``'_REDUCEDSUB'`` /
+    ``'_AEPBILLABLE'`` — those carry ``_USER_`` too but are owned by
+    Subproject B and route through B's own scope/cleanup). Helper
+    (``_HELPER_``) and vac (``_VACCREW``) groups never match because they
+    do not contain ``_USER_``.
+
+    Shared by ``_run_subproject_d_hash_prune`` (hash-prune scope) and the
+    TARGET ``cleanup_untracked_sheet_attachments`` call site (bare-primary
+    migration scope). A single implementation prevents the scope-build
+    drift that the [2026-05-15 12:00] three-site invariant warns against.
+    """
+    _scope: set[str] = set()
+    for _key, _g_rows in groups.items():
+        if (
+            '_USER_' in _key
+            and '_REDUCEDSUB' not in _key
+            and '_AEPBILLABLE' not in _key
+            and _g_rows
+        ):
+            _g_wr_raw = _g_rows[0].get('Work Request #', '')
+            _g_wr = str(_g_wr_raw).split('.')[0]
+            _g_wr = _RE_SANITIZE_HELPER_NAME.sub('_', _g_wr)[:50]
+            if _g_wr:
+                _scope.add(_g_wr)
+    return _scope
+
+
 def _run_phase_1_1_hash_prune(hash_history: dict, groups: dict) -> bool:
     """Phase 1.1 SUB-12 / D-17..D-19: idempotent hash-history prune.
 

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -5969,10 +5969,12 @@ def group_source_rows(rows):
     if WR_FILTER and TEST_MODE:
         before = len(groups)
         def _key_matches_wr(k: str, wr: str) -> bool:
-            # k format examples (all seven shapes emitted by group_source_rows):
+            # k format examples (all eight shapes emitted by group_source_rows):
             #   MMDDYY_WR                                   → primary
+            #   MMDDYY_WR_USER_<name>                       → primary (Subproject D)
             #   MMDDYY_WR_HELPER_<name>                     → helper
             #   MMDDYY_WR_VACCREW                           → vac_crew
+            #   MMDDYY_WR_VACCREW_<claimer>                 → vac_crew (Subproject C)
             #   MMDDYY_WR_REDUCEDSUB                        → reduced_sub  (Phase 1)
             #   MMDDYY_WR_AEPBILLABLE                       → aep_billable (Phase 1)
             #   MMDDYY_WR_REDUCEDSUB_HELPER_<name>          → reduced_sub_helper  (Phase 1)
@@ -5985,16 +5987,19 @@ def group_source_rows(rows):
             # producing zero ``_AEPBillable`` / ``_ReducedSub`` output for the
             # filtered WR — which makes the Step B operator diagnostic
             # documented in 01-VERIFICATION.md unexercisable. Match shape is
-            # IDENTICAL to ``_key_matches_excluded_wr`` (minus the
-            # ``_USER_`` legacy clause, which has never been a WR_FILTER
-            # target). The two matchers MUST stay in sync — any future
-            # variant added in ``group_source_rows`` must extend BOTH.
+            # IDENTICAL to ``_key_matches_excluded_wr``. The two matchers
+            # MUST stay in sync — any future variant added in
+            # ``group_source_rows`` must extend BOTH.
             try:
                 suffix = k.split('_', 1)[1]  # take everything after first underscore (WR...)
             except Exception:
                 return False
             return (
                 suffix == wr
+                # Subproject D: per-claimer primary key {wr}_USER_<claimer>
+                # (attribution on). Mirror of the _key_matches_excluded_wr
+                # clause below — the two matchers MUST stay in sync.
+                or suffix.startswith(f"{wr}_USER_")
                 or suffix.startswith(f"{wr}_HELPER_")
                 or suffix == f"{wr}_VACCREW"
                 # Subproject C: per-claimer vac key {wr}_VACCREW_<claimer>
@@ -6021,11 +6026,12 @@ def group_source_rows(rows):
         logging.info(f"🔍 Sample group keys: {sample_keys}")
         
         def _key_matches_excluded_wr(k: str, wr: str) -> bool:
-            # k format examples (all seven shapes emitted by group_source_rows):
+            # k format examples (all nine shapes emitted by group_source_rows):
             #   MMDDYY_WR                                   → primary
+            #   MMDDYY_WR_USER_<name>                       → primary (Subproject D)
             #   MMDDYY_WR_HELPER_<name>                     → helper
-            #   MMDDYY_WR_USER_<name>                       → user-tagged (legacy)
             #   MMDDYY_WR_VACCREW                           → vac_crew
+            #   MMDDYY_WR_VACCREW_<claimer>                 → vac_crew (Subproject C)
             #   MMDDYY_WR_REDUCEDSUB                        → reduced_sub  (Phase 1)
             #   MMDDYY_WR_AEPBILLABLE                       → aep_billable (Phase 1)
             #   MMDDYY_WR_REDUCEDSUB_HELPER_<name>          → reduced_sub_helper  (Phase 1)

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -5969,7 +5969,7 @@ def group_source_rows(rows):
     if WR_FILTER and TEST_MODE:
         before = len(groups)
         def _key_matches_wr(k: str, wr: str) -> bool:
-            # k format examples (all eight shapes emitted by group_source_rows):
+            # k format examples (all nine shapes emitted by group_source_rows):
             #   MMDDYY_WR                                   → primary
             #   MMDDYY_WR_USER_<name>                       → primary (Subproject D)
             #   MMDDYY_WR_HELPER_<name>                     → helper

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -5423,8 +5423,42 @@ def group_source_rows(rows):
                     # Living Ledger entry [Phase 1.1 timestamp]
                     # documents the design-intent change.
                     if not is_subcontractor_row and not valid_helper_row:
-                        primary_key = f"{week_end_for_key}_{wr_key}"
-                        keys_to_add.append(('primary', primary_key, None))
+                        # Subproject D (2026-05-25): partition the
+                        # production primary file by the FROZEN primary
+                        # claimer. Consume the pre-pass map. ``use`` ->
+                        # partition by claimer; ``hold`` (Supabase outage),
+                        # map miss, or disabled -> use the current
+                        # effective_user and STILL emit (D never holds —
+                        # operator decision for the core path). Empty
+                        # claimer -> 'Unknown Foreman' sentinel so the
+                        # _User_ suffix builder never gets an empty
+                        # identifier (mirrors B's Codex-P1 fix).
+                        if PRIMARY_CLAIM_ATTRIBUTION_ENABLED:
+                            _d_outcome = _primary_claimer_map.get(r.get('__row_id'))
+                            if _d_outcome is not None and _d_outcome.action == 'use':
+                                _d_claimer = (
+                                    _d_outcome.name or effective_user or 'Unknown Foreman'
+                                )
+                            else:
+                                # hold / map-miss / disabled / None -> current.
+                                _d_claimer = effective_user or 'Unknown Foreman'
+                            _d_claimer_sanitized = _RE_SANITIZE_IDENTIFIER.sub(
+                                '_', _d_claimer
+                            )[:50]
+                            primary_key = (
+                                f"{week_end_for_key}_{wr_key}_USER_"
+                                f"{_d_claimer_sanitized}"
+                            )
+                            keys_to_add.append(('primary', primary_key, _d_claimer))
+                            if primary_key not in groups:
+                                logging.info(
+                                    f"🧑 PRIMARY GROUP CREATED: WR={wr_key}, "
+                                    f"Week={week_end_for_key}"
+                                )
+                        else:
+                            # Kill switch OFF -> exact legacy bare primary.
+                            primary_key = f"{week_end_for_key}_{wr_key}"
+                            keys_to_add.append(('primary', primary_key, None))
                     elif is_subcontractor_row and not valid_helper_row:
                         # Diagnostic log only — no group emission.
                         # Operators can confirm the partition is

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -3752,6 +3752,8 @@ def _run_subproject_d_hash_prune(hash_history: dict, groups: dict) -> bool:
             "🧹 Subproject D hash-history prune: no legacy unpartitioned "
             "primary orphans to drop"
         )
+    # Body path advanced the sentinel (and may have dropped orphans) —
+    # report the mutation so the caller persists it even on a no-update run.
     return True
 
 

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -6267,8 +6267,25 @@ def generate_excel(group_key, group_rows, snapshot_date, ai_analysis_results=Non
             # Disabled mode (or no claimer resolved) → exact legacy bare suffix.
             variant_suffix = '_VacCrew'
     elif variant == 'primary':
-        # Primary variant (no suffix needed)
-        variant_suffix = ''
+        # Subproject D (2026-05-25): partition the production primary
+        # file by the FROZEN primary claimer (__current_foreman is the
+        # resolved claimer set in group_source_rows' emission tuple).
+        # GATED on the kill switch (mirrors the vac_crew branch above):
+        #   • Enabled + claimer present -> _User_<sanitized claimer> so
+        #     each claimer's file is distinct and round-trips through
+        #     build_group_identity as ('primary', wr, week, claimer).
+        #   • Disabled (or no claimer) -> exact legacy bare suffix '',
+        #     preserving byte-identical filenames with pre-D attachments.
+        # __current_foreman in disabled mode is effective_user (the
+        # emission passes None -> `current_foreman or effective_user`),
+        # but the kill-switch gate keeps the suffix bare in that case.
+        _pf = first_row.get('__current_foreman', '')
+        if PRIMARY_CLAIM_ATTRIBUTION_ENABLED and _pf:
+            variant_suffix = (
+                f"_User_{_RE_SANITIZE_IDENTIFIER.sub('_', _pf)[:50]}"
+            )
+        else:
+            variant_suffix = ''
 
     # Phase 01 Plan 03 Task 2 (D-16): per-call missing-CU accumulator.
     # ``_resolve_row_price`` populates this Counter when a row's CU

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -1106,6 +1106,12 @@ _PII_LOG_MARKERS: tuple[str, ...] = (
     # per the [2026-05-15 12:00] rule 3 — no accidental substring
     # containment with pre-existing markers.
     "Vac crew hash-history prune",
+    # Subproject D Task 9: one-time hash-history prune INFO log embeds
+    # the affected-WR list (capped to first 20 entries). Explicit marker
+    # per the [2026-05-15 12:00] rule 3 — no accidental substring
+    # containment with pre-existing markers (body does not overlap
+    # "Subproject B hash-history prune" or "Vac crew hash-history prune").
+    "Subproject D hash-history prune",
 )
 
 
@@ -3673,6 +3679,79 @@ def _run_vac_crew_hash_prune(hash_history: dict, groups: dict) -> bool:
         )
     # Body path advanced the sentinel (and may have dropped orphans) —
     # report the mutation so the caller persists it even on a no-update run.
+    return True
+
+
+def _run_subproject_d_hash_prune(hash_history: dict, groups: dict) -> bool:
+    """Subproject D (2026-05-25): idempotent one-time hash-history prune.
+
+    Drops LEGACY blank-identifier production-primary orphans — 4-part keys
+    ``wr|week|primary|`` with an EMPTY identifier — for WRs that have a
+    partitioned ``_USER_`` primary group in this run. D re-partitions the
+    production primary variant by frozen claimer (new keys carry a
+    non-empty identifier), so the blank-identifier entries are obsolete.
+    The normal stale-prune at the end of the run would clear them
+    eventually; this makes the migration deterministic on the first run
+    and survives interrupted / no-update runs.
+
+    Scope-building delegates to ``_build_primary_wr_scope`` (shared with
+    the TARGET cleanup call site — no drift, per the [2026-05-15 12:00]
+    three-site invariant). Sentinel key ``_subproject_d_prune_version`` is
+    DISTINCT from the Phase 1.1 / Subproject B / Subproject C sentinels so
+    all four migrations are independent. Mutates ``hash_history`` in place.
+    Dropping a hash entry costs at most one benign regeneration — never
+    data loss — so no live-identity exemption is needed on this drop path
+    (unlike the every-run attachment cleanup).
+
+    GATED on ``PRIMARY_CLAIM_ATTRIBUTION_ENABLED``: when OFF, the
+    blank-identifier ``wr|week|primary|`` key is the ACTIVE legacy format
+    (the kill-switch-OFF path emits the bare primary key), so pruning it
+    would delete valid current history and force regeneration churn —
+    breaking the exact-legacy contract. Skip entirely when the flag is
+    off, and do NOT advance the sentinel, so the one-time migration still
+    runs if attribution is later enabled. (Mirrors the Subproject C
+    ``_run_vac_crew_hash_prune`` kill-switch guard.)
+    """
+    if not PRIMARY_CLAIM_ATTRIBUTION_ENABLED:
+        return False
+    _persisted = hash_history.pop('_subproject_d_prune_version', 0)
+    if (
+        isinstance(_persisted, int)
+        and _persisted >= SUBPROJECT_D_HASH_PRUNE_VERSION
+    ):
+        hash_history['_subproject_d_prune_version'] = _persisted
+        return False
+
+    _scope = _build_primary_wr_scope(groups)
+    _orphans: list[str] = []
+    for _hk in list(hash_history.keys()):
+        if isinstance(_hk, str) and _hk.startswith('_'):
+            continue
+        _parts = str(_hk).split('|')
+        if len(_parts) != 4:
+            continue
+        _hk_wr, _hk_week, _hk_variant, _hk_ident = _parts
+        if (
+            _hk_wr in _scope
+            and _hk_variant == 'primary'
+            and _hk_ident == ''
+        ):
+            _orphans.append(_hk)
+    for _ok in _orphans:
+        del hash_history[_ok]
+    hash_history['_subproject_d_prune_version'] = SUBPROJECT_D_HASH_PRUNE_VERSION
+    if _orphans:
+        _wr_sample = sorted({k.split('|')[0] for k in _orphans})[:20]
+        logging.info(
+            f"🧹 Subproject D hash-history prune: dropped {len(_orphans)} "
+            f"legacy unpartitioned primary orphan(s) "
+            f"(affected WRs first 20: {_wr_sample})"
+        )
+    else:
+        logging.info(
+            "🧹 Subproject D hash-history prune: no legacy unpartitioned "
+            "primary orphans to drop"
+        )
     return True
 
 
@@ -7930,6 +8009,19 @@ def main():  # pyright: ignore[reportGeneralTypeIssues]
             logging.warning(
                 f"⚠️ Vac crew hash-history prune failed; continuing "
                 f"with existing history: {_vc_prune_exc!r}"
+            )
+
+        # Subproject D: one-time prune of legacy blank-identifier primary
+        # orphans (kill switch is PRIMARY_CLAIM_ATTRIBUTION_ENABLED + the
+        # version constant). Fail-safe — a failed prune must not break the
+        # run.
+        try:
+            if _run_subproject_d_hash_prune(hash_history, groups):
+                _hash_history_migration_dirty = True
+        except Exception as _d_prune_exc:
+            logging.warning(
+                f"⚠️ Subproject D hash-history prune failed; continuing "
+                f"with existing history: {_d_prune_exc!r}"
             )
 
         billing_audit_row_cache: set[str] = set()

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -8229,12 +8229,24 @@ def main():  # pyright: ignore[reportGeneralTypeIssues]
                     )
                     file_identifier = identifier
                 else:
-                    # Legacy primary variant: identifier derived from the
-                    # row's ``User`` field.
-                    user_val = first_row.get('User')
-                    # PERFORMANCE: Use pre-compiled regex for identifier sanitization
-                    identifier = _RE_SANITIZE_IDENTIFIER.sub('_', user_val)[:50] if user_val else ''
-                    file_identifier = identifier
+                    # Subproject D (2026-05-25): Site 1 — main-loop primary
+                    # identity (history_key / file_identifier). Gated on kill
+                    # switch: enabled → frozen claimer (__current_foreman);
+                    # disabled → legacy ``User`` field ('' in production).
+                    if PRIMARY_CLAIM_ATTRIBUTION_ENABLED:
+                        __current_foreman = first_row.get('__current_foreman', '')
+                        identifier = (
+                            _RE_SANITIZE_IDENTIFIER.sub('_', __current_foreman)[:50]
+                            if __current_foreman else ''
+                        )
+                        file_identifier = identifier
+                    else:
+                        # Legacy primary variant: identifier derived from
+                        # the row's ``User`` field.
+                        user_val = first_row.get('User')
+                        # PERFORMANCE: Use pre-compiled regex for identifier sanitization
+                        identifier = _RE_SANITIZE_IDENTIFIER.sub('_', user_val)[:50] if user_val else ''
+                        file_identifier = identifier
                 
                 # History key includes variant dimension to prevent collisions
                 history_key = f"{wr_num}|{week_raw}|{variant}|{identifier}"

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -323,6 +323,14 @@ SUBPROJECT_B_HASH_PRUNE_VERSION = 1
 # three migrations are independent + auditable.
 # Advancing this constant is the kill switch (re-run trigger).
 VAC_CREW_HASH_PRUNE_VERSION = 1
+# Subproject D (2026-05-25): one-time hash-history prune version for
+# dropping LEGACY blank-identifier `primary` orphans left behind when
+# D re-partitions the production primary variant by frozen primary
+# claimer. Separate sentinel (`_subproject_d_prune_version`) from
+# Phase 1.1, Subproject B, and Subproject C so all four migrations are
+# independent + auditable. Advancing this constant is the kill switch
+# (re-run trigger).
+SUBPROJECT_D_HASH_PRUNE_VERSION = 1
 # Verbose debug tunables
 DEBUG_SAMPLE_ROWS = int(os.getenv('DEBUG_SAMPLE_ROWS','3') or 3)  # How many initial rows (across all sheets) to show full per-cell mapping
 DEBUG_ESSENTIAL_ROWS = int(os.getenv('DEBUG_ESSENTIAL_ROWS','5') or 5)  # How many initial rows to log essential field summary
@@ -551,6 +559,35 @@ VAC_CREW_LEGACY_CLEANUP_ENABLED = os.getenv(
     'VAC_CREW_LEGACY_CLEANUP_ENABLED', '1'
 ).strip().lower() in ('1', 'true', 'yes', 'on')
 
+# Subproject D (2026-05-25): default-ON kill switch that enables
+# per-claimer partitioning of the PRODUCTION primary Excel files. When
+# enabled, each non-subcontractor primary Excel is partitioned by the
+# FROZEN primary foreman (``primary`` role from
+# ``billing_audit.attribution_snapshot`` via ``resolve_claimer``) and
+# named ``_User_<claimer>``. When disabled, the legacy one-file-per-WR
+# bare primary behavior is preserved exactly. Unlike Subproject B, the
+# core primary path NEVER holds on a Supabase outage — it falls back to
+# the current foreman and still generates (operator decision: this path
+# covers every non-sub WR, so HOLD would suppress all primary billing
+# during an outage). Pinned in workflow env: block per [2026-05-15
+# 12:00] rule 7.
+PRIMARY_CLAIM_ATTRIBUTION_ENABLED = os.getenv(
+    'PRIMARY_CLAIM_ATTRIBUTION_ENABLED', '1'
+).strip().lower() in ('1', 'true', 'yes', 'on')
+
+# Subproject D (2026-05-25): default-ON kill switch for the one-time
+# removal of legacy UNPARTITIONED bare ``primary`` attachments (no
+# ``_User_`` token, parsed identifier == '') on TARGET_SHEET_ID for
+# non-subcontractor WRs, once those files are re-partitioned by frozen
+# primary claimer. Set to '0' to skip the destructive cleanup (legacy
+# duplicates then persist until removed manually). Separate from
+# PRIMARY_CLAIM_ATTRIBUTION_ENABLED (which gates attribution
+# resolution, NOT this cleanup). Workflow-pinned per [2026-05-15
+# 12:00] rule 7.
+LEGACY_PRIMARY_PARTITION_CLEANUP_ENABLED = os.getenv(
+    'LEGACY_PRIMARY_PARTITION_CLEANUP_ENABLED', '1'
+).strip().lower() in ('1', 'true', 'yes', 'on')
+
 # Cutoff date for ``_AEPBillable`` variant generation. Awarded to
 # Linetec on 2026-04-12 (subcontractor rate contract). Plan 2 (parser
 # extension) and Plan 3 (variant emission) gate variant emission on
@@ -718,6 +755,17 @@ logging.info(
 logging.info(
     f"📋 VAC Crew legacy cleanup: "
     f"{'ENABLED' if VAC_CREW_LEGACY_CLEANUP_ENABLED else 'DISABLED'}"
+)
+# Subproject D: surface resolved kill-switch state at startup so
+# operators grepping the banner see the active feature state at a
+# glance. Banner body carries no row PII (just the resolved bools).
+logging.info(
+    f"📋 PRIMARY_CLAIM_ATTRIBUTION_ENABLED="
+    f"{PRIMARY_CLAIM_ATTRIBUTION_ENABLED}"
+)
+logging.info(
+    f"📋 LEGACY_PRIMARY_PARTITION_CLEANUP_ENABLED="
+    f"{LEGACY_PRIMARY_PARTITION_CLEANUP_ENABLED}"
 )
 
 RESET_HASH_HISTORY = os.getenv('RESET_HASH_HISTORY','0').lower() in ('1','true','yes')  # When true, delete ALL existing WR_*.xlsx attachments & local files first

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -5383,6 +5383,16 @@ def group_source_rows(rows):
                 continue
             if _r.get('__is_vac_crew'):
                 continue
+            # Valid helper rows are excluded from the primary emission path
+            # below, so resolving a frozen primary claimer for them is pure
+            # overhead (extra Supabase load / latency). Mirror the
+            # valid_helper_row predicate (helper_dept required, job optional).
+            if (
+                _r.get('__is_helper_row')
+                and _r.get('__helper_foreman')
+                and _r.get('__helper_dept')
+            ):
+                continue
             _sid = _r.get('__source_sheet_id')
             if _sid is not None and _sid in _FOLDER_DISCOVERED_SUB_IDS:
                 continue  # subcontractor rows are Sub-project B's domain
@@ -5399,6 +5409,7 @@ def group_source_rows(rows):
                 _we.date() if isinstance(_we, datetime.datetime) else _we,
                 _r.get('__effective_user', 'Unknown Foreman'),
             ))
+
         if _d_pre_rows:
             try:
                 from billing_audit.writer import resolve_claimer as _resolve_claimer_primary
@@ -5418,7 +5429,10 @@ def group_source_rows(rows):
                 else:
                     _workers = min(PARALLEL_WORKERS, len(_d_pre_rows))
                     with ThreadPoolExecutor(max_workers=_workers) as _ex:
-                        _futs = [_ex.submit(_resolve_one_primary, _it) for _it in _d_pre_rows]
+                        _futs = [
+                            _ex.submit(_resolve_one_primary, _it)
+                            for _it in _d_pre_rows
+                        ]
                         for _fut in as_completed(_futs):
                             try:
                                 _rid, _out = _fut.result()

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -6565,7 +6565,19 @@ def generate_excel(group_key, group_rows, snapshot_date, ai_analysis_results=Non
         # emission passes None -> `current_foreman or effective_user`),
         # but the kill-switch gate keeps the suffix bare in that case.
         _pf = first_row.get('__current_foreman', '')
-        if PRIMARY_CLAIM_ATTRIBUTION_ENABLED and _pf:
+        # PR #223 Codex-P1 follow-up: gate on the grouping mode too. In
+        # RES_GROUPING_MODE='primary' the emission deliberately stays bare and
+        # lumps every non-helper/non-sub foreman's rows into ONE workbook per
+        # WR/week (partitioning by primary_foreman there is documented as
+        # semantically wrong). A _User_<claimer> suffix would mislabel that
+        # merged file and let row-order flip the attachment identity between
+        # runs. Primary mode therefore stays bare here, matching the
+        # already-mode-gated pre-pass + emission and Sites 1/2/3.
+        if (
+            PRIMARY_CLAIM_ATTRIBUTION_ENABLED
+            and RES_GROUPING_MODE in ('helper', 'both')
+            and _pf
+        ):
             variant_suffix = (
                 f"_User_{_RE_SANITIZE_IDENTIFIER.sub('_', _pf)[:50]}"
             )
@@ -8416,7 +8428,10 @@ def main():  # pyright: ignore[reportGeneralTypeIssues]
                     # identity (history_key / file_identifier). Gated on kill
                     # switch: enabled → frozen claimer (__current_foreman);
                     # disabled → legacy ``User`` field ('' in production).
-                    if PRIMARY_CLAIM_ATTRIBUTION_ENABLED:
+                    if (
+                        PRIMARY_CLAIM_ATTRIBUTION_ENABLED
+                        and RES_GROUPING_MODE in ('helper', 'both')
+                    ):
                         _pf = first_row.get('__current_foreman', '')
                         identifier = (
                             _RE_SANITIZE_IDENTIFIER.sub('_', _pf)[:50]
@@ -9159,7 +9174,10 @@ def main():  # pyright: ignore[reportGeneralTypeIssues]
                     # (Site 2 — valid_wr_weeks). Mirror Site 1 so attachment
                     # cleanup keeps the live per-claimer primary file.
                     # Disabled mode preserves the legacy ``User``-field path.
-                    if PRIMARY_CLAIM_ATTRIBUTION_ENABLED:
+                    if (
+                        PRIMARY_CLAIM_ATTRIBUTION_ENABLED
+                        and RES_GROUPING_MODE in ('helper', 'both')
+                    ):
                         _pf = group_rows[0].get('__current_foreman', '')
                         file_id = (
                             _RE_SANITIZE_IDENTIFIER.sub('_', _pf)[:50]
@@ -9415,7 +9433,10 @@ def main():  # pyright: ignore[reportGeneralTypeIssues]
                             # (sanitized claimer when on, legacy User-field
                             # when off) or the freshly-written entry is
                             # treated as stale and deleted before save.
-                            if PRIMARY_CLAIM_ATTRIBUTION_ENABLED:
+                            if (
+                                PRIMARY_CLAIM_ATTRIBUTION_ENABLED
+                                and RES_GROUPING_MODE in ('helper', 'both')
+                            ):
                                 _pf = group_rows[0].get('__current_foreman', '')
                                 _ident = (
                                     _RE_SANITIZE_IDENTIFIER.sub('_', _pf)[:50]

--- a/tests/test_primary_claim_attribution.py
+++ b/tests/test_primary_claim_attribution.py
@@ -64,7 +64,7 @@ class TestPrimaryFilenameSuffix(unittest.TestCase):
 def _make_primary_row(
     row_id,
     wr='90001',
-    week_serial=46100,  # arbitrary Excel serial -> a real date
+    week_serial='2026-04-19',  # ISO date; excel_serial_to_date is STRICT (rejects numeric serials) -> week key 041926
     effective_user='CurrentForeman',
     source_sheet_id=99999,  # NOT in _FOLDER_DISCOVERED_SUB_IDS
 ):

--- a/tests/test_primary_claim_attribution.py
+++ b/tests/test_primary_claim_attribution.py
@@ -129,6 +129,40 @@ class TestPrimaryPrePass(unittest.TestCase):
             f"expected a _USER_FrozenFM primary group, got {keys}",
         )
 
+    def _make_valid_helper_row(self, row_id, wr='90001'):
+        # A completed helper row (both checkboxes) with helper_foreman +
+        # helper_dept -> emitted to the _Helper_ shadow file, NOT the primary
+        # _USER_ group. The pre-pass must skip it (no wasted resolve_claimer).
+        r = _make_primary_row(row_id, wr=wr, effective_user='CurFM')
+        r['__is_helper_row'] = True
+        r['__helper_foreman'] = 'HelpFM'
+        r['__helper_dept'] = '600'
+        return r
+
+    def test_prepass_skips_valid_helper_row(self):
+        # PR #223 review follow-up: a valid helper row never emits a primary
+        # _USER_ group, so the pre-pass must not call resolve_claimer for it.
+        with mock.patch(
+            'billing_audit.writer.resolve_claimer',
+            return_value=ResolveOutcome('use', 'FrozenFM', 'frozen', 'success'),
+        ) as _rc:
+            gwp.group_source_rows([self._make_valid_helper_row(2001)])
+        _rc.assert_not_called()
+
+    def test_prepass_resolves_primary_only_skipping_helper(self):
+        rows = [
+            _make_primary_row(3001, wr='90002', effective_user='PFM'),
+            self._make_valid_helper_row(3002, wr='90002'),
+        ]
+        with mock.patch(
+            'billing_audit.writer.resolve_claimer',
+            return_value=ResolveOutcome('use', 'FrozenFM', 'frozen', 'success'),
+        ) as _rc:
+            gwp.group_source_rows(rows)
+        # resolve_claimer called exactly once (the primary row); the valid
+        # helper row was skipped by the pre-pass eligibility filter.
+        self.assertEqual(_rc.call_count, 1)
+
 
 class TestPrimaryPrePassSource(unittest.TestCase):
     """Task 3: the pre-pass exists with the right shape."""

--- a/tests/test_primary_claim_attribution.py
+++ b/tests/test_primary_claim_attribution.py
@@ -398,3 +398,57 @@ class TestBuildPrimaryWrScope(unittest.TestCase):
 
     def test_empty_groups(self):
         self.assertEqual(gwp._build_primary_wr_scope({}), set())
+
+
+class TestSubprojectDHashPrune(unittest.TestCase):
+    """Task 9: one-time prune of legacy bare-primary orphans, gated +
+    idempotent + migration-dirty bool."""
+
+    def setUp(self):
+        _ensure_smartsheet_mocked()
+        self._attr = gwp.PRIMARY_CLAIM_ATTRIBUTION_ENABLED
+        gwp.PRIMARY_CLAIM_ATTRIBUTION_ENABLED = True
+
+    def tearDown(self):
+        gwp.PRIMARY_CLAIM_ATTRIBUTION_ENABLED = self._attr
+
+    def _groups(self):
+        return {'041926_90001_USER_Alice': [{'Work Request #': '90001'}]}
+
+    def test_drops_bare_primary_orphan_for_in_scope_wr(self):
+        hist = {
+            '90001|041926|primary|': {'hash': 'x'},   # legacy bare orphan
+            '90001|041926|primary|Alice': {'hash': 'y'},  # new per-claimer (kept)
+            '90002|041926|primary|': {'hash': 'z'},   # out-of-scope (kept)
+        }
+        mutated = gwp._run_subproject_d_hash_prune(hist, self._groups())
+        self.assertTrue(mutated)
+        self.assertNotIn('90001|041926|primary|', hist)
+        self.assertIn('90001|041926|primary|Alice', hist)
+        self.assertIn('90002|041926|primary|', hist)
+        self.assertEqual(
+            hist['_subproject_d_prune_version'],
+            gwp.SUBPROJECT_D_HASH_PRUNE_VERSION,
+        )
+
+    def test_idempotent_second_run_is_noop(self):
+        hist = {'_subproject_d_prune_version': gwp.SUBPROJECT_D_HASH_PRUNE_VERSION}
+        mutated = gwp._run_subproject_d_hash_prune(hist, self._groups())
+        self.assertFalse(mutated)
+
+    def test_kill_switch_off_skips_and_no_sentinel_advance(self):
+        gwp.PRIMARY_CLAIM_ATTRIBUTION_ENABLED = False
+        hist = {'90001|041926|primary|': {'hash': 'x'}}
+        mutated = gwp._run_subproject_d_hash_prune(hist, self._groups())
+        self.assertFalse(mutated)
+        # OFF: the bare key is the ACTIVE legacy format — must NOT be dropped.
+        self.assertIn('90001|041926|primary|', hist)
+        self.assertNotIn('_subproject_d_prune_version', hist)
+
+    def test_call_site_wired_into_migration_dirty(self):
+        src = inspect.getsource(generate_weekly_pdfs)
+        self.assertRegex(
+            src,
+            r"if _run_subproject_d_hash_prune\(hash_history, groups\):"
+            r"\s*\n\s*_hash_history_migration_dirty = True",
+        )

--- a/tests/test_primary_claim_attribution.py
+++ b/tests/test_primary_claim_attribution.py
@@ -313,3 +313,62 @@ class TestSitesBCIdentity(unittest.TestCase):
             r"_ident = \(\s*_RE_SANITIZE_IDENTIFIER\.sub\('_', _pf\)\[:50\]"
             r"\s*if \(PRIMARY_CLAIM_ATTRIBUTION_ENABLED and _pf\)",
         )
+
+
+class TestWrFilterMatchesUserVariant(unittest.TestCase):
+    """Task 7: WR_FILTER (_key_matches_wr) retains _USER_ primary groups;
+    EXCLUDE_WRS (_key_matches_excluded_wr) already does."""
+
+    def setUp(self):
+        _ensure_smartsheet_mocked()
+        _reset_all()
+        self._saved = {
+            'attr': gwp.PRIMARY_CLAIM_ATTRIBUTION_ENABLED,
+            'avail': gwp.BILLING_AUDIT_AVAILABLE,
+            'mode': gwp.RES_GROUPING_MODE,
+            'sub': set(gwp._FOLDER_DISCOVERED_SUB_IDS),
+            'tm': gwp.TEST_MODE,
+            'wf': list(gwp.WR_FILTER),
+            'ex': list(gwp.EXCLUDE_WRS),
+        }
+        gwp.PRIMARY_CLAIM_ATTRIBUTION_ENABLED = True
+        gwp.BILLING_AUDIT_AVAILABLE = True
+        gwp.RES_GROUPING_MODE = 'both'
+        gwp._FOLDER_DISCOVERED_SUB_IDS.clear()
+
+    def tearDown(self):
+        gwp.PRIMARY_CLAIM_ATTRIBUTION_ENABLED = self._saved['attr']
+        gwp.BILLING_AUDIT_AVAILABLE = self._saved['avail']
+        gwp.RES_GROUPING_MODE = self._saved['mode']
+        gwp._FOLDER_DISCOVERED_SUB_IDS.clear()
+        gwp._FOLDER_DISCOVERED_SUB_IDS.update(self._saved['sub'])
+        gwp.TEST_MODE = self._saved['tm']
+        gwp.WR_FILTER = self._saved['wf']
+        gwp.EXCLUDE_WRS = self._saved['ex']
+
+    def test_wr_filter_retains_user_primary_group(self):
+        gwp.TEST_MODE = True
+        gwp.WR_FILTER = ['90001']
+        rows = [_make_primary_row(1, wr='90001', effective_user='CurFM')]
+        with mock.patch(
+            'billing_audit.writer.resolve_claimer',
+            return_value=ResolveOutcome('use', 'FrozenFM', 'frozen', 'success'),
+        ):
+            groups = gwp.group_source_rows(rows)
+        self.assertTrue(
+            any(k.endswith('_USER_FrozenFM') for k in groups),
+            f"WR_FILTER dropped the _USER_ primary group: {list(groups)}",
+        )
+
+    def test_exclude_wrs_drops_user_primary_group(self):
+        gwp.EXCLUDE_WRS = ['90001']
+        rows = [_make_primary_row(1, wr='90001', effective_user='CurFM')]
+        with mock.patch(
+            'billing_audit.writer.resolve_claimer',
+            return_value=ResolveOutcome('use', 'FrozenFM', 'frozen', 'success'),
+        ):
+            groups = gwp.group_source_rows(rows)
+        self.assertEqual(
+            [k for k in groups if k.endswith('_USER_FrozenFM')], [],
+            f"EXCLUDE_WRS failed to drop the _USER_ primary group: {list(groups)}",
+        )

--- a/tests/test_primary_claim_attribution.py
+++ b/tests/test_primary_claim_attribution.py
@@ -372,3 +372,29 @@ class TestWrFilterMatchesUserVariant(unittest.TestCase):
             [k for k in groups if k.endswith('_USER_FrozenFM')], [],
             f"EXCLUDE_WRS failed to drop the _USER_ primary group: {list(groups)}",
         )
+
+
+class TestBuildPrimaryWrScope(unittest.TestCase):
+    """Task 8: scope helper returns sanitized WRs with a partitioned
+    _USER_ primary group in this run."""
+
+    def test_scope_collects_partitioned_primary_wrs(self):
+        groups = {
+            '041926_90001_USER_Alice': [{'Work Request #': '90001'}],
+            '041926_90002_USER_Bob': [{'Work Request #': '90002'}],
+            '041926_90003_HELPER_Carol': [{'Work Request #': '90003'}],
+            '041926_90004_VACCREW_Dan': [{'Work Request #': '90004'}],
+            '041926_90005_REDUCEDSUB_USER_Eve': [{'Work Request #': '90005'}],
+            '041926_90006': [{'Work Request #': '90006'}],  # bare primary (OFF mode)
+        }
+        scope = gwp._build_primary_wr_scope(groups)
+        self.assertIn('90001', scope)
+        self.assertIn('90002', scope)
+        # Helper / vac / subcontractor / bare-primary groups are NOT in scope.
+        self.assertNotIn('90003', scope)
+        self.assertNotIn('90004', scope)
+        self.assertNotIn('90005', scope)  # REDUCEDSUB_USER is B's, not D's
+        self.assertNotIn('90006', scope)
+
+    def test_empty_groups(self):
+        self.assertEqual(gwp._build_primary_wr_scope({}), set())

--- a/tests/test_primary_claim_attribution.py
+++ b/tests/test_primary_claim_attribution.py
@@ -399,6 +399,17 @@ class TestBuildPrimaryWrScope(unittest.TestCase):
     def test_empty_groups(self):
         self.assertEqual(gwp._build_primary_wr_scope({}), set())
 
+    def test_helper_or_vac_only_wr_excluded_from_scope(self):
+        # A WR that has ONLY a _HELPER_ or _VACCREW group (no _USER_
+        # primary group) must NOT appear in D's scope — D only owns WRs
+        # it actually partitioned this run.
+        groups = {
+            '041926_90010_HELPER_Carol': [{'Work Request #': '90010'}],
+            '041926_90011_VACCREW_Dan': [{'Work Request #': '90011'}],
+        }
+        scope = gwp._build_primary_wr_scope(groups)
+        self.assertEqual(scope, set())
+
 
 class TestSubprojectDHashPrune(unittest.TestCase):
     """Task 9: one-time prune of legacy bare-primary orphans, gated +
@@ -451,4 +462,28 @@ class TestSubprojectDHashPrune(unittest.TestCase):
             src,
             r"if _run_subproject_d_hash_prune\(hash_history, groups\):"
             r"\s*\n\s*_hash_history_migration_dirty = True",
+        )
+
+    def test_non_primary_variant_not_dropped_for_in_scope_wr(self):
+        # A helper-variant (6-part) and a vac_crew-variant key for an
+        # IN-SCOPE WR must NOT be dropped — the prune is scoped to
+        # variant=='primary' + empty-identifier 4-part keys only.
+        hist = {
+            '90001|041926|primary|': {'hash': 'x'},          # dropped
+            '90001|041926|helper|Bob|500|J1': {'hash': 'h'},  # kept
+            '90001|041926|vac_crew|': {'hash': 'v'},          # kept
+        }
+        mutated = gwp._run_subproject_d_hash_prune(hist, self._groups())
+        self.assertTrue(mutated)
+        self.assertNotIn('90001|041926|primary|', hist)
+        self.assertIn('90001|041926|helper|Bob|500|J1', hist)
+        self.assertIn('90001|041926|vac_crew|', hist)
+
+    def test_empty_history_advances_sentinel(self):
+        hist = {}
+        mutated = gwp._run_subproject_d_hash_prune(hist, self._groups())
+        self.assertTrue(mutated)
+        self.assertEqual(
+            hist['_subproject_d_prune_version'],
+            gwp.SUBPROJECT_D_HASH_PRUNE_VERSION,
         )

--- a/tests/test_primary_claim_attribution.py
+++ b/tests/test_primary_claim_attribution.py
@@ -487,3 +487,66 @@ class TestSubprojectDHashPrune(unittest.TestCase):
             hist['_subproject_d_prune_version'],
             gwp.SUBPROJECT_D_HASH_PRUNE_VERSION,
         )
+
+
+class TestBarePrimaryCleanup(unittest.TestCase):
+    """Task 10: forced bare-primary attachment cleanup on TARGET, gated +
+    valid_wr_weeks-exempt."""
+
+    def setUp(self):
+        _ensure_smartsheet_mocked()
+
+    def _att(self, name):
+        a = mock.MagicMock()
+        a.name = name
+        a.id = name
+        return a
+
+    def _run(self, attachments, valid_wr_weeks, primary_wr_scope):
+        client = mock.MagicMock()
+        sheet = mock.MagicMock()
+        row = mock.MagicMock()
+        row.id = 1
+        sheet.rows = [row]
+        client.Attachments.list_row_attachments.return_value.data = attachments
+        deleted = []
+        client.Attachments.delete_attachment.side_effect = (
+            lambda sid, aid: deleted.append(aid)
+        )
+        gwp.cleanup_untracked_sheet_attachments(
+            client, 12345, valid_wr_weeks, False,
+            target_sheet=sheet,
+            primary_wr_scope=primary_wr_scope,
+        )
+        return deleted
+
+    def test_in_scope_bare_primary_deleted(self):
+        bare = self._att("WR_90001_WeekEnding_041926_120000_aaaaaaaaaaaaaaaa.xlsx")
+        deleted = self._run([bare], valid_wr_weeks=set(), primary_wr_scope={'90001'})
+        self.assertIn(bare.id, deleted)
+
+    def test_live_per_claimer_not_deleted(self):
+        live = self._att("WR_90001_WeekEnding_041926_120000_User_Alice_aaaaaaaaaaaaaaaa.xlsx")
+        # Per-claimer file is identity ('90001','041926','primary','Alice');
+        # it's in valid_wr_weeks this run and has a non-empty identifier.
+        vww = {('90001', '041926', 'primary', 'Alice')}
+        deleted = self._run([live], valid_wr_weeks=vww, primary_wr_scope={'90001'})
+        self.assertNotIn(live.id, deleted)
+
+    def test_overlapping_live_bare_exempt_via_valid_wr_weeks(self):
+        # A bare primary whose identity IS in valid_wr_weeks (e.g. OFF for
+        # those rows) must be exempt.
+        bare = self._att("WR_90001_WeekEnding_041926_120000_aaaaaaaaaaaaaaaa.xlsx")
+        vww = {('90001', '041926', 'primary', None)}
+        deleted = self._run([bare], valid_wr_weeks=vww, primary_wr_scope={'90001'})
+        self.assertNotIn(bare.id, deleted)
+
+    def test_out_of_scope_bare_primary_kept(self):
+        bare = self._att("WR_90099_WeekEnding_041926_120000_aaaaaaaaaaaaaaaa.xlsx")
+        deleted = self._run([bare], valid_wr_weeks=set(), primary_wr_scope={'90001'})
+        self.assertNotIn(bare.id, deleted)
+
+    def test_none_scope_is_noop(self):
+        bare = self._att("WR_90001_WeekEnding_041926_120000_aaaaaaaaaaaaaaaa.xlsx")
+        deleted = self._run([bare], valid_wr_weeks=set(), primary_wr_scope=None)
+        self.assertNotIn(bare.id, deleted)

--- a/tests/test_primary_claim_attribution.py
+++ b/tests/test_primary_claim_attribution.py
@@ -1,6 +1,8 @@
 """Sub-project D — primary-workflow primary claim attribution tests."""
 import datetime
 import inspect
+import os
+import tempfile
 import unittest
 from unittest import mock
 
@@ -54,9 +56,13 @@ class TestPrimaryFilenameSuffix(unittest.TestCase):
         # the kill switch + a non-empty __current_foreman.
         self.assertIn("_User_", src)
         # Confirm the gate wording is present in the primary suffix branch.
+        # PR #223 Codex-P1 follow-up widened the gate to also require
+        # RES_GROUPING_MODE in ('helper','both') (see TestPrimaryModeStaysBare),
+        # so the kill switch and ``and _pf`` are no longer adjacent — tolerate
+        # the interposed mode clause.
         self.assertRegex(
             src,
-            r"PRIMARY_CLAIM_ATTRIBUTION_ENABLED and _pf"
+            r"PRIMARY_CLAIM_ATTRIBUTION_ENABLED[\s\S]{0,120}and _pf"
             r"[\s\S]{0,200}_User_\{",
         )
 
@@ -242,6 +248,128 @@ class TestPrimaryEmission(unittest.TestCase):
         self.assertTrue(bare, f"expected a bare primary key, got {list(groups)}")
         # bare key shape is {week}_{wr}
         self.assertTrue(any(k.endswith('_90001') for k in bare))
+
+
+class TestPrimaryModeStaysBare(unittest.TestCase):
+    """PR #223 Codex P1 follow-up — primary-mode consistency.
+
+    In ``RES_GROUPING_MODE == 'primary'`` the emission deliberately stays
+    bare (``{week}_{wr}``) and lumps every non-helper/non-sub foreman's rows
+    into ONE workbook per WR/week — partitioning by ``primary_foreman`` there
+    is documented as *semantically wrong* (design spec §Scope / Out of scope;
+    Living Ledger). But pre-fix the ``generate_excel`` filename suffix and the
+    three identity sites gated ONLY on ``PRIMARY_CLAIM_ATTRIBUTION_ENABLED``
+    (default on), so they derived ``_User_<first-row foreman>`` even in
+    primary mode — mislabeling a multi-foreman workbook and letting row-order
+    changes flip the attachment identity between runs.
+
+    The fix gates all four surfaces on ``RES_GROUPING_MODE in ('helper',
+    'both')`` too, so primary mode is *consistently* bare at every surface
+    (matching the already-mode-gated pre-pass + emission). ``both`` / ``helper``
+    production behaviour is unchanged.
+    """
+
+    def setUp(self):
+        self._saved = {
+            'mode': gwp.RES_GROUPING_MODE,
+            'attr': gwp.PRIMARY_CLAIM_ATTRIBUTION_ENABLED,
+            'out': gwp.OUTPUT_FOLDER,
+        }
+        self._tmpdir = tempfile.TemporaryDirectory()
+        gwp.OUTPUT_FOLDER = self._tmpdir.name
+        gwp.PRIMARY_CLAIM_ATTRIBUTION_ENABLED = True
+
+    def tearDown(self):
+        gwp.RES_GROUPING_MODE = self._saved['mode']
+        gwp.PRIMARY_CLAIM_ATTRIBUTION_ENABLED = self._saved['attr']
+        gwp.OUTPUT_FOLDER = self._saved['out']
+        self._tmpdir.cleanup()
+
+    def _make_row(self, foreman):
+        return {
+            'Work Request #': '90001',
+            'Weekly Reference Logged Date': '2026-04-19',
+            'Units Completed?': True,
+            'Units Total Price': '$100.00',
+            'CU': 'XYZ',
+            'Work Type': 'Install',
+            'Quantity': 1,
+            'Customer Name': 'TestCustomer',
+            'Foreman': foreman,
+            'Dept #': '500',
+            'Job #': 'J-1',
+            '__effective_user': foreman,
+            '__current_foreman': foreman,
+            '__variant': 'primary',
+            '__week_ending_date': datetime.datetime(2026, 4, 19),
+        }
+
+    def _gen_basename(self):
+        rows = [self._make_row('PrimaryFM')]
+        result = gwp.generate_excel(
+            '041926_90001', rows, datetime.datetime(2026, 4, 19),
+            data_hash='deadbeefcafe0001',
+        )
+        return os.path.basename(result[0])
+
+    def test_primary_mode_filename_has_no_user_suffix(self):
+        gwp.RES_GROUPING_MODE = 'primary'
+        name = self._gen_basename()
+        self.assertNotIn(
+            '_User_', name,
+            f"primary-mode workbook must be bare (no _User_), got {name!r}",
+        )
+
+    def test_both_mode_filename_keeps_user_suffix(self):
+        # Positive control: the fix must NOT regress production ('both')
+        # mode, which DOES partition by claimer.
+        gwp.RES_GROUPING_MODE = 'both'
+        name = self._gen_basename()
+        self.assertIn(
+            '_User_PrimaryFM', name,
+            f"both-mode workbook must keep _User_<claimer>, got {name!r}",
+        )
+
+    def test_filename_suffix_gated_on_grouping_mode(self):
+        src = inspect.getsource(generate_weekly_pdfs)
+        # The primary filename-suffix branch must require helper/both mode
+        # in addition to the kill switch + non-empty __current_foreman.
+        # (\s+ tolerates the multi-line ``if (`` continuation form.)
+        self.assertRegex(
+            src,
+            r"PRIMARY_CLAIM_ATTRIBUTION_ENABLED\s+and\s+"
+            r"RES_GROUPING_MODE in \('helper', 'both'\)"
+            r"[\s\S]{0,160}_User_\{",
+        )
+
+    def test_site_a_identity_gated_on_grouping_mode(self):
+        src = inspect.getsource(generate_weekly_pdfs)
+        # Site 1 (main-loop history_key/file_identifier): gate must include
+        # the grouping-mode check so primary mode produces the legacy
+        # (User-field) identifier, NOT a __current_foreman _User_ identity.
+        self.assertRegex(
+            src,
+            r"PRIMARY_CLAIM_ATTRIBUTION_ENABLED\s+and\s+"
+            r"RES_GROUPING_MODE in \('helper', 'both'\)"
+            r"[\s\S]{0,520}__current_foreman"
+            r"[\s\S]{0,520}first_row\.get\('User'\)",
+        )
+
+    def test_sites_bc_identity_gated_on_grouping_mode(self):
+        import re as _re
+        src = inspect.getsource(generate_weekly_pdfs)
+        # Sites 2 & 3 (valid_wr_weeks / current_keys builders) plus the
+        # filename suffix and Site 1 all gate the __current_foreman primary
+        # partition on the grouping mode -> at least 4 occurrences.
+        count = len(_re.findall(
+            r"PRIMARY_CLAIM_ATTRIBUTION_ENABLED\s+and\s+"
+            r"RES_GROUPING_MODE in \('helper', 'both'\)",
+            src,
+        ))
+        self.assertGreaterEqual(
+            count, 4,
+            f"expected >=4 mode-gated primary surfaces, found {count}",
+        )
 
 
 class TestPrimaryFilenameRoundTrip(unittest.TestCase):
@@ -622,9 +750,14 @@ class TestSubprojectDProductionInvariants(unittest.TestCase):
             cls.src = f.read()
 
     def test_filename_suffix_user_gated(self):
+        # PR #223 Codex-P1 follow-up widened the primary suffix gate to also
+        # require RES_GROUPING_MODE in ('helper','both') (TestPrimaryModeStaysBare),
+        # so the kill switch and ``and _pf`` are no longer adjacent — tolerate
+        # the interposed mode clause.
         self.assertRegex(
             self.src,
-            r"PRIMARY_CLAIM_ATTRIBUTION_ENABLED and _pf[\s\S]{0,200}_User_\{",
+            r"PRIMARY_CLAIM_ATTRIBUTION_ENABLED[\s\S]{0,120}and _pf"
+            r"[\s\S]{0,200}_User_\{",
         )
 
     def test_wr_filter_matcher_has_user_clause(self):

--- a/tests/test_primary_claim_attribution.py
+++ b/tests/test_primary_claim_attribution.py
@@ -36,3 +36,26 @@ class TestConfigConstants(unittest.TestCase):
         self.assertIn(
             "📋 LEGACY_PRIMARY_PARTITION_CLEANUP_ENABLED=", src
         )
+
+
+class TestPrimaryFilenameSuffix(unittest.TestCase):
+    """Task 2: generate_excel emits _User_<claimer> for primary variant
+    when attribution is enabled, bare otherwise."""
+
+    def setUp(self):
+        self._orig = gwp.PRIMARY_CLAIM_ATTRIBUTION_ENABLED
+
+    def tearDown(self):
+        gwp.PRIMARY_CLAIM_ATTRIBUTION_ENABLED = self._orig
+
+    def test_primary_branch_builds_user_suffix_gated(self):
+        src = inspect.getsource(generate_weekly_pdfs)
+        # The primary branch must build _User_<sanitized claimer> gated on
+        # the kill switch + a non-empty __current_foreman.
+        self.assertIn("_User_", src)
+        # Confirm the gate wording is present in the primary suffix branch.
+        self.assertRegex(
+            src,
+            r"PRIMARY_CLAIM_ATTRIBUTION_ENABLED and _pf"
+            r"[\s\S]{0,200}_User_\{",
+        )

--- a/tests/test_primary_claim_attribution.py
+++ b/tests/test_primary_claim_attribution.py
@@ -619,3 +619,71 @@ class TestSubprojectDProductionInvariants(unittest.TestCase):
 
     def test_cleanup_has_primary_wr_scope_param(self):
         self.assertIn("primary_wr_scope: set[str] | None = None", self.src)
+
+
+class TestBuildGroupIdentityReservedTokenInClaimerName(unittest.TestCase):
+    """Final-review Issue #1 fix: a bare _User_<claimer> primary file whose
+    CLAIMER NAME contains a reserved token (Helper / VacCrew / ReducedSub /
+    AEPBillable) must parse as 'primary' with the full claimer, not be
+    misclassified by the variant scan. Generalizes the reserved-token-
+    parse-order rule (ledger [2026-05-21 13:20]) to the bare _User_ shape.
+    The parser now dispatches on the EARLIEST reserved-token position."""
+
+    _H = 'aaaaaaaaaaaaaaaa'  # 16-char hash
+
+    def _bgi(self, suffix):
+        return gwp.build_group_identity(
+            f"WR_90001_WeekEnding_041926_120000_{suffix}_{self._H}.xlsx"
+        )
+
+    # --- primary claimer NAME contains a reserved token (the bug) ---
+    def test_primary_claimer_named_helper(self):
+        self.assertEqual(self._bgi('User_Pat_Helper'),
+                         ('90001', '041926', 'primary', 'Pat_Helper'))
+
+    def test_primary_claimer_named_vaccrew(self):
+        self.assertEqual(self._bgi('User_VacCrew_Joe'),
+                         ('90001', '041926', 'primary', 'VacCrew_Joe'))
+
+    def test_primary_claimer_named_reducedsub(self):
+        self.assertEqual(self._bgi('User_ReducedSub_Bob'),
+                         ('90001', '041926', 'primary', 'ReducedSub_Bob'))
+
+    def test_primary_claimer_named_aepbillable(self):
+        self.assertEqual(self._bgi('User_AEPBillable_Sue'),
+                         ('90001', '041926', 'primary', 'AEPBillable_Sue'))
+
+    # --- inverse guards: helper/vac/sub members NAMED 'User' still parse right ---
+    def test_helper_named_user(self):
+        self.assertEqual(self._bgi('Helper_User_Smith'),
+                         ('90001', '041926', 'helper', 'User_Smith'))
+
+    def test_vaccrew_named_user(self):
+        self.assertEqual(self._bgi('VacCrew_User_Jones'),
+                         ('90001', '041926', 'vac_crew', 'User_Jones'))
+
+    # --- regression guards: B/C normal two-level shapes unchanged ---
+    def test_reducedsub_user_normal(self):
+        self.assertEqual(self._bgi('ReducedSub_User_Alice'),
+                         ('90001', '041926', 'reduced_sub', 'Alice'))
+
+    def test_aepbillable_helper_normal(self):
+        self.assertEqual(self._bgi('AEPBillable_Helper_Jane'),
+                         ('90001', '041926', 'aep_billable_helper', 'Jane'))
+
+    def test_reducedsub_helper_normal(self):
+        self.assertEqual(self._bgi('ReducedSub_Helper_Jane'),
+                         ('90001', '041926', 'reduced_sub_helper', 'Jane'))
+
+    def test_legacy_bare_vaccrew(self):
+        self.assertEqual(self._bgi('VacCrew'),
+                         ('90001', '041926', 'vac_crew', ''))
+
+    def test_bare_primary_no_marker(self):
+        # No reserved token at all -> bare primary, identifier None.
+        self.assertEqual(
+            gwp.build_group_identity(
+                f"WR_90001_WeekEnding_041926_120000_{self._H}.xlsx"
+            ),
+            ('90001', '041926', 'primary', None),
+        )

--- a/tests/test_primary_claim_attribution.py
+++ b/tests/test_primary_claim_attribution.py
@@ -197,13 +197,27 @@ class TestPrimaryEmission(unittest.TestCase):
         self.assertTrue(any(k.endswith('_USER_Bob') for k in groups))
 
     def test_no_history_falls_back_to_current(self):
+        # Use distinct values for effective_user vs outcome.name so the
+        # test can distinguish which branch the code took:
+        #   outcome.name='ResolvedName'  → the ``use`` branch consumed .name
+        #   effective_user='CurFM'       → the wrong/else branch fallback
+        # The ``no_history`` → ``use`` path must consume outcome.name.
         rows = [_make_primary_row(1, effective_user='CurFM')]
         with mock.patch(
             'billing_audit.writer.resolve_claimer',
-            return_value=ResolveOutcome('use', 'CurFM', 'current', 'no_history'),
+            return_value=ResolveOutcome('use', 'ResolvedName', 'current', 'no_history'),
         ):
             groups = gwp.group_source_rows(rows)
-        self.assertTrue(any(k.endswith('_USER_CurFM') for k in groups))
+        # outcome.name was consumed: key must end with _USER_ResolvedName,
+        # NOT with _USER_CurFM (which would mean effective_user was used).
+        self.assertTrue(
+            any(k.endswith('_USER_ResolvedName') for k in groups),
+            f"expected _USER_ResolvedName key; got {list(groups)}",
+        )
+        self.assertFalse(
+            any(k.endswith('_USER_CurFM') for k in groups),
+            "effective_user leaked into key — code must use outcome.name on the 'use' branch",
+        )
 
     def test_hold_outage_still_emits_under_current(self):
         rows = [_make_primary_row(1, effective_user='CurFM')]
@@ -245,3 +259,13 @@ class TestPrimaryFilenameRoundTrip(unittest.TestCase):
         self.assertEqual(a, ('90001', '041926', 'primary', 'Alice'))
         self.assertEqual(b, ('90001', '041926', 'primary', 'Bob'))
         self.assertNotEqual(a, b)  # distinct -> cleanup keeps both
+
+
+class TestPrimaryGroupCreatedPiiMarker(unittest.TestCase):
+    """Task 4 review fix: the PRIMARY GROUP CREATED INFO log embeds WR=/Week=
+    PII, so its marker must be registered in _PII_LOG_MARKERS (mirrors the
+    five sibling GROUP CREATED markers; [2026-04-20 12:00] / [2026-05-15
+    12:00] rules)."""
+
+    def test_marker_registered(self):
+        self.assertIn("PRIMARY GROUP CREATED", gwp._PII_LOG_MARKERS)

--- a/tests/test_primary_claim_attribution.py
+++ b/tests/test_primary_claim_attribution.py
@@ -59,3 +59,83 @@ class TestPrimaryFilenameSuffix(unittest.TestCase):
             r"PRIMARY_CLAIM_ATTRIBUTION_ENABLED and _pf"
             r"[\s\S]{0,200}_User_\{",
         )
+
+
+def _make_primary_row(
+    row_id,
+    wr='90001',
+    week_serial=46100,  # arbitrary Excel serial -> a real date
+    effective_user='CurrentForeman',
+    source_sheet_id=99999,  # NOT in _FOLDER_DISCOVERED_SUB_IDS
+):
+    """Build a synthetic NON-subcontractor, completed, non-helper,
+    non-vac primary row for group_source_rows."""
+    return {
+        '__row_id': row_id,
+        '__source_sheet_id': source_sheet_id,
+        '__effective_user': effective_user,
+        '__is_helper_row': False,
+        '__is_vac_crew': False,
+        'Work Request #': wr,
+        'Weekly Reference Logged Date': week_serial,
+        'Units Completed?': True,
+        'Units Total Price': 100.0,
+        'Dept #': '500',
+        'Job #': 'J-1',
+    }
+
+
+class TestPrimaryPrePass(unittest.TestCase):
+    """Task 3: the pre-pass resolves frozen claimers for non-sub
+    completed primary rows into _primary_claimer_map."""
+
+    def setUp(self):
+        _ensure_smartsheet_mocked()
+        _reset_all()
+        self._saved = {
+            'attr': gwp.PRIMARY_CLAIM_ATTRIBUTION_ENABLED,
+            'avail': gwp.BILLING_AUDIT_AVAILABLE,
+            'mode': gwp.RES_GROUPING_MODE,
+            'sub': set(gwp._FOLDER_DISCOVERED_SUB_IDS),
+        }
+        gwp.PRIMARY_CLAIM_ATTRIBUTION_ENABLED = True
+        gwp.BILLING_AUDIT_AVAILABLE = True
+        gwp.RES_GROUPING_MODE = 'both'
+        gwp._FOLDER_DISCOVERED_SUB_IDS.clear()  # row sheet 99999 is non-sub
+
+    def tearDown(self):
+        gwp.PRIMARY_CLAIM_ATTRIBUTION_ENABLED = self._saved['attr']
+        gwp.BILLING_AUDIT_AVAILABLE = self._saved['avail']
+        gwp.RES_GROUPING_MODE = self._saved['mode']
+        gwp._FOLDER_DISCOVERED_SUB_IDS.clear()
+        gwp._FOLDER_DISCOVERED_SUB_IDS.update(self._saved['sub'])
+
+    def test_prepass_resolves_frozen_claimer_into_group_key(self):
+        rows = [_make_primary_row(1001, effective_user='CurFM')]
+        with mock.patch(
+            'billing_audit.writer.resolve_claimer',
+            return_value=ResolveOutcome('use', 'FrozenFM', 'frozen', 'success'),
+        ):
+            groups = gwp.group_source_rows(rows)
+        keys = list(groups.keys())
+        self.assertTrue(
+            any(k.endswith('_USER_FrozenFM') for k in keys),
+            f"expected a _USER_FrozenFM primary group, got {keys}",
+        )
+
+
+class TestPrimaryPrePassSource(unittest.TestCase):
+    """Task 3: the pre-pass exists with the right shape."""
+
+    def test_prepass_block_present(self):
+        src = inspect.getsource(generate_weekly_pdfs)
+        self.assertIn("_primary_claimer_map", src)
+        self.assertRegex(
+            src,
+            r"resolve_claimer_primary\(\s*'primary'",
+        )
+        # Pre-pass must exclude subcontractor + vac rows.
+        self.assertRegex(
+            src,
+            r"_primary_claimer_map[\s\S]{0,600}_FOLDER_DISCOVERED_SUB_IDS",
+        )

--- a/tests/test_primary_claim_attribution.py
+++ b/tests/test_primary_claim_attribution.py
@@ -379,13 +379,15 @@ class TestBuildPrimaryWrScope(unittest.TestCase):
     _USER_ primary group in this run."""
 
     def test_scope_collects_partitioned_primary_wrs(self):
+        # __variant is the authoritative variant signal (set at emission);
+        # the scope builder reads it, not a key substring.
         groups = {
-            '041926_90001_USER_Alice': [{'Work Request #': '90001'}],
-            '041926_90002_USER_Bob': [{'Work Request #': '90002'}],
-            '041926_90003_HELPER_Carol': [{'Work Request #': '90003'}],
-            '041926_90004_VACCREW_Dan': [{'Work Request #': '90004'}],
-            '041926_90005_REDUCEDSUB_USER_Eve': [{'Work Request #': '90005'}],
-            '041926_90006': [{'Work Request #': '90006'}],  # bare primary (OFF mode)
+            '041926_90001_USER_Alice': [{'Work Request #': '90001', '__variant': 'primary'}],
+            '041926_90002_USER_Bob': [{'Work Request #': '90002', '__variant': 'primary'}],
+            '041926_90003_HELPER_Carol': [{'Work Request #': '90003', '__variant': 'helper'}],
+            '041926_90004_VACCREW_Dan': [{'Work Request #': '90004', '__variant': 'vac_crew'}],
+            '041926_90005_REDUCEDSUB_USER_Eve': [{'Work Request #': '90005', '__variant': 'reduced_sub'}],
+            '041926_90006': [{'Work Request #': '90006', '__variant': 'primary'}],  # bare primary (OFF/'primary' mode), no _USER_
         }
         scope = gwp._build_primary_wr_scope(groups)
         self.assertIn('90001', scope)
@@ -393,8 +395,8 @@ class TestBuildPrimaryWrScope(unittest.TestCase):
         # Helper / vac / subcontractor / bare-primary groups are NOT in scope.
         self.assertNotIn('90003', scope)
         self.assertNotIn('90004', scope)
-        self.assertNotIn('90005', scope)  # REDUCEDSUB_USER is B's, not D's
-        self.assertNotIn('90006', scope)
+        self.assertNotIn('90005', scope)  # reduced_sub variant is B's, not D's
+        self.assertNotIn('90006', scope)  # primary but bare (no _USER_)
 
     def test_empty_groups(self):
         self.assertEqual(gwp._build_primary_wr_scope({}), set())
@@ -404,11 +406,39 @@ class TestBuildPrimaryWrScope(unittest.TestCase):
         # primary group) must NOT appear in D's scope — D only owns WRs
         # it actually partitioned this run.
         groups = {
-            '041926_90010_HELPER_Carol': [{'Work Request #': '90010'}],
-            '041926_90011_VACCREW_Dan': [{'Work Request #': '90011'}],
+            '041926_90010_HELPER_Carol': [{'Work Request #': '90010', '__variant': 'helper'}],
+            '041926_90011_VACCREW_Dan': [{'Work Request #': '90011', '__variant': 'vac_crew'}],
         }
         scope = gwp._build_primary_wr_scope(groups)
         self.assertEqual(scope, set())
+
+    def test_reserved_token_in_name_does_not_false_positive(self):
+        # Codex PR #223 P1 regression guard. The scope builder must decide
+        # variant from the authoritative ``__variant`` field, NOT a key
+        # substring — otherwise a claimer / helper / vac name containing a
+        # reserved word mis-buckets the WR (and the scope feeds the
+        # DESTRUCTIVE bare-primary cleanup + the hash prune).
+        groups = {
+            # helper whose NAME contains the USER token -> key has _USER_
+            # substring but __variant=='helper' -> must be EXCLUDED.
+            '041926_90020_HELPER_USER_Smith': [
+                {'Work Request #': '90020', '__variant': 'helper'}],
+            # vac member named USER -> EXCLUDED.
+            '041926_90021_VACCREW_USER_Jones': [
+                {'Work Request #': '90021', '__variant': 'vac_crew'}],
+            # genuine primary claimer whose NAME contains a reserved word
+            # -> must be INCLUDED (the old substring exclusions wrongly
+            # dropped these).
+            '041926_90022_USER_ReducedSub_Bob': [
+                {'Work Request #': '90022', '__variant': 'primary'}],
+            '041926_90023_USER_AEPBillable_Sue': [
+                {'Work Request #': '90023', '__variant': 'primary'}],
+        }
+        scope = gwp._build_primary_wr_scope(groups)
+        self.assertNotIn('90020', scope)
+        self.assertNotIn('90021', scope)
+        self.assertIn('90022', scope)
+        self.assertIn('90023', scope)
 
 
 class TestSubprojectDHashPrune(unittest.TestCase):
@@ -424,7 +454,8 @@ class TestSubprojectDHashPrune(unittest.TestCase):
         gwp.PRIMARY_CLAIM_ATTRIBUTION_ENABLED = self._attr
 
     def _groups(self):
-        return {'041926_90001_USER_Alice': [{'Work Request #': '90001'}]}
+        return {'041926_90001_USER_Alice': [
+            {'Work Request #': '90001', '__variant': 'primary'}]}
 
     def test_drops_bare_primary_orphan_for_in_scope_wr(self):
         hist = {

--- a/tests/test_primary_claim_attribution.py
+++ b/tests/test_primary_claim_attribution.py
@@ -139,3 +139,109 @@ class TestPrimaryPrePassSource(unittest.TestCase):
             src,
             r"_primary_claimer_map[\s\S]{0,600}_FOLDER_DISCOVERED_SUB_IDS",
         )
+
+
+class TestPrimaryEmission(unittest.TestCase):
+    """Task 4: production primary emission partitions by claimer when on,
+    bare when off; never holds."""
+
+    def setUp(self):
+        _ensure_smartsheet_mocked()
+        _reset_all()
+        self._saved = {
+            'attr': gwp.PRIMARY_CLAIM_ATTRIBUTION_ENABLED,
+            'avail': gwp.BILLING_AUDIT_AVAILABLE,
+            'mode': gwp.RES_GROUPING_MODE,
+            'sub': set(gwp._FOLDER_DISCOVERED_SUB_IDS),
+        }
+        gwp.PRIMARY_CLAIM_ATTRIBUTION_ENABLED = True
+        gwp.BILLING_AUDIT_AVAILABLE = True
+        gwp.RES_GROUPING_MODE = 'both'
+        gwp._FOLDER_DISCOVERED_SUB_IDS.clear()
+
+    def tearDown(self):
+        gwp.PRIMARY_CLAIM_ATTRIBUTION_ENABLED = self._saved['attr']
+        gwp.BILLING_AUDIT_AVAILABLE = self._saved['avail']
+        gwp.RES_GROUPING_MODE = self._saved['mode']
+        gwp._FOLDER_DISCOVERED_SUB_IDS.clear()
+        gwp._FOLDER_DISCOVERED_SUB_IDS.update(self._saved['sub'])
+
+    def test_frozen_claimer_partitions_key(self):
+        rows = [_make_primary_row(1, effective_user='CurFM')]
+        with mock.patch(
+            'billing_audit.writer.resolve_claimer',
+            return_value=ResolveOutcome('use', 'FrozenFM', 'frozen', 'success'),
+        ):
+            groups = gwp.group_source_rows(rows)
+        self.assertTrue(any(k.endswith('_USER_FrozenFM') for k in groups))
+        # The legacy bare primary key must NOT be present.
+        self.assertFalse(
+            any(k.split('_USER_')[0] == k and '_USER_' not in k
+                and k.count('_') == 1 for k in groups),
+        )
+
+    def test_two_claimers_two_groups(self):
+        rows = [
+            _make_primary_row(1, wr='90001', effective_user='A'),
+            _make_primary_row(2, wr='90001', effective_user='B'),
+        ]
+
+        def _resolve(variant, current, *, wr, week_ending, row_id, enabled):
+            return ResolveOutcome(
+                'use', 'Alice' if row_id == 1 else 'Bob', 'frozen', 'success'
+            )
+
+        with mock.patch('billing_audit.writer.resolve_claimer', side_effect=_resolve):
+            groups = gwp.group_source_rows(rows)
+        self.assertTrue(any(k.endswith('_USER_Alice') for k in groups))
+        self.assertTrue(any(k.endswith('_USER_Bob') for k in groups))
+
+    def test_no_history_falls_back_to_current(self):
+        rows = [_make_primary_row(1, effective_user='CurFM')]
+        with mock.patch(
+            'billing_audit.writer.resolve_claimer',
+            return_value=ResolveOutcome('use', 'CurFM', 'current', 'no_history'),
+        ):
+            groups = gwp.group_source_rows(rows)
+        self.assertTrue(any(k.endswith('_USER_CurFM') for k in groups))
+
+    def test_hold_outage_still_emits_under_current(self):
+        rows = [_make_primary_row(1, effective_user='CurFM')]
+        with mock.patch(
+            'billing_audit.writer.resolve_claimer',
+            return_value=ResolveOutcome('hold', None, None, 'fetch_failure'),
+        ), mock.patch(
+            'billing_audit.writer.record_attribution_hold'
+        ) as _rec:
+            groups = gwp.group_source_rows(rows)
+        # D never holds: a primary group IS emitted under current foreman.
+        self.assertTrue(any(k.endswith('_USER_CurFM') for k in groups))
+        # And record_attribution_hold is NEVER called for the primary path.
+        _rec.assert_not_called()
+
+    def test_kill_switch_off_emits_bare_legacy_key(self):
+        gwp.PRIMARY_CLAIM_ATTRIBUTION_ENABLED = False
+        rows = [_make_primary_row(1, wr='90001', effective_user='CurFM')]
+        # No mock needed — pre-pass is gated off, emission is legacy.
+        groups = gwp.group_source_rows(rows)
+        bare = [k for k in groups if '_USER_' not in k]
+        self.assertTrue(bare, f"expected a bare primary key, got {list(groups)}")
+        # bare key shape is {week}_{wr}
+        self.assertTrue(any(k.endswith('_90001') for k in bare))
+
+
+class TestPrimaryFilenameRoundTrip(unittest.TestCase):
+    """Task 2+4: two claimers on one WR+week produce two distinct
+    _User_ filenames that round-trip through build_group_identity as
+    distinct primary identities (coexistence; no cross-delete)."""
+
+    def test_distinct_identities_for_two_claimers(self):
+        a = gwp.build_group_identity(
+            "WR_90001_WeekEnding_041926_120000_User_Alice_abcdef0123456789.xlsx"
+        )
+        b = gwp.build_group_identity(
+            "WR_90001_WeekEnding_041926_120000_User_Bob_abcdef0123456789.xlsx"
+        )
+        self.assertEqual(a, ('90001', '041926', 'primary', 'Alice'))
+        self.assertEqual(b, ('90001', '041926', 'primary', 'Bob'))
+        self.assertNotEqual(a, b)  # distinct -> cleanup keeps both

--- a/tests/test_primary_claim_attribution.py
+++ b/tests/test_primary_claim_attribution.py
@@ -550,3 +550,72 @@ class TestBarePrimaryCleanup(unittest.TestCase):
         bare = self._att("WR_90001_WeekEnding_041926_120000_aaaaaaaaaaaaaaaa.xlsx")
         deleted = self._run([bare], valid_wr_weeks=set(), primary_wr_scope=None)
         self.assertNotIn(bare.id, deleted)
+
+
+class TestBuildGroupIdentityPrimaryUserRoundTrip(unittest.TestCase):
+    """Task 11: parser round-trips D's _User_<claimer> primary filename."""
+
+    def test_plain_claimer(self):
+        self.assertEqual(
+            gwp.build_group_identity(
+                "WR_90001_WeekEnding_041926_120000_User_Alice_aaaaaaaaaaaaaaaa.xlsx"
+            ),
+            ('90001', '041926', 'primary', 'Alice'),
+        )
+
+    def test_underscored_claimer(self):
+        self.assertEqual(
+            gwp.build_group_identity(
+                "WR_90001_WeekEnding_041926_120000_User_Jane_Smith_aaaaaaaaaaaaaaaa.xlsx"
+            ),
+            ('90001', '041926', 'primary', 'Jane_Smith'),
+        )
+
+    def test_bare_primary_still_parses(self):
+        # OFF-mode legacy bare primary -> identifier None.
+        self.assertEqual(
+            gwp.build_group_identity(
+                "WR_90001_WeekEnding_041926_120000_aaaaaaaaaaaaaaaa.xlsx"
+            ),
+            ('90001', '041926', 'primary', None),
+        )
+
+
+class TestSubprojectDProductionInvariants(unittest.TestCase):
+    """Task 11: source-grep guards for the four-site lockstep + matcher
+    mirror + filename suffix + prune-kill-switch gate."""
+
+    @classmethod
+    def setUpClass(cls):
+        with open(inspect.getsourcefile(generate_weekly_pdfs), encoding='utf-8') as f:
+            cls.src = f.read()
+
+    def test_filename_suffix_user_gated(self):
+        self.assertRegex(
+            self.src,
+            r"PRIMARY_CLAIM_ATTRIBUTION_ENABLED and _pf[\s\S]{0,200}_User_\{",
+        )
+
+    def test_wr_filter_matcher_has_user_clause(self):
+        # Both matchers must carry the _USER_ prefix clause (count >= 2).
+        self.assertGreaterEqual(
+            self.src.count('startswith(f"{wr}_USER_")'), 2,
+            "both _key_matches_wr and _key_matches_excluded_wr must match _USER_",
+        )
+
+    def test_prune_gated_on_kill_switch(self):
+        # Window widened to 2000: Task 9 added a long docstring (~1824 chars)
+        # between the def line and the kill-switch guard. The structural
+        # invariant (kill-switch early-return) is present and correct in
+        # production; only the scan window needed adjustment.
+        self.assertRegex(
+            self.src,
+            r"def _run_subproject_d_hash_prune[\s\S]{0,2000}"
+            r"if not PRIMARY_CLAIM_ATTRIBUTION_ENABLED:\s*\n\s*return False",
+        )
+
+    def test_prune_wired_into_call_site(self):
+        self.assertIn("_run_subproject_d_hash_prune(hash_history, groups)", self.src)
+
+    def test_cleanup_has_primary_wr_scope_param(self):
+        self.assertIn("primary_wr_scope: set[str] | None = None", self.src)

--- a/tests/test_primary_claim_attribution.py
+++ b/tests/test_primary_claim_attribution.py
@@ -280,9 +280,36 @@ class TestSiteAMainLoopIdentity(unittest.TestCase):
         # The primary identity branch must derive from __current_foreman
         # gated on PRIMARY_CLAIM_ATTRIBUTION_ENABLED, and keep the legacy
         # User-field path for the disabled case.
+        # Note: span widened to 500 after Task 6 renamed the Site-1 local
+        # variable to ``_pf``, adding comments that push the gap past 300
+        # chars. The structural invariant (PRIMARY_CLAIM_ATTRIBUTION_ENABLED
+        # → __current_foreman dict-key → first_row.get('User') fallback) is
+        # preserved — only the window size changed.
         self.assertRegex(
             src,
-            r"PRIMARY_CLAIM_ATTRIBUTION_ENABLED[\s\S]{0,300}"
-            r"__current_foreman[\s\S]{0,300}"
+            r"PRIMARY_CLAIM_ATTRIBUTION_ENABLED[\s\S]{0,500}"
+            r"__current_foreman[\s\S]{0,500}"
             r"first_row\.get\('User'\)",
+        )
+
+
+class TestSitesBCIdentity(unittest.TestCase):
+    """Task 6: valid_wr_weeks (Site 2) and current_keys (Site 3) primary
+    branches derive from __current_foreman gated on the kill switch."""
+
+    def test_sites_b_and_c_gated_primary_identity(self):
+        src = inspect.getsource(generate_weekly_pdfs)
+        # Site 2 (valid_wr_weeks builder): the else branch builds file_id
+        # from __current_foreman gated on PRIMARY_CLAIM_ATTRIBUTION_ENABLED.
+        self.assertRegex(
+            src,
+            r"file_id = \(\s*_RE_SANITIZE_IDENTIFIER\.sub\('_', _pf\)\[:50\]"
+            r"\s*if \(PRIMARY_CLAIM_ATTRIBUTION_ENABLED and _pf\)",
+        )
+        # Site 3 (current_keys builder): the else branch builds _ident
+        # from __current_foreman gated on PRIMARY_CLAIM_ATTRIBUTION_ENABLED.
+        self.assertRegex(
+            src,
+            r"_ident = \(\s*_RE_SANITIZE_IDENTIFIER\.sub\('_', _pf\)\[:50\]"
+            r"\s*if \(PRIMARY_CLAIM_ATTRIBUTION_ENABLED and _pf\)",
         )

--- a/tests/test_primary_claim_attribution.py
+++ b/tests/test_primary_claim_attribution.py
@@ -1,0 +1,38 @@
+"""Sub-project D — primary-workflow primary claim attribution tests."""
+import datetime
+import inspect
+import unittest
+from unittest import mock
+
+import generate_weekly_pdfs  # noqa: E402
+from tests.test_billing_audit_shadow import _ensure_smartsheet_mocked, _reset_all  # noqa: E402
+
+_ensure_smartsheet_mocked()
+
+from billing_audit.writer import ResolveOutcome  # noqa: E402
+
+gwp = generate_weekly_pdfs
+
+
+class TestConfigConstants(unittest.TestCase):
+    """Task 1: D config surface exists with the right defaults."""
+
+    def test_hash_prune_version_constant(self):
+        self.assertEqual(gwp.SUBPROJECT_D_HASH_PRUNE_VERSION, 1)
+
+    def test_attribution_flag_is_bool(self):
+        self.assertIsInstance(gwp.PRIMARY_CLAIM_ATTRIBUTION_ENABLED, bool)
+
+    def test_cleanup_flag_is_bool(self):
+        self.assertIsInstance(
+            gwp.LEGACY_PRIMARY_PARTITION_CLEANUP_ENABLED, bool
+        )
+
+    def test_banner_logs_attribution_flag(self):
+        src = inspect.getsource(generate_weekly_pdfs)
+        self.assertIn(
+            "📋 PRIMARY_CLAIM_ATTRIBUTION_ENABLED=", src
+        )
+        self.assertIn(
+            "📋 LEGACY_PRIMARY_PARTITION_CLEANUP_ENABLED=", src
+        )

--- a/tests/test_primary_claim_attribution.py
+++ b/tests/test_primary_claim_attribution.py
@@ -269,3 +269,20 @@ class TestPrimaryGroupCreatedPiiMarker(unittest.TestCase):
 
     def test_marker_registered(self):
         self.assertIn("PRIMARY GROUP CREATED", gwp._PII_LOG_MARKERS)
+
+
+class TestSiteAMainLoopIdentity(unittest.TestCase):
+    """Task 5: main-loop primary identity derives from __current_foreman
+    when attribution is on (gated), legacy User field when off."""
+
+    def test_site_a_gated_primary_identity(self):
+        src = inspect.getsource(generate_weekly_pdfs)
+        # The primary identity branch must derive from __current_foreman
+        # gated on PRIMARY_CLAIM_ATTRIBUTION_ENABLED, and keep the legacy
+        # User-field path for the disabled case.
+        self.assertRegex(
+            src,
+            r"PRIMARY_CLAIM_ATTRIBUTION_ENABLED[\s\S]{0,300}"
+            r"__current_foreman[\s\S]{0,300}"
+            r"first_row\.get\('User'\)",
+        )

--- a/tests/test_security_audit_followup.py
+++ b/tests/test_security_audit_followup.py
@@ -2415,7 +2415,7 @@ class TestWrFilterMatchesAllVariants(unittest.TestCase):
             or suffix.startswith(f"{wr}_USER_")
         )
 
-    def test_all_seven_variants_retained_for_target_wr(self):
+    def test_all_eight_variants_retained_for_target_wr(self):
         # Sub-project D (2026-05-25): _USER_ IS now retained — the
         # asymmetry with `_key_matches_excluded_wr` is resolved.
         wr = '12345'

--- a/tests/test_security_audit_followup.py
+++ b/tests/test_security_audit_followup.py
@@ -2303,23 +2303,35 @@ class TestExcludeWrsMatchesAllVariants(unittest.TestCase):
             or suffix.startswith(f"{wr}_HELPER_")
             or suffix.startswith(f"{wr}_USER_")
             or suffix == f"{wr}_VACCREW"
+            or suffix.startswith(f"{wr}_VACCREW_")
             or suffix == f"{wr}_REDUCEDSUB"
             or suffix == f"{wr}_AEPBILLABLE"
             or suffix.startswith(f"{wr}_REDUCEDSUB_HELPER_")
             or suffix.startswith(f"{wr}_AEPBILLABLE_HELPER_")
+            or suffix.startswith(f"{wr}_REDUCEDSUB_USER_")
+            or suffix.startswith(f"{wr}_AEPBILLABLE_USER_")
         )
 
-    def test_all_seven_variants_excluded_for_target_wr(self):
+    def test_all_variants_excluded_for_target_wr(self):
+        # PR #223 follow-up (Copilot): added the Subproject B per-claimer
+        # subcontractor primary shapes {wr}_REDUCEDSUB_USER_<claimer> and
+        # {wr}_AEPBILLABLE_USER_<claimer> (attribution-on production default)
+        # plus the Subproject C {wr}_VACCREW_<claimer> shape — the matcher
+        # previously missed all three, so EXCLUDE_WRS silently failed to
+        # exclude them.
         wr = '12345'
         keys = [
             f'041926_{wr}',                            # primary
             f'041926_{wr}_HELPER_Jane_Smith',          # helper
-            f'041926_{wr}_USER_John_Doe',              # USER (legacy)
+            f'041926_{wr}_USER_John_Doe',              # primary (Subproject D)
             f'041926_{wr}_VACCREW',                    # vac_crew
+            f'041926_{wr}_VACCREW_Vic_Crew',           # vac_crew (Subproject C)
             f'041926_{wr}_REDUCEDSUB',                 # reduced_sub
             f'041926_{wr}_AEPBILLABLE',                # aep_billable
             f'041926_{wr}_REDUCEDSUB_HELPER_Jane_Doe', # reduced_sub_helper
             f'041926_{wr}_AEPBILLABLE_HELPER_J_Smith', # aep_billable_helper
+            f'041926_{wr}_REDUCEDSUB_USER_Sue_Sub',    # reduced_sub (Subproject B)
+            f'041926_{wr}_AEPBILLABLE_USER_Sue_Sub',   # aep_billable (Subproject B)
         ]
         for k in keys:
             with self.subTest(key=k):
@@ -2413,21 +2425,31 @@ class TestWrFilterMatchesAllVariants(unittest.TestCase):
             or suffix.startswith(f"{wr}_REDUCEDSUB_HELPER_")
             or suffix.startswith(f"{wr}_AEPBILLABLE_HELPER_")
             or suffix.startswith(f"{wr}_USER_")
+            or suffix.startswith(f"{wr}_REDUCEDSUB_USER_")
+            or suffix.startswith(f"{wr}_AEPBILLABLE_USER_")
         )
 
-    def test_all_eight_variants_retained_for_target_wr(self):
+    def test_all_variants_retained_for_target_wr(self):
         # Sub-project D (2026-05-25): _USER_ IS now retained — the
         # asymmetry with `_key_matches_excluded_wr` is resolved.
+        # PR #223 follow-up (Copilot): added the Subproject B per-claimer
+        # subcontractor primary shapes {wr}_REDUCEDSUB_USER_<claimer> /
+        # {wr}_AEPBILLABLE_USER_<claimer> (renamed from
+        # test_all_{seven,eight}_variants_* — the shape count has grown past
+        # eight).
         wr = '12345'
         keys_to_retain = [
             f'041926_{wr}',
             f'041926_{wr}_HELPER_Jane_Smith',
             f'041926_{wr}_VACCREW',
+            f'041926_{wr}_VACCREW_Vic_Crew',
             f'041926_{wr}_REDUCEDSUB',
             f'041926_{wr}_AEPBILLABLE',
             f'041926_{wr}_REDUCEDSUB_HELPER_Jane_Doe',
             f'041926_{wr}_AEPBILLABLE_HELPER_J_Smith',
             f'041926_{wr}_USER_John_Doe',
+            f'041926_{wr}_REDUCEDSUB_USER_Sue_Sub',
+            f'041926_{wr}_AEPBILLABLE_USER_Sue_Sub',
         ]
         for k in keys_to_retain:
             with self.subTest(key=k):
@@ -2484,6 +2506,10 @@ class TestWrFilterMatchesAllVariants(unittest.TestCase):
             'f"{wr}_AEPBILLABLE"',
             'f"{wr}_REDUCEDSUB_HELPER_"',
             'f"{wr}_AEPBILLABLE_HELPER_"',
+            # PR #223 follow-up (Copilot): Subproject B per-claimer
+            # subcontractor primary shapes — both matchers must carry them.
+            'f"{wr}_REDUCEDSUB_USER_"',
+            'f"{wr}_AEPBILLABLE_USER_"',
         ):
             with self.subTest(needle=needle):
                 self.assertGreaterEqual(

--- a/tests/test_security_audit_followup.py
+++ b/tests/test_security_audit_followup.py
@@ -2735,18 +2735,21 @@ class TestPppCleanupUntrackedAttachments(unittest.TestCase):
         # sub_wr_scope and sub_offcontract_variants. Subproject B
         # (2026-05-20, Task 7) appends one more trailing kwarg:
         # sub_legacy_primary_variants. Subproject C Task 6 (2026-05-21)
-        # appends one more trailing kwarg: vac_legacy_wr_scope. All five
-        # are optional (None default) so existing TARGET / PPP call sites
-        # remain byte-identical. IN-PLACE UPDATE per [2026-05-20 00:26]
-        # rule 2 — the assertion follows the v4 signature contract.
+        # appends one more trailing kwarg: vac_legacy_wr_scope. Subproject
+        # D Task 10 (2026-05-25) appends one more trailing kwarg:
+        # primary_wr_scope. All six are optional (None default) so
+        # existing TARGET / PPP call sites remain byte-identical.
+        # IN-PLACE UPDATE per [2026-05-20 00:26] rule 2 — the assertion
+        # follows the v5 signature contract.
         self.assertEqual(
             params,
             ['client', 'target_sheet_id', 'valid_wr_weeks',
              'test_mode', 'attachment_cache', 'target_sheet',
              'variant_whitelist', 'sub_wr_scope', 'sub_offcontract_variants',
-             'sub_legacy_primary_variants', 'vac_legacy_wr_scope'],
-            "Subproject C Task 6 appends a trailing kwarg after "
-            "'sub_legacy_primary_variants': 'vac_legacy_wr_scope'. "
+             'sub_legacy_primary_variants', 'vac_legacy_wr_scope',
+             'primary_wr_scope'],
+            "Subproject D Task 10 appends a trailing kwarg after "
+            "'vac_legacy_wr_scope': 'primary_wr_scope'. "
             "Any further drift must be reviewed against D-09 (TARGET "
             "legacy behavior). "
             f"Got: {params}"
@@ -2774,6 +2777,11 @@ class TestPppCleanupUntrackedAttachments(unittest.TestCase):
             sig.parameters['vac_legacy_wr_scope'].default, None,
             'vac_legacy_wr_scope must default to None '
             '(Subproject C Task 6).'
+        )
+        self.assertIs(
+            sig.parameters['primary_wr_scope'].default, None,
+            'primary_wr_scope must default to None '
+            '(Subproject D Task 10).'
         )
 
 

--- a/tests/test_security_audit_followup.py
+++ b/tests/test_security_audit_followup.py
@@ -2389,9 +2389,10 @@ class TestWrFilterMatchesAllVariants(unittest.TestCase):
     recognize the new variant suffixes in TEST_MODE.
 
     Mirror of TestExcludeWrsMatchesAllVariants for the WR_FILTER
-    matcher. Tests document the deliberate asymmetry that
-    ``_key_matches_wr`` does NOT match ``_USER_`` — preserves
-    pre-fix surface (the matcher never carried that clause).
+    matcher. Sub-project D ([2026-05-25]) added the ``_USER_`` clause
+    to ``_key_matches_wr`` so the two matchers are now in full sync —
+    the previous deliberate asymmetry (``_USER_`` excluded) is
+    superseded by D's production-primary partitioning.
     """
 
     @staticmethod
@@ -2406,16 +2407,17 @@ class TestWrFilterMatchesAllVariants(unittest.TestCase):
             suffix == wr
             or suffix.startswith(f"{wr}_HELPER_")
             or suffix == f"{wr}_VACCREW"
+            or suffix.startswith(f"{wr}_VACCREW_")
             or suffix == f"{wr}_REDUCEDSUB"
             or suffix == f"{wr}_AEPBILLABLE"
             or suffix.startswith(f"{wr}_REDUCEDSUB_HELPER_")
             or suffix.startswith(f"{wr}_AEPBILLABLE_HELPER_")
+            or suffix.startswith(f"{wr}_USER_")
         )
 
     def test_all_seven_variants_retained_for_target_wr(self):
-        # Note: 7 keys but no _USER_ — `_USER_` is intentionally
-        # excluded from this matcher (asymmetry with
-        # `_key_matches_excluded_wr`).
+        # Sub-project D (2026-05-25): _USER_ IS now retained — the
+        # asymmetry with `_key_matches_excluded_wr` is resolved.
         wr = '12345'
         keys_to_retain = [
             f'041926_{wr}',
@@ -2425,6 +2427,7 @@ class TestWrFilterMatchesAllVariants(unittest.TestCase):
             f'041926_{wr}_AEPBILLABLE',
             f'041926_{wr}_REDUCEDSUB_HELPER_Jane_Doe',
             f'041926_{wr}_AEPBILLABLE_HELPER_J_Smith',
+            f'041926_{wr}_USER_John_Doe',
         ]
         for k in keys_to_retain:
             with self.subTest(key=k):
@@ -2434,14 +2437,17 @@ class TestWrFilterMatchesAllVariants(unittest.TestCase):
                 )
 
     def test_user_variant_intentionally_not_matched(self):
-        # The asymmetry guard: _USER_ exists in
-        # _key_matches_excluded_wr but NOT in _key_matches_wr. If a
-        # future contributor adds _USER_ to _key_matches_wr without
-        # a documented production incident, this test fails loudly.
-        self.assertFalse(
+        # Sub-project D (2026-05-25) INVERTED this contract: WR_FILTER now
+        # DOES match the per-claimer primary key {wr}_USER_<claimer>, because
+        # D partitions the production primary file by frozen claimer. Before
+        # D, _USER_ was the decommissioned activity-log variant and was
+        # intentionally excluded. Per [2026-05-20 00:26] rule 2, this prior
+        # test's contract is rewritten in place to assert the new invariant.
+        # (Method name preserved for git-blame traceability.)
+        self.assertTrue(
             self._filter_matches('041926_12345_USER_John_Doe', '12345'),
-            "_USER_ is intentionally NOT in _key_matches_wr; do not "
-            "add it without a documented incident.",
+            "Sub-project D: _USER_ MUST be matched by _key_matches_wr "
+            "(mirror of _key_matches_excluded_wr).",
         )
 
     def test_unrelated_wr_dropped(self):

--- a/tests/test_subcontractor_pricing.py
+++ b/tests/test_subcontractor_pricing.py
@@ -2748,6 +2748,15 @@ class TestSubcontractorB1PartitioningGate(unittest.TestCase):
         self._orig_sub_ids = set(generate_weekly_pdfs._FOLDER_DISCOVERED_SUB_IDS)
         self._orig_orig_ids = set(generate_weekly_pdfs._FOLDER_DISCOVERED_ORIG_IDS)
         self._orig_mode = generate_weekly_pdfs.RES_GROUPING_MODE
+        # Sub-project D (2026-05-25) pins this OFF: this class asserts the
+        # legacy bare-primary behavior for NON-subcontractor rows, which D's
+        # default-on production-primary partitioning would otherwise change
+        # to _User_<claimer>. D's new behavior is covered by
+        # tests/test_primary_claim_attribution.py::TestPrimaryEmission. Per
+        # [2026-05-20 00:26] rule 2 (test-contract override), pin D off here
+        # to keep this an isolated B/B1 guard.
+        self._orig_primary_attr = generate_weekly_pdfs.PRIMARY_CLAIM_ATTRIBUTION_ENABLED
+        generate_weekly_pdfs.PRIMARY_CLAIM_ATTRIBUTION_ENABLED = False
         # Default test config — production-like 'both' mode + variants on.
         generate_weekly_pdfs.RES_GROUPING_MODE = 'both'
         generate_weekly_pdfs.SUBCONTRACTOR_RATE_VARIANTS_ENABLED = True
@@ -2756,6 +2765,7 @@ class TestSubcontractorB1PartitioningGate(unittest.TestCase):
         generate_weekly_pdfs._FOLDER_DISCOVERED_ORIG_IDS.clear()
 
     def tearDown(self):
+        generate_weekly_pdfs.PRIMARY_CLAIM_ATTRIBUTION_ENABLED = self._orig_primary_attr
         generate_weekly_pdfs.SUBCONTRACTOR_RATE_VARIANTS_ENABLED = self._orig_enabled
         generate_weekly_pdfs._FOLDER_DISCOVERED_SUB_IDS.clear()
         generate_weekly_pdfs._FOLDER_DISCOVERED_SUB_IDS.update(self._orig_sub_ids)

--- a/tests/test_subcontractor_primary_claim_attribution.py
+++ b/tests/test_subcontractor_primary_claim_attribution.py
@@ -190,12 +190,22 @@ class TestPrePassEmission(unittest.TestCase):
         self._orig_variants = generate_weekly_pdfs.SUBCONTRACTOR_RATE_VARIANTS_ENABLED
         self._orig_attr = generate_weekly_pdfs.SUBCONTRACTOR_HELPER_CLAIM_ATTRIBUTION_ENABLED
         self._orig_sub_ids = set(generate_weekly_pdfs._FOLDER_DISCOVERED_SUB_IDS)
+        # Sub-project D (2026-05-25) pins this OFF: this class asserts the
+        # legacy bare-primary behavior for NON-subcontractor rows, which D's
+        # default-on production-primary partitioning would otherwise change
+        # to _User_<claimer>. D's new behavior is covered by
+        # tests/test_primary_claim_attribution.py::TestPrimaryEmission. Per
+        # [2026-05-20 00:26] rule 2 (test-contract override), pin D off here
+        # to keep this an isolated B/B1 guard.
+        self._orig_primary_attr = generate_weekly_pdfs.PRIMARY_CLAIM_ATTRIBUTION_ENABLED
+        generate_weekly_pdfs.PRIMARY_CLAIM_ATTRIBUTION_ENABLED = False
         generate_weekly_pdfs.SUBCONTRACTOR_RATE_VARIANTS_ENABLED = True
         generate_weekly_pdfs.SUBCONTRACTOR_HELPER_CLAIM_ATTRIBUTION_ENABLED = True
         generate_weekly_pdfs._FOLDER_DISCOVERED_SUB_IDS.clear()
         generate_weekly_pdfs._FOLDER_DISCOVERED_SUB_IDS.add(self._SUB_SHEET_ID)
 
     def tearDown(self):
+        generate_weekly_pdfs.PRIMARY_CLAIM_ATTRIBUTION_ENABLED = self._orig_primary_attr
         generate_weekly_pdfs.SUBCONTRACTOR_RATE_VARIANTS_ENABLED = self._orig_variants
         generate_weekly_pdfs.SUBCONTRACTOR_HELPER_CLAIM_ATTRIBUTION_ENABLED = self._orig_attr
         generate_weekly_pdfs._FOLDER_DISCOVERED_SUB_IDS.clear()
@@ -673,11 +683,21 @@ class TestNonSubVariantsPreserved(unittest.TestCase):
         _reset_all()
         self._orig_variants = generate_weekly_pdfs.SUBCONTRACTOR_RATE_VARIANTS_ENABLED
         self._orig_sub_ids = set(generate_weekly_pdfs._FOLDER_DISCOVERED_SUB_IDS)
+        # Sub-project D (2026-05-25) pins this OFF: this class asserts the
+        # legacy bare-primary behavior for NON-subcontractor rows, which D's
+        # default-on production-primary partitioning would otherwise change
+        # to _User_<claimer>. D's new behavior is covered by
+        # tests/test_primary_claim_attribution.py::TestPrimaryEmission. Per
+        # [2026-05-20 00:26] rule 2 (test-contract override), pin D off here
+        # to keep this an isolated B/B1 guard.
+        self._orig_primary_attr = generate_weekly_pdfs.PRIMARY_CLAIM_ATTRIBUTION_ENABLED
+        generate_weekly_pdfs.PRIMARY_CLAIM_ATTRIBUTION_ENABLED = False
         generate_weekly_pdfs.SUBCONTRACTOR_RATE_VARIANTS_ENABLED = True
         generate_weekly_pdfs._FOLDER_DISCOVERED_SUB_IDS.clear()
         generate_weekly_pdfs._FOLDER_DISCOVERED_SUB_IDS.add(self._SUB_SHEET_ID)
 
     def tearDown(self):
+        generate_weekly_pdfs.PRIMARY_CLAIM_ATTRIBUTION_ENABLED = self._orig_primary_attr
         generate_weekly_pdfs.SUBCONTRACTOR_RATE_VARIANTS_ENABLED = self._orig_variants
         generate_weekly_pdfs._FOLDER_DISCOVERED_SUB_IDS.clear()
         generate_weekly_pdfs._FOLDER_DISCOVERED_SUB_IDS.update(self._orig_sub_ids)

--- a/website/docs/reference/environment.md
+++ b/website/docs/reference/environment.md
@@ -464,6 +464,49 @@ silently override the pinned value without code review.
 **Startup banner:** The resolved state is logged at startup as
 `📋 VAC Crew legacy cleanup: ENABLED` or `📋 VAC Crew legacy cleanup: DISABLED`.
 
+### `PRIMARY_CLAIM_ATTRIBUTION_ENABLED`
+
+**Default:** `1` (enabled). Truthy values: `1`, `true`, `yes`, `on`.
+
+Sub-project D. When enabled, the production primary Excel files (every
+non-subcontractor WR) are partitioned by the **frozen primary foreman**
+who claimed each line item — read from `billing_audit.attribution_snapshot`
+via `resolve_claimer('primary', …)` — and named
+`WR_..._WeekEnding_..._User_<claimer>_<hash>.xlsx`. A WR+week claimed by
+two foremen produces two files, one per claimer.
+
+Unlike Sub-project B (subcontractor primary), the core primary path
+**never holds** on a Supabase outage: if attribution can't be read
+(`fetch_failure`), or there is no frozen row yet (`no_history`), the row
+falls back to the **current** foreman and the file is still generated.
+This is deliberate — D covers every non-subcontractor WR, so holding on an
+outage would suppress all primary billing for that run.
+
+Set to `0` to revert to the legacy one-file-per-WR bare primary behavior
+(`WR_..._WeekEnding_..._<hash>.xlsx`). The resolved value is printed at
+startup as `📋 PRIMARY_CLAIM_ATTRIBUTION_ENABLED=<bool>`. Pinned to `1`
+in the `weekly-excel-generation.yml` `env:` block.
+
+### `LEGACY_PRIMARY_PARTITION_CLEANUP_ENABLED`
+
+**Default:** `1` (enabled). Truthy values: `1`, `true`, `yes`, `on`.
+
+Sub-project D one-time migration. When enabled, the legacy UNPARTITIONED
+bare primary attachments (no `_User_` token) on `TARGET_SHEET_ID` for
+non-subcontractor WRs that now produce a partitioned `_User_<claimer>`
+file are deleted — UNLESS the bare file's identity is live this run
+(`valid_wr_weeks` exemption). A matching one-time hash-history prune
+(`_subproject_d_prune_version` sentinel) drops the stale
+`{wr}|{week}|primary|` entries.
+
+**Separate from `PRIMARY_CLAIM_ATTRIBUTION_ENABLED`,** which gates
+attribution resolution, NOT this cleanup. Set to `0` to skip the
+destructive cleanup (legacy bare-primary duplicates persist until removed
+manually). The resolved value is printed at startup as
+`📋 LEGACY_PRIMARY_PARTITION_CLEANUP_ENABLED=<bool>`. Pinned to `1` in the
+`weekly-excel-generation.yml` `env:` block alongside
+`PRIMARY_CLAIM_ATTRIBUTION_ENABLED`.
+
 ### `AEP_BILLABLE_CUTOFF`
 
 **Default:** `2026-04-12` (AEP rate-increase contract awarded to Linetec)

--- a/website/docs/reference/environment.md
+++ b/website/docs/reference/environment.md
@@ -495,9 +495,19 @@ Sub-project D one-time migration. When enabled, the legacy UNPARTITIONED
 bare primary attachments (no `_User_` token) on `TARGET_SHEET_ID` for
 non-subcontractor WRs that now produce a partitioned `_User_<claimer>`
 file are deleted — UNLESS the bare file's identity is live this run
-(`valid_wr_weeks` exemption). A matching one-time hash-history prune
-(`_subproject_d_prune_version` sentinel) drops the stale
-`{wr}|{week}|primary|` entries.
+(`valid_wr_weeks` exemption).
+
+**Scope note:** this flag gates only the destructive **attachment**
+cleanup. The companion one-time hash-history prune
+(`_subproject_d_prune_version` sentinel, which drops the stale
+`{wr}|{week}|primary|` entries) is gated on
+**`PRIMARY_CLAIM_ATTRIBUTION_ENABLED`** instead — not on this flag —
+because when attribution is off the bare `{wr}|{week}|primary|` key is the
+*active* legacy key and must not be pruned. So disabling this cleanup flag
+while leaving attribution on still mutates `hash_history.json` via the
+prune (the prune only drops a hash entry, forcing at most one benign
+regeneration — never a file deletion). This mirrors Sub-project C's
+`_run_vac_crew_hash_prune` gating.
 
 **Separate from `PRIMARY_CLAIM_ATTRIBUTION_ENABLED`,** which gates
 attribution resolution, NOT this cleanup. Set to `0` to skip the


### PR DESCRIPTION
## Objective

Sub-project D — the fourth and final consumer (before E) of the universal per-line-item claim attribution effort (A → Phase 1.1 → B → C → **D** → E). Production (non-subcontractor) primary Excel files are now partitioned by the **frozen primary foreman** who claimed each line item — sourced from `billing_audit.attribution_snapshot` via Foundation A's `resolve_claimer('primary', …)` — and named `_User_<claimer>`. A WR+week claimed by two foremen yields two coexisting files (one per claimer, distinct identity tuples, never cross-deleted).

**No-HOLD operator decision (the key D-vs-B distinction):** unlike Subproject B (which HOLDs subcontractor primary on a Supabase outage), D's core path **never holds** — on `fetch_failure`/`no_history`/`disabled`/map-miss it falls back to the current `effective_user` and still generates. Rationale: D covers *every* non-subcontractor WR, so HOLDing on an outage would suppress all primary billing for that run.

Everything is gated behind two new default-on, workflow-pinned kill switches so OFF reproduces exact legacy behavior. Zero `billing_audit/` changes (Foundation A already supports `'primary'`).

## Changes Made

- **`generate_weekly_pdfs.py`** (~446 lines, additive):
  - Two kill switches `PRIMARY_CLAIM_ATTRIBUTION_ENABLED` / `LEGACY_PRIMARY_PARTITION_CLEANUP_ENABLED` + `SUBPROJECT_D_HASH_PRUNE_VERSION` constant + startup banner.
  - `generate_excel` primary filename suffix → `_User_<claimer>` (gated; bare when off).
  - `group_source_rows` attribution pre-pass (`_primary_claimer_map`, bounded ThreadPoolExecutor) + emission partitioning of the production primary key.
  - CR-01 four-site identity lockstep (main-loop `history_key`/`file_identifier`, `valid_wr_weeks`, `current_keys`, plus the parser + filename suffix) — all gated.
  - `_key_matches_wr` (WR_FILTER) `_USER_` mirror clause.
  - `_build_primary_wr_scope` helper; `_run_subproject_d_hash_prune` one-time migration (distinct sentinel, kill-switch-gated); `primary_wr_scope` param + gate in `cleanup_untracked_sheet_attachments` (TARGET-only, `valid_wr_weeks` live-identity exemption).
  - **Parser hardening:** `build_group_identity` now dispatches variants by **earliest reserved-token position** (fixes misparse when a claimer/helper/vac name contains a reserved token like "Pat Helper"; generalizes the [2026-05-21] reserved-token rule). Repairs latent B-shape bugs too.
- **`tests/test_primary_claim_attribution.py`** (new, ~620 lines): full D suite — config, filename suffix, pre-pass, emission (partition / two-claimer coexistence / no-history / hold-still-emits / OFF-bare), four-site source invariants, WR matcher, scope helper, hash prune (idempotency/kill-switch/scope), bare-primary cleanup safety, parser round-trip + reserved-token-in-name.
- **Reconciled prior tests** (`test_subcontractor_pricing.py`, `test_subcontractor_primary_claim_attribution.py`, `test_security_audit_followup.py`): pinned 3 B/B1 isolation tests to `PRIMARY_CLAIM_ATTRIBUTION_ENABLED=False` and inverted a stale WR-filter mirror test, per the test-contract-override rule (D changes the non-sub primary contract).
- **`.github/workflows/weekly-excel-generation.yml`**: pinned both new env vars to `'1'`.
- **`website/docs/reference/environment.md`**: documented both env vars.
- **`CLAUDE.md`**: Living Ledger entry. **`docs/superpowers/`**: design spec + implementation plan.

## Production Safety Check

- **Full suite green: 865 passed / 26 skipped / 61 subtests / 0 failed** (was 854 baseline; +11 net).
- **OFF = byte-identical legacy:** every D surface is kill-switch-gated; with `PRIMARY_CLAIM_ATTRIBUTION_ENABLED=0` the engine emits the bare `{week}_{wr}` key, `''` identifier, bare filename, `{wr}|{week}|primary|` history key, runs no migration prune, and the bare-primary cleanup no-ops. Verified by the final whole-implementation review (Opus) which proved the parser refactor is equivalent to the prior fixed-order dispatch for all *produced* filenames.
- **Scope boundaries airtight:** subcontractor (B) and vac_crew (C) rows are excluded from D's pre-pass/emission; helper rows never emit a primary `_USER_` key; `_build_primary_wr_scope` excludes B's `_REDUCEDSUB`/`_AEPBILLABLE` keys so the migration can't touch B's WRs.
- **Destructive migration is safe:** the forced bare-primary attachment cleanup is TARGET-only, double-gated on both kill switches, and carries the `ident not in valid_wr_weeks` live-identity exemption; the hash prune is gated on the attribution flag (OFF won't delete the then-active bare key) with a distinct sentinel.
- **Existing pipeline untouched:** discovery, row fetch, grouping for other variants, Excel generation, and upload paths are unchanged; `generate_weekly_pdfs.py` core flow preserved. Smoke run (`TEST_MODE=true`) confirmed clean startup + both banner flags + end-to-end `_User_<claimer>` file generation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)