### PR TITLE
fix: pin smartsheet-python-sdk <4.0.0 to stop CI import crash

### DIFF
--- a/memory-bank/living-ledger.md
+++ b/memory-bank/living-ledger.md
@@ -3738,3 +3738,38 @@ infra / third-party (Smartsheet `ApiError 0/1278/4000/503`, `JSONDecodeError`;
 3 `str+None` TypeErrors raised *inside the Smartsheet SDK's* error formatter,
 `handled:yes`; 2 frontend third-party — a browser-extension `Range` error and a
 `getItem` null inside Sentry's own `feedback/instrument.js`).
+
+---
+
+[2026-06-08 10:45] **Pin transport-critical SDK dependencies with an upper bound — smartsheet-python-sdk 4.0.0 import crash**
+
+**What:** Pinned `smartsheet-python-sdk` to `>=3.1.0,<4.0.0` in `requirements.txt`. The
+previous spec (`>=3.1.0`, no ceiling) caused GitHub Actions to silently pull the breaking
+4.0.0 major on its publish day (2026-06-08), crashing `generate_weekly_pdfs.py` at line 28
+(`import smartsheet.exceptions as ss_exc`) before any billing work could run.
+
+**Why:** SDK 4.0.0 is a backward-incompatible major that removed `smartsheet.exceptions`
+entirely, removed `Folders.get_folder` and `Folders.list_folders`, removed the `Templates`
+endpoint, and changed pagination — all surfaces the billing pipeline depends on. CI runs a
+fresh `pip install -r requirements.txt` on every workflow execution; an open `>=` lower-bound
+on a rapidly evolving SDK is equivalent to an unpinned dependency in a fresh-install
+environment.
+
+**Root cause pattern:** A transport-critical library (one whose import or API surfaces are
+called unconditionally at the top of the production script) was given only a lower bound in
+`requirements.txt`. When the library published a breaking major, the next CI run resolved
+to that major, crashing before a single row was processed. The failure was silent until the
+scheduled run fired — no local developer environment surfaced the issue.
+
+**Rule established:** Transport-critical / production-pipeline dependencies — any package
+whose import or API is called unconditionally by `generate_weekly_pdfs.py` or
+`audit_billing_changes.py` — MUST carry an upper bound that excludes the next major version.
+Format: `>=CURRENT_MAJOR.MINOR.PATCH,<NEXT_MAJOR.0.0`. A deliberate major-version migration
+(e.g., adopting smartsheet-python-sdk 4.x) is a separate planned effort with explicit
+compatibility testing — it must never arrive as a transitive auto-upgrade on publish day.
+Apply this rule to: `smartsheet-python-sdk`, `openpyxl`, `sentry-sdk`, `supabase`, and any
+future SDK added as a direct import in the billing engine.
+
+**Fix:** Single-line change in `requirements.txt`; zero change to `generate_weekly_pdfs.py`,
+`ss_exc` usage, or the SDK retry-exception re-export workaround. Fully reversible by removing
+`,<4.0.0`. Dry-run confirmed `smartsheet-python-sdk 3.7.2` resolves correctly post-pin.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,9 @@ sentry-sdk>=2.54.0
 
 # Core Dependencies
 # 3.1.0+ required for Folders.get_folder_children (replacement for deprecated get_folder)
-smartsheet-python-sdk>=3.1.0
+# Upper bound excludes the breaking 4.0.0 (2026-06-08) major release, which removed
+# smartsheet.exceptions + Folders.get_folder/list_folders + Templates and changed pagination.
+smartsheet-python-sdk>=3.1.0,<4.0.0
 openpyxl==3.1.5
 Pillow==12.2.0
 python-dateutil==2.9.0.post0


### PR DESCRIPTION
@
## Objective

Restore the production **weekly Excel generation** GitHub Actions workflow, which is currently crashing on every run at import time:

```
File "generate_weekly_pdfs.py", line 28, in <module>
    import smartsheet.exceptions as ss_exc
ModuleNotFoundError: No module named 'smartsheet.exceptions'
```

**Root cause:** `requirements.txt` pinned `smartsheet-python-sdk>=3.1.0` with **no upper bound**. `smartsheet-python-sdk` **4.0.0** was published to PyPI on **2026-06-08** — a breaking major release that restructured the SDK so `import smartsheet.exceptions` no longer resolves. CI runs a fresh `pip install -r requirements.txt`, so the unpinned spec silently pulled 4.0.0 and the script crashed before any billing work ran. (4.0.0 also removed `Folders.get_folder`/`list_folders` + `Templates` and changed pagination — it is broadly incompatible with the current pipeline.)

This PR is the **emergency hotfix**: pin out 4.0.0 to restore the exact 3.x behavior the pipeline was built and tested against. A deliberate, planned migration to 4.0.0 is tracked separately (milestone v1.2) and is **out of scope here**.

## Changes Made

- **`requirements.txt`** — `smartsheet-python-sdk>=3.1.0` → `smartsheet-python-sdk>=3.1.0,<4.0.0`, with an expanded comment explaining both bounds (the `>=3.1.0` floor for `Folders.get_folder_children`, the `<4.0.0` ceiling excluding the breaking 2026-06-08 major).
- **`memory-bank/living-ledger.md`** — appended a dated `[2026-06-08]` entry recording the incident and the operational rule: transport-critical / production-pipeline SDKs must carry an upper bound, because CI fresh-installs and an unpinned `>=` pulls breaking majors on their publish day.

## Production Safety Check

- **Zero change to billing logic.** No edits to `generate_weekly_pdfs.py`, the `ss_exc` retry blocks, or the SDK retry-exception re-export workaround. The only functional change is the dependency constraint.
- **Verified:** `python -m py_compile generate_weekly_pdfs.py` exits clean; a non-mutating `pip install --dry-run -r requirements.txt` resolves `smartsheet-python-sdk` to **3.7.2** (a 3.x release that ships `smartsheet/exceptions.py`), never 4.0.0.
- **Fully reversible.** Rollback = delete `,<4.0.0`. Blast radius is dependency resolution only.
- **Note:** branched off `origin/master`, so the recent `python-dotenv==1.2.2` bump on master is preserved.
- Full `pytest tests/ -v` push gate should run in CI on this branch before merge (covers `tests/test_billing_audit_shadow.py`, which also imports `smartsheet.exceptions`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@