### PR TITLE
fix(sentry-cron): correct monitor timezone to UTC

### DIFF
--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -8022,6 +8022,32 @@ def _run_synthetic_test_mode(session_start):
 
 # --- MAIN EXECUTION ---
 
+# Sentry Crons monitor schedule. This cron VALUE must stay byte-for-byte
+# identical to the weekday ``schedule.cron`` in
+# .github/workflows/weekly-excel-generation.yml. GitHub Actions evaluates every
+# ``schedule:`` cron in UTC, so the monitor ``timezone`` below MUST be "UTC".
+# (Mislabeling it "America/Chicago" made Sentry expect each check-in 5-6h late
+# and fire a perpetual "missed check-in" outage — GENERATE-WEEKLY-EXCEL-6V.)
+_CRON_MONITOR_SCHEDULE = "0 13,15,17,19,21,23,1 * * 1-5"
+
+
+def _build_cron_monitor_config():
+    """Return the Sentry Crons ``monitor_config`` for the weekly billing job.
+
+    Pure (no I/O); extracted so the schedule/timezone contract can be unit
+    tested. ``timezone`` MUST equal the timezone GitHub Actions evaluates the
+    workflow ``schedule:`` cron in (UTC); see ``_CRON_MONITOR_SCHEDULE``.
+    """
+    return {
+        "schedule": {"type": "crontab", "value": _CRON_MONITOR_SCHEDULE},
+        "timezone": "UTC",
+        "checkin_margin": 5,
+        "max_runtime": 180,
+        "failure_issue_threshold": 1,
+        "recovery_threshold": 1,
+    }
+
+
 def _sentry_cron_checkin_start(monitor_slug):
     """Send a Sentry cron 'in_progress' check-in. Returns the check-in id or None.
 
@@ -8034,14 +8060,7 @@ def _sentry_cron_checkin_start(monitor_slug):
         return capture_checkin(
             monitor_slug=monitor_slug,
             status=MonitorStatus.IN_PROGRESS,
-            monitor_config={
-                "schedule": {"type": "crontab", "value": "0 13,15,17,19,21,23,1 * * 1-5"},
-                "timezone": "America/Chicago",
-                "checkin_margin": 5,
-                "max_runtime": 180,
-                "failure_issue_threshold": 1,
-                "recovery_threshold": 1,
-            },
+            monitor_config=_build_cron_monitor_config(),
         )
     except Exception as exc:
         logging.warning(f"⚠️ Sentry cron check-in (in_progress) failed: {exc}")

--- a/memory-bank/living-ledger.md
+++ b/memory-bank/living-ledger.md
@@ -3689,3 +3689,52 @@ tests continue to pass (empty-dict contract preserved). Full suite: all passed.
 **Guardrails preserved:** Additive only — billing/grouping/hashing/filename/upload paths untouched; `_sanitize_csv_path` untouched; plan-01 edits untouched; `SENTRY_ENABLE_LOGS` default stays `false` (milestone logs are no-ops in prod until an operator explicitly enables them). `if _txn:` guard preserved on all transaction calls.
 
 **Tests:** Full suite 1043 passed, 0 failed; `python -m py_compile generate_weekly_pdfs.py` clean.
+
+---
+
+## [2026-06-05 16:15] Sentry Crons monitor timezone MUST be UTC (GitHub Actions crons are UTC) — fixes perpetual false "missed check-in"
+
+**Root cause (Sentry issue `GENERATE-WEEKLY-EXCEL-6V`, 130 events, last seen
+the day of this fix):** the Sentry Crons `monitor_config` in
+`_sentry_cron_checkin_start()` carried `"timezone": "America/Chicago"` while its
+`schedule` value (`0 13,15,17,19,21,23,1 * * 1-5`) is the **weekday GitHub
+Actions cron** — and GitHub Actions evaluates every `schedule:` cron in **UTC**.
+Labeling the monitor `America/Chicago` made Sentry expect each check-in 5–6h
+later than the job actually checks in, so every weekday slot was flagged as a
+missed check-in (an `outage`-category issue). The earlier PR #261 correction
+(Phoenix → Chicago) fixed the schedule string + max_runtime but introduced this
+tz mismatch; the correct value is **UTC**.
+
+**RULE (operative, locked):** The Sentry cron `monitor_config.timezone` MUST
+equal the timezone GitHub Actions uses to evaluate the workflow `schedule:`
+cron — which is always **UTC**. Never set it to a local zone
+(`America/Chicago`, `America/Phoenix`) just because the *job's* internal
+`TZ` env is Central. The monitor `schedule.value` MUST also stay byte-for-byte
+identical to the weekday cron in `.github/workflows/weekly-excel-generation.yml`.
+
+**What changed (`generate_weekly_pdfs.py`):** Extracted a pure, testable
+`_build_cron_monitor_config()` helper (+ module constant `_CRON_MONITOR_SCHEDULE`)
+out of `_sentry_cron_checkin_start()`; flipped `timezone` `America/Chicago` → `UTC`.
+Behavior otherwise identical (`checkin_margin:5`, `max_runtime:180`,
+`failure_issue_threshold:1`, `recovery_threshold:1`). No billing/grouping/upload
+path touched — monitoring config only. `-6V` left unresolved in Sentry; it
+auto-recovers (`recovery_threshold:1`) on the first correctly-timed check-in
+after deploy.
+
+**Tests (TDD RED→GREEN):** New `tests/test_cron_monitor_config.py` (5 tests):
+asserts `timezone == "UTC"` and never a local zone (the regression guard), the
+schedule/runtime shape, AND that `_CRON_MONITOR_SCHEDULE` matches the workflow's
+weekday cron parsed live from `weekly-excel-generation.yml` (locks out the whole
+drift class). RED confirmed on `America/Chicago` first, then GREEN. Full suite:
+1048 passed, 29 skipped, 0 failed; `py_compile` clean.
+
+**Sentry hygiene (same session, 2026-06-05):** Triaged all 61 unresolved issues
+across `generate-weekly-excel` + `generate-weekly-excel-frontend` (the two
+deleted Express projects had 0). Resolved 34 verified-fixed (rates-CSV `-72`
+post-PR#261; the 29 `KeyError 'refId'` issues — that code path no longer exists
+in `get_all_source_rows`, all stopped 2026-03-18; 4 frontend errors from the
+broken 2026-04-18 deploy: `USE_MOCK`/`DOCS_URL`/React-queue). Ignored 27 transient
+infra / third-party (Smartsheet `ApiError 0/1278/4000/503`, `JSONDecodeError`;
+3 `str+None` TypeErrors raised *inside the Smartsheet SDK's* error formatter,
+`handled:yes`; 2 frontend third-party — a browser-extension `Range` error and a
+`getItem` null inside Sentry's own `feedback/instrument.js`).

--- a/tests/test_cron_monitor_config.py
+++ b/tests/test_cron_monitor_config.py
@@ -1,0 +1,69 @@
+"""Tests for the Sentry Crons monitor_config contract.
+
+Guards the schedule/timezone contract between the Sentry cron monitor
+(``_build_cron_monitor_config`` in ``generate_weekly_pdfs``) and the
+GitHub Actions workflow that actually triggers the job.
+
+Regression: ``GENERATE-WEEKLY-EXCEL-6V`` ("Cron failure: missed check-in").
+The monitor schedule string is the weekday GitHub Actions cron, which Actions
+evaluates in **UTC**. Labeling the monitor ``timezone`` as ``America/Chicago``
+made Sentry expect every check-in 5-6h late and fire a perpetual
+missed-check-in outage. The timezone MUST be ``UTC`` and the schedule VALUE
+MUST stay identical to the workflow's weekday cron.
+"""
+
+import os
+import re
+from pathlib import Path
+from unittest.mock import patch
+
+# Import under a patched environment so a developer's real SENTRY_DSN cannot
+# trigger import-time Sentry initialization during pytest collection.
+with patch.dict(os.environ, {"SENTRY_DSN": ""}, clear=False):
+    import generate_weekly_pdfs as gwp
+
+_WORKFLOW = (
+    Path(__file__).resolve().parent.parent
+    / ".github" / "workflows" / "weekly-excel-generation.yml"
+)
+
+
+class TestBuildCronMonitorConfig:
+    """The monitor_config dict shape and the timezone fix."""
+
+    def test_timezone_is_utc(self):
+        # The core regression guard: GitHub Actions crons are UTC, so the
+        # Sentry monitor timezone must be UTC — never America/Chicago.
+        cfg = gwp._build_cron_monitor_config()
+        assert cfg["timezone"] == "UTC"
+
+    def test_timezone_is_not_a_local_zone(self):
+        cfg = gwp._build_cron_monitor_config()
+        assert cfg["timezone"] not in ("America/Chicago", "America/Phoenix")
+
+    def test_schedule_shape(self):
+        cfg = gwp._build_cron_monitor_config()
+        assert cfg["schedule"]["type"] == "crontab"
+        assert cfg["schedule"]["value"] == gwp._CRON_MONITOR_SCHEDULE
+
+    def test_runtime_and_threshold_fields(self):
+        cfg = gwp._build_cron_monitor_config()
+        assert cfg["max_runtime"] == 180
+        assert cfg["checkin_margin"] == 5
+        assert cfg["failure_issue_threshold"] == 1
+        assert cfg["recovery_threshold"] == 1
+
+
+class TestScheduleMatchesWorkflow:
+    """The monitor schedule must track the real workflow trigger cron."""
+
+    def test_monitor_schedule_matches_workflow_weekday_cron(self):
+        text = _WORKFLOW.read_text(encoding="utf-8")
+        crons = re.findall(r"- cron:\s*'([^']+)'", text)
+        # The weekday cron (Mon-Fri, '* * 1-5') is the one the monitor tracks.
+        weekday = [c for c in crons if c.strip().endswith("1-5")]
+        assert weekday, f"no weekday cron found in {_WORKFLOW.name}: {crons}"
+        assert gwp._CRON_MONITOR_SCHEDULE in weekday, (
+            "Sentry monitor schedule drifted from the workflow weekday cron: "
+            f"{gwp._CRON_MONITOR_SCHEDULE!r} not in {weekday!r}"
+        )


### PR DESCRIPTION
## Objective

Fix the perpetual false **"Cron failure: missed check-in"** outage in Sentry
(`GENERATE-WEEKLY-EXCEL-6V`, 130 events, last seen the day of this fix). The
Sentry Crons monitor was configured with `timezone: "America/Chicago"` while its
`schedule` value is the **weekday GitHub Actions cron** — and GitHub Actions
evaluates every `schedule:` cron in **UTC**. The 5–6h offset made Sentry expect
each check-in hours late and flag every weekday slot as missed. (PR #261's
earlier Phoenix→Chicago correction fixed the schedule string but introduced this
timezone mismatch; the correct value is UTC.)

## Changes Made

- **`generate_weekly_pdfs.py`** — Extracted a pure, testable
  `_build_cron_monitor_config()` helper (+ `_CRON_MONITOR_SCHEDULE` constant)
  out of `_sentry_cron_checkin_start()`, and flipped `timezone`
  `America/Chicago` → `UTC`. Other config unchanged (`checkin_margin: 5`,
  `max_runtime: 180`, `failure_issue_threshold: 1`, `recovery_threshold: 1`).
- **`tests/test_cron_monitor_config.py`** (new) — 5 TDD tests (RED→GREEN):
  asserts `timezone == "UTC"` and never a local zone; the schedule/runtime
  shape; and that `_CRON_MONITOR_SCHEDULE` matches the **live workflow weekday
  cron** parsed from `weekly-excel-generation.yml` (locks out the drift class).
- **`memory-bank/living-ledger.md`** — Dated rule: the Sentry cron monitor
  timezone MUST be UTC (GitHub Actions crons are UTC), plus the same-session
  Sentry triage summary (34 resolved / 27 ignored).

## Production Safety Check

- **Monitoring config only** — no billing / grouping / hashing / filename /
  Smartsheet upload path is touched. The change is confined to the
  `monitor_config` dict sent with the cron check-in.
- **Tests:** full `pytest tests/` → **1048 passed, 29 skipped, 0 failed**;
  `python -m py_compile generate_weekly_pdfs.py` clean; `portal-v2` vitest
  **113 passed** (unrelated surface, unaffected).
- **`-6V` recovery:** intentionally left open in Sentry; it auto-recovers
  (`recovery_threshold: 1`) on the first correctly-timed check-in after deploy.
- **Rollback:** revert this commit; the monitor reverts to the prior config on
  the next check-in. Blast radius: Sentry cron alerting only — zero billing impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)