### PR TITLE
fix(billing): revert hash-store AUTHORITATIVE to 0 (stop corruption)

### DIFF
--- a/.github/workflows/weekly-excel-generation.yml
+++ b/.github/workflows/weekly-excel-generation.yml
@@ -430,7 +430,16 @@ jobs:
           # (fail-safe to regenerate). Revert: set AUTHORITATIVE back to
           # '0'. Living Ledger [2026-05-25].
           SUPABASE_HASH_STORE_WRITE_ENABLED: '1'
-          SUPABASE_HASH_STORE_AUTHORITATIVE: '1'
+          # REVERTED to '0' on 2026-05-26: with a near-empty
+          # group_content_hash store, AUTHORITATIVE=1 forced regeneration of
+          # historical (out-of-8-week-scope) groups whose claimer fell back to
+          # the current foreman (#NO MATCH / blank) instead of the real frozen
+          # claimer that exists in attribution_snapshot — producing
+          # _User__NO_MATCH / _User_Unknown_Foreman files uploaded over real
+          # historical attachments. Stays '0' until the attribution
+          # bulk-prefetch fix lands (removes the week-scope from key
+          # formation). See Living Ledger 2026-05-26.
+          SUPABASE_HASH_STORE_AUTHORITATIVE: '0'
 
           # Perf hotfix 2026-05-26: scope the per-row frozen-attribution
           # pre-pass (B/C/D + subcontractor-helper path) to the last N


### PR DESCRIPTION
## Objective

Immediate mitigation to stop a production data-corruption issue. With
`SUPABASE_HASH_STORE_AUTHORITATIVE=1` (set yesterday in `67539ec`) and a
near-empty `group_content_hash` store, Sub-project E forced regeneration of
historical groups via the `no_row` path. Those historical weeks are outside the
`ATTRIBUTION_RESOLUTION_WEEKS=8` scope, so their claimer fell back to the current
Smartsheet foreman (`#NO MATCH` / blank) instead of the real frozen claimer that
exists in `billing_audit.attribution_snapshot` — uploading `_User__NO_MATCH` /
`_User_Unknown_Foreman` files over real historical attachments.

This reverts the Sub-project E activation flag to `0` while the proper fix
(Phase 2: attribution bulk-prefetch + historical remediation) is built and
validated.

## Changes Made

- `.github/workflows/weekly-excel-generation.yml`: `SUPABASE_HASH_STORE_AUTHORITATIVE`
  `'1'` → `'0'`, with an inline rationale comment.

## Production Safety Check

- Pure config revert to a previously-shipped, tested value (`'0'` was the default
  since PR #229; only flipped to `'1'` in `67539ec` one day ago).
- Reverts to JSON change-detection + token filenames (the dormant Sub-project E
  state). Shadow-writes (`SUPABASE_HASH_STORE_WRITE_ENABLED=1`) continue
  harmlessly to keep priming the store.
- Recent-week attribution is unaffected (already correct). This stops the
  `no_row`-driven historical regeneration that produced the garbage names.
- No code-path changes; fail-safe behavior preserved.
- Already-uploaded garbage files are NOT re-fixed by this revert (that is Phase 2
  remediation) — but no NEW garbage is generated.