### PR TITLE
fix(sentry): clear 3 Pylance type errors in generate_weekly_pdfs.py

### DIFF
--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -67,7 +67,14 @@ import sys
 import json
 import signal
 import csv
-from typing import Any, cast
+from typing import Any, cast, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    # ``MonitorConfig`` is a TypedDict consulted only by the static type
+    # checker to validate ``capture_checkin(monitor_config=...)``. Importing it
+    # under ``TYPE_CHECKING`` keeps the runtime import surface unchanged (it is
+    # never imported when the script actually runs).
+    from sentry_sdk._types import MonitorConfig
 
 # Load environment variables
 load_dotenv()
@@ -1126,7 +1133,12 @@ def _sentry_log_event(level: str, message: str, **attributes: int | float | bool
     if not hasattr(sentry_sdk, "logger"):
         return
     try:
-        log_fn = getattr(sentry_sdk.logger, level, sentry_sdk.logger.info)
+        # ``sentry_sdk.logger`` is a lazily-bound attribute (real in
+        # sentry-sdk >= 2.54.0; presence already asserted by the hasattr guard
+        # above). Resolve it via getattr so static analysis does not flag it as
+        # an unknown module attribute. Runtime behavior is unchanged.
+        _logger = getattr(sentry_sdk, "logger")
+        log_fn = getattr(_logger, level, _logger.info)
         log_fn(message, **attributes)
     except Exception as _log_exc:
         logging.debug(f"_sentry_log_event swallowed error: {_log_exc}")
@@ -8031,7 +8043,7 @@ def _run_synthetic_test_mode(session_start):
 _CRON_MONITOR_SCHEDULE = "0 13,15,17,19,21,23,1 * * 1-5"
 
 
-def _build_cron_monitor_config():
+def _build_cron_monitor_config() -> "MonitorConfig":
     """Return the Sentry Crons ``monitor_config`` for the weekly billing job.
 
     Pure (no I/O); extracted so the schedule/timezone contract can be unit


### PR DESCRIPTION
## Objective

Resolve the **3 `Error`-severity Pylance/Pyright diagnostics** in
`generate_weekly_pdfs.py` (Sentry helpers). All three are **static-analysis
errors, not runtime bugs** — the code is `hasattr`-guarded, covered by tests,
CI-passed, and running in production. Verified via the IDE `getDiagnostics`
MCP: Error-severity **3 → 0** (the 369 `Hint`-level diagnostics are intentionally
left untouched — out of scope).

## Changes Made

- **`_sentry_log_event`** — `sentry_sdk.logger` was flagged twice as *"not a
  known attribute of module sentry_sdk"* (it's a lazily-bound attribute, real
  in sentry-sdk ≥ 2.54.0). Resolve it via `getattr(sentry_sdk, "logger")` into
  a local — the presence is already asserted by the `hasattr` guard on the line
  above. Fixes errors #1 and #2.
- **`_build_cron_monitor_config`** — its returned dict was *"not assignable to
  parameter monitor_config of type MonitorConfig | None"* in `capture_checkin`.
  Added a `TYPE_CHECKING` import of `MonitorConfig` (`sentry_sdk._types`) and
  annotated the helper `-> "MonitorConfig"`. Fixes error #3.

## Production Safety Check

- **Type-only — zero runtime behavior change.** `getattr` resolves the exact
  same attribute the `hasattr` guard already proved exists; the `MonitorConfig`
  import is under `if TYPE_CHECKING:` so it is **never imported at runtime**.
- No billing / grouping / hashing / filename / Smartsheet-upload / cron-schedule
  logic is touched.
- **Tests:** `python -m py_compile generate_weekly_pdfs.py` clean; full
  `pytest tests/` → **1048 passed, 29 skipped** (identical to pre-change).
- **IDE diagnostics:** Error-severity **3 → 0**; 369 Hints unchanged.
- **Rollback:** revert this commit — blast radius is zero (annotations / attribute-access style only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)