### PR TITLE
fix(billing): scope builders use __variant, not key substring

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3199,3 +3199,58 @@ When proposing new workflows, dynamically evaluate the absolute best technology.
   (called exactly once for a primary+helper pair). ``pytest tests/``
   → **873 passed / 26 skipped / 69 subtests** (was 871; +2, zero
   regressions).
+- [2026-05-25 19:55] Scope-builder ``__variant`` consistency follow-up
+  (standalone PR off master, the deferred item from PR #223's
+  [2026-05-25 17:50] entry). Converted the two sibling scope builders
+  ``_build_subcontractor_wr_scope`` and ``_build_vac_crew_wr_scope`` from
+  key-substring detection (``'_REDUCEDSUB' in _key`` / ``'_VACCREW' in
+  _key``) to the authoritative ``__variant`` field gate, completing the
+  rule established by Subproject D's ``_build_primary_wr_scope`` fix
+  ([2026-05-25 17:50]): **variant detection MUST use the ``__variant``
+  field (or a positional ``build_group_identity`` parse), never a key
+  substring scan.** ``_build_subcontractor_wr_scope`` now gates on
+  ``__variant in {'reduced_sub','aep_billable','reduced_sub_helper',
+  'aep_billable_helper'}`` (new module frozenset
+  ``_SUBCONTRACTOR_SCOPE_VARIANTS``); ``_build_vac_crew_wr_scope`` gates
+  on ``__variant == 'vac_crew'``. **Why it matters:** both scopes feed
+  DESTRUCTIVE attachment-cleanup + hash-prune paths, and the substring
+  scan had two latent defects: (1) a non-sub/non-vac group whose
+  claimer/helper NAME is an all-caps reserved token (``REDUCEDSUB`` /
+  ``VACCREW`` — e.g. a helper named "VACCREW" → key ``..._HELPER_VACCREW``)
+  false-positived into the destructive scope (the ``valid_wr_weeks``
+  live-identity exemption is the only thing that prevented an actual
+  deletion); (2) ``_build_subcontractor_wr_scope``'s ``'_REDUCEDSUB'``
+  substring silently MISSED ``_AEPBILLABLE``-only keys — it produced the
+  correct WR set only by relying on the invariant that every sub WR also
+  emits a ``reduced_sub`` group. The ``__variant`` gate is both robust
+  (no pathological-name false positives) and strictly more complete
+  (catches every subcontractor variant directly). **Behavior-preserving
+  for production data:** realistic WR#s and foreman names produce the
+  identical WR scope set under either approach, so this is a robustness
+  hardening, not a behavior change. The realistic-data risk of the old
+  substring approach was nil (an all-caps reserved-word foreman name is
+  required to trigger, and the live-identity exemption blunts the
+  blast), which is why this was deferred from PR #223 to keep that PR
+  scoped — but the three sibling scope builders are now consistent, and
+  the rule has a regression net at all three. **Test-fixture
+  reconciliation** ([2026-05-20 00:26] rule 2): six hash-prune tests
+  across Subprojects A/B/C built synthetic ``groups`` dicts whose rows
+  omitted ``__variant`` (production always sets it at the
+  ``group_source_rows`` emission site); their fixtures
+  (``_make_groups_with_reducedsub``, the two ``_groups`` helpers, and
+  two inline group dicts) were updated to carry ``__variant`` — the same
+  fixture update D applied to ``TestBuildPrimaryWrScope`` /
+  ``TestSubprojectDHashPrune``. Regression tests:
+  ``tests/test_vac_crew_claim_attribution.py`` gains
+  ``test_scope_builder_rejects_pathological_vaccrew_name`` (a helper
+  named "VACCREW" must NOT enter the vac scope) and updates the three
+  existing vac-scope tests to the ``__variant`` contract;
+  ``tests/test_subcontractor_helper_shadow_rescue.py`` gains
+  ``TestSubcontractorWrScopeVariantGate`` (4 methods — collects all four
+  sub variants incl. ``_AEPBILLABLE``-only, excludes non-sub variants,
+  rejects a primary claimer named "REDUCEDSUB", empty-groups). ``pytest
+  tests/`` → **878 passed / 26 skipped / 69 subtests** (was 873 on
+  master; +5, zero regressions). NOTE for future variants: when adding
+  a new variant whose group key embeds a reserved token, the scope
+  builder (if any) MUST gate on ``__variant``, and synthetic prune/
+  cleanup test fixtures MUST set ``__variant`` on their rows.

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -3355,13 +3355,28 @@ def save_hash_history(path: str, history: dict):
         logging.warning(f"⚠️ Failed to save hash history: {e}")
 
 
+_SUBCONTRACTOR_SCOPE_VARIANTS = frozenset({
+    'reduced_sub', 'aep_billable',
+    'reduced_sub_helper', 'aep_billable_helper',
+})
+
+
 def _build_subcontractor_wr_scope(groups: dict) -> set[str]:
     """Return the set of sanitized WR tokens active as subcontractor in this run.
 
-    Scans ``groups.keys()`` for keys containing ``'_REDUCEDSUB'`` (the
-    simplified D-18 detection per RESEARCH.md §HP planner-discretion
-    recommendation), extracts each group's WR# from the first row of the
-    group, and returns the sanitized set.
+    Gates on each group's authoritative ``__variant`` field (set at the
+    ``group_source_rows`` emission site) — NOT a ``'_REDUCEDSUB'`` key
+    substring scan. The variant gate is what distinguishes a subcontractor
+    group, so a primary claimer, helper, or vac-crew name (or a pathological
+    WR token) that itself contains an all-caps reserved word like
+    ``REDUCEDSUB`` / ``AEPBILLABLE`` cannot false-positive into this
+    destructive cleanup scope. This mirrors the ``_build_primary_wr_scope``
+    consistency fix (Codex PR #223 P1) — variant detection MUST use the
+    ``__variant`` field, never a key substring. The prior substring scan also
+    silently missed ``_AEPBILLABLE``-only keys (the ``'_REDUCEDSUB'``
+    substring is absent there); it happened to produce the correct WR set
+    only because every sub WR always emits a ``reduced_sub`` group, so the
+    variant gate is both more robust and strictly more complete.
 
     Shared by ``_run_phase_1_1_hash_prune`` (hash-prune scope) and the
     TARGET ``cleanup_untracked_sheet_attachments`` call site (SUB-09
@@ -3370,8 +3385,10 @@ def _build_subcontractor_wr_scope(groups: dict) -> set[str]:
     warns against.
     """
     _scope: set[str] = set()
-    for _key, _g_rows in groups.items():
-        if '_REDUCEDSUB' in _key and _g_rows:
+    for _g_rows in groups.values():
+        if not _g_rows:
+            continue
+        if _g_rows[0].get('__variant') in _SUBCONTRACTOR_SCOPE_VARIANTS:
             _g_wr_raw = _g_rows[0].get('Work Request #', '')
             _g_wr = str(_g_wr_raw).split('.')[0]
             _g_wr = _RE_SANITIZE_HELPER_NAME.sub('_', _g_wr)[:50]
@@ -3383,17 +3400,24 @@ def _build_subcontractor_wr_scope(groups: dict) -> set[str]:
 def _build_vac_crew_wr_scope(groups: dict) -> set[str]:
     """Return the set of sanitized WR tokens active as vac_crew in this run.
 
-    Scans ``groups.keys()`` for keys containing ``'_VACCREW'``, extracts
-    each group's WR# from the first row of the group, and returns the
-    sanitized set.
+    Gates on each group's authoritative ``__variant`` field (``== 'vac_crew'``,
+    set at the ``group_source_rows`` emission site) — NOT a ``'_VACCREW'`` key
+    substring scan. The variant gate prevents a non-vac group whose
+    claimer/helper name is the all-caps reserved token ``VACCREW`` (key
+    ``..._HELPER_VACCREW``) from false-positiving into this destructive
+    cleanup scope. Mirrors the ``_build_primary_wr_scope`` /
+    ``_build_subcontractor_wr_scope`` consistency fix (Codex PR #223 P1):
+    variant detection MUST use the ``__variant`` field, never a key substring.
 
     Shared by the TARGET ``cleanup_untracked_sheet_attachments`` call site
     (Task 6 vac-crew legacy cleanup scope).  A single implementation prevents
     scope-build drift — mirrors ``_build_subcontractor_wr_scope``.
     """
     _scope: set[str] = set()
-    for _key, _g_rows in groups.items():
-        if '_VACCREW' in _key and _g_rows:
+    for _g_rows in groups.values():
+        if not _g_rows:
+            continue
+        if _g_rows[0].get('__variant') == 'vac_crew':
             _g_wr_raw = _g_rows[0].get('Work Request #', '')
             _g_wr = str(_g_wr_raw).split('.')[0]
             _g_wr = _RE_SANITIZE_HELPER_NAME.sub('_', _g_wr)[:50]

--- a/tests/test_subcontractor_helper_shadow_rescue.py
+++ b/tests/test_subcontractor_helper_shadow_rescue.py
@@ -833,6 +833,9 @@ class TestHashPruneIdempotency(unittest.TestCase):
             groups[key] = [{
                 'Work Request #': wr,
                 '__source_sheet_id': 8162920222379908,
+                # Production rows always carry __variant (set at emission);
+                # the scope builder now gates on it.
+                '__variant': 'reduced_sub',
             }]
         return groups
 
@@ -1180,6 +1183,66 @@ class TestProductionCodeSiteInvariants(unittest.TestCase):
             'Phase 1.1 hash-history prune',
             generate_weekly_pdfs._PII_LOG_MARKERS,
         )
+
+
+class TestSubcontractorWrScopeVariantGate(unittest.TestCase):
+    """``_build_subcontractor_wr_scope`` gates on the authoritative
+    ``__variant`` field (subcontractor variant set), not a ``'_REDUCEDSUB'``
+    key substring — mirror of the Subproject D ``_build_primary_wr_scope``
+    Codex-P1 consistency fix. A non-sub group whose claimer/helper NAME is an
+    all-caps reserved token (``REDUCEDSUB`` / ``AEPBILLABLE``) must NOT enter
+    the destructive subcontractor cleanup scope. Production rows always carry
+    ``__variant`` (set at the ``group_source_rows`` emission site)."""
+
+    def test_collects_all_subcontractor_variants(self):
+        groups = {
+            '041926_111_REDUCEDSUB': [
+                {'Work Request #': '111', '__variant': 'reduced_sub'}],
+            '041926_222_AEPBILLABLE': [
+                {'Work Request #': '222', '__variant': 'aep_billable'}],
+            '041926_333_REDUCEDSUB_HELPER_H': [
+                {'Work Request #': '333', '__variant': 'reduced_sub_helper'}],
+            '041926_444_AEPBILLABLE_HELPER_H': [
+                {'Work Request #': '444', '__variant': 'aep_billable_helper'}],
+            '041926_555_REDUCEDSUB_USER_C': [
+                {'Work Request #': '555', '__variant': 'reduced_sub'}],
+        }
+        scope = generate_weekly_pdfs._build_subcontractor_wr_scope(groups)
+        self.assertEqual(scope, {'111', '222', '333', '444', '555'})
+
+    def test_excludes_non_subcontractor_variants(self):
+        groups = {
+            '041926_666_USER_Claimer': [
+                {'Work Request #': '666', '__variant': 'primary'}],
+            '041926_777_VACCREW_Vic': [
+                {'Work Request #': '777', '__variant': 'vac_crew'}],
+            '041926_888_HELPER_Help': [
+                {'Work Request #': '888', '__variant': 'helper'}],
+        }
+        scope = generate_weekly_pdfs._build_subcontractor_wr_scope(groups)
+        self.assertEqual(scope, set())
+
+    def test_rejects_pathological_reducedsub_name(self):
+        # Primary claimer literally named "REDUCEDSUB" → key contains the
+        # _REDUCEDSUB substring, but __variant is 'primary'. The variant gate
+        # must exclude it; the genuine sub group must still be collected.
+        groups = {
+            '041926_999_USER_REDUCEDSUB': [
+                {'Work Request #': '999', '__variant': 'primary'}],
+            '041926_123_REDUCEDSUB': [
+                {'Work Request #': '123', '__variant': 'reduced_sub'}],
+        }
+        scope = generate_weekly_pdfs._build_subcontractor_wr_scope(groups)
+        self.assertIn('123', scope)
+        self.assertNotIn(
+            '999', scope,
+            "a non-sub group whose claimer name contains 'REDUCEDSUB' must "
+            "NOT enter the subcontractor cleanup scope (variant gate)",
+        )
+
+    def test_empty_groups(self):
+        self.assertEqual(
+            generate_weekly_pdfs._build_subcontractor_wr_scope({}), set())
 
 
 if __name__ == '__main__':

--- a/tests/test_subcontractor_primary_claim_attribution.py
+++ b/tests/test_subcontractor_primary_claim_attribution.py
@@ -574,7 +574,13 @@ class TestSubprojectBHashPrune(unittest.TestCase):
         groups = {}
         for wr in wrs:
             key = f"041926_{wr}_REDUCEDSUB_USER_John"
-            groups[key] = [{'Work Request #': wr, '__source_sheet_id': 8162920222379908}]
+            # Production rows always carry __variant (set at emission); the
+            # subcontractor scope builder now gates on it.
+            groups[key] = [{
+                'Work Request #': wr,
+                '__source_sheet_id': 8162920222379908,
+                '__variant': 'reduced_sub',
+            }]
         return groups
 
     def test_first_run_drops_legacy_primary_variant_orphans(self):

--- a/tests/test_vac_crew_claim_attribution.py
+++ b/tests/test_vac_crew_claim_attribution.py
@@ -460,10 +460,18 @@ class TestVacCrewLegacyCleanup(unittest.TestCase):
     # ------------------------------------------------------------------
 
     def test_scope_builder_collects_vac_wrs(self):
-        """_build_vac_crew_wr_scope extracts WR# from VACCREW groups only."""
+        """_build_vac_crew_wr_scope extracts WR# from vac_crew groups only.
+
+        Gates on the authoritative ``__variant`` field (set at emission),
+        not a ``'_VACCREW'`` key substring — mirrors ``_build_primary_wr_scope``
+        (Subproject D) so a non-vac name containing a reserved token cannot
+        false-positive. Production rows always carry ``__variant``.
+        """
         groups = {
-            '041926_91467680_VACCREW_John': [{'Work Request #': '91467680'}],
-            '041926_55555_REDUCEDSUB_USER_X': [{'Work Request #': '55555'}],
+            '041926_91467680_VACCREW_John': [
+                {'Work Request #': '91467680', '__variant': 'vac_crew'}],
+            '041926_55555_REDUCEDSUB_USER_X': [
+                {'Work Request #': '55555', '__variant': 'reduced_sub'}],
         }
         scope = generate_weekly_pdfs._build_vac_crew_wr_scope(groups)
         self.assertIn('91467680', scope)
@@ -474,13 +482,37 @@ class TestVacCrewLegacyCleanup(unittest.TestCase):
         self.assertEqual(generate_weekly_pdfs._build_vac_crew_wr_scope({}), set())
 
     def test_scope_builder_ignores_helper_and_primary_keys(self):
-        """Non-VACCREW group keys are excluded from the vac scope."""
+        """Non-vac_crew variants are excluded from the vac scope."""
         groups = {
-            '041926_11111_HELPER_Alice': [{'Work Request #': '11111'}],
-            '041926_22222': [{'Work Request #': '22222'}],
+            '041926_11111_HELPER_Alice': [
+                {'Work Request #': '11111', '__variant': 'helper'}],
+            '041926_22222': [
+                {'Work Request #': '22222', '__variant': 'primary'}],
         }
         scope = generate_weekly_pdfs._build_vac_crew_wr_scope(groups)
         self.assertEqual(scope, set())
+
+    def test_scope_builder_rejects_pathological_vaccrew_name(self):
+        """A helper/primary whose NAME is the all-caps reserved token
+        ``VACCREW`` produces a key containing the ``_VACCREW`` substring,
+        but its ``__variant`` is not ``vac_crew`` — the variant gate must
+        exclude it from the destructive vac cleanup scope (mirror of the
+        Subproject D Codex-P1 fix)."""
+        groups = {
+            # Helper literally named "VACCREW" → key has the _VACCREW substring.
+            '041926_33333_HELPER_VACCREW': [
+                {'Work Request #': '33333', '__variant': 'helper'}],
+            # Genuine vac group → must still be collected.
+            '041926_44444_VACCREW_Real_Vac': [
+                {'Work Request #': '44444', '__variant': 'vac_crew'}],
+        }
+        scope = generate_weekly_pdfs._build_vac_crew_wr_scope(groups)
+        self.assertIn('44444', scope)
+        self.assertNotIn(
+            '33333', scope,
+            "a non-vac group whose name contains 'VACCREW' must NOT enter "
+            "the vac cleanup scope (variant gate, not substring scan)",
+        )
 
     # ------------------------------------------------------------------
     # Legacy bare _VacCrew deletion + live per-claimer exemption
@@ -691,7 +723,13 @@ class TestVacCrewHashPrune(unittest.TestCase):
         _ensure_smartsheet_mocked()
 
     def _groups(self, wrs):
-        return {f"041926_{wr}_VACCREW_John": [{'Work Request #': wr}] for wr in wrs}
+        # Production rows always carry __variant (set at emission); the scope
+        # builder gates on it, so synthetic prune fixtures must include it.
+        return {
+            f"041926_{wr}_VACCREW_John": [
+                {'Work Request #': wr, '__variant': 'vac_crew'}]
+            for wr in wrs
+        }
 
     def test_drops_legacy_vaccrew_orphans_returns_true(self):
         hist = {
@@ -851,7 +889,8 @@ class TestVacCrewReviewFixes(unittest.TestCase):
         # Guard: with the kill switch ON, the prune still drops legacy orphans.
         generate_weekly_pdfs.VAC_CREW_CLAIM_ATTRIBUTION_ENABLED = True
         hist = {'91467680|041926|vac_crew|': {'hash': 'h1'}}
-        groups = {'041926_91467680_VACCREW_CrewA': [{'Work Request #': '91467680'}]}
+        groups = {'041926_91467680_VACCREW_CrewA': [
+            {'Work Request #': '91467680', '__variant': 'vac_crew'}]}
         changed = generate_weekly_pdfs._run_vac_crew_hash_prune(hist, groups)
         self.assertIs(changed, True)
         self.assertNotIn('91467680|041926|vac_crew|', hist)


### PR DESCRIPTION
## Objective
Complete the deferred consistency follow-up from PR #223 (Living Ledger `[2026-05-25 17:50]`): convert the two sibling WR-scope builders to the authoritative `__variant` field gate, finishing the rule established by Subproject D's `_build_primary_wr_scope` fix — **variant detection MUST use `__variant` (or a positional parse), never a key substring scan.**

## Changes Made
- `generate_weekly_pdfs.py`
  - `_build_subcontractor_wr_scope`: gate on `__variant in {reduced_sub, aep_billable, reduced_sub_helper, aep_billable_helper}` (new module frozenset `_SUBCONTRACTOR_SCOPE_VARIANTS`) instead of `'_REDUCEDSUB' in _key`.
  - `_build_vac_crew_wr_scope`: gate on `__variant == 'vac_crew'` instead of `'_VACCREW' in _key`.
- `tests/` — added pathological-name + complete-variant regression tests (`TestSubcontractorWrScopeVariantGate`, `test_scope_builder_rejects_pathological_vaccrew_name`); reconciled 6 hash-prune fixtures across Subprojects A/B/C to carry `__variant` (production always sets it at emission).
- `CLAUDE.md` — Living Ledger entry `[2026-05-25 19:55]`.

### Why
Both scopes feed **destructive** attachment-cleanup + hash-prune paths. The substring scan had two latent defects: (1) a non-sub/non-vac group whose claimer/helper NAME is an all-caps reserved token (`REDUCEDSUB`/`VACCREW`) false-positived into the destructive scope; (2) `'_REDUCEDSUB'` silently missed `_AEPBILLABLE`-only keys. The `__variant` gate is robust and strictly more complete.

## Production Safety Check
Behavior-preserving for realistic production data — realistic WR#s and foreman names yield the identical WR scope set under either approach (every sub WR always emits a `reduced_sub` group), so this is robustness hardening, not a behavior change. The `valid_wr_weeks` live-identity exemption on the cleanup paths is unchanged. Full suite: **878 passed / 26 skipped / 69 subtests / 0 failed**.