### PR TITLE
fix: replay Units Completed? gate in VAC exclusion pre-pass (#274 follow-up)

### DIFF
--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -6107,14 +6107,17 @@ def group_source_rows(rows):
     for _vr in rows:
         if not _vr.get('__is_vac_crew'):
             continue
-        # Gate on Units Completed? exactly as the emission loop below
-        # (the `units_completed_checked` requirement) does. A VAC row that
-        # is NOT completed is dropped at that gate and never billed on the
-        # VacCrew sheet, so it must NOT suppress the foreman/helper copy of
-        # the same unit — otherwise a unit that IS completed on the foreman
-        # row vanishes from every sheet and is billed to nobody (revenue
-        # leak). Mirrors operator contract 2026-06-08: a unit is VAC-claimed
-        # only when Units Completed? is checked.
+        # Defense-in-depth: replay the emission loop's `Units Completed?`
+        # gate in this pre-pass too. Today this is belt-and-suspenders — the
+        # only place `__is_vac_crew` is set (get_all_source_rows ~L5464)
+        # already requires `units_completed_checked`, so no production row
+        # reaches here with `__is_vac_crew=True` and `Units Completed?`
+        # unchecked. The guard future-proofs against that detection ever
+        # being decoupled: an incomplete VAC row, if it slipped through,
+        # would be dropped at the emission gate (never billed on VacCrew)
+        # yet could still suppress the foreman/helper copy of the same unit,
+        # billing a completed unit to nobody. Repo rule: a pre-pass that
+        # mirrors a downstream gate must replay that gate's full predicate.
         if not is_checked(_vr.get('Units Completed?')):
             continue
         _vwr = _vr.get('Work Request #')

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -6107,6 +6107,16 @@ def group_source_rows(rows):
     for _vr in rows:
         if not _vr.get('__is_vac_crew'):
             continue
+        # Gate on Units Completed? exactly as the emission loop below
+        # (the `units_completed_checked` requirement) does. A VAC row that
+        # is NOT completed is dropped at that gate and never billed on the
+        # VacCrew sheet, so it must NOT suppress the foreman/helper copy of
+        # the same unit — otherwise a unit that IS completed on the foreman
+        # row vanishes from every sheet and is billed to nobody (revenue
+        # leak). Mirrors operator contract 2026-06-08: a unit is VAC-claimed
+        # only when Units Completed? is checked.
+        if not is_checked(_vr.get('Units Completed?')):
+            continue
         _vwr = _vr.get('Work Request #')
         _vdate_raw = _vr.get('Weekly Reference Logged Date')
         if not _vwr or not _vdate_raw:

--- a/memory-bank/living-ledger.md
+++ b/memory-bank/living-ledger.md
@@ -3837,32 +3837,40 @@ failures; `py_compile` OK. Hash key NOT shortened (dropping a leaked row changes
 `_User_`/`_VacCrew_` group hashes → expected regeneration, not a regression). No `@cell`;
 `safe_merge_cells`/`oddFooter`/`PARALLEL_WORKERS` untouched. PR #274.
 
-[2026-06-16 00:00] **VAC exclusion-set pre-pass MUST gate on `Units Completed?` — an incomplete VAC row was poisoning the foreman's completed copy (revenue leak)**
+[2026-06-16 00:00] **VAC exclusion-set pre-pass replays the `Units Completed?` gate — defense-in-depth against a latent coupling (NOT an active production leak)**
 
-**What:** Follow-up to PR #274. The cross-row reconciliation pre-pass that builds
-`_vac_claimed_units` in `group_source_rows` added EVERY `__is_vac_crew` row's `(WR, week, Point,
-CU)` to the exclusion set without checking `Units Completed?`. The per-row emission loop below it,
-however, drops any row whose `Units Completed?` is unchecked (the `units_completed_checked` gate).
+**What:** Follow-up to PR #274 (shipped as PR #278). The cross-row reconciliation pre-pass that
+builds `_vac_claimed_units` in `group_source_rows` added EVERY `__is_vac_crew` row's `(WR, week,
+Point, CU)` to the exclusion set without re-checking `Units Completed?`. The per-row emission loop
+below it drops any row whose `Units Completed?` is unchecked (the `units_completed_checked` gate).
+The guard added here replays that same gate inside the pre-pass.
 
-**Bug (HIGH, revenue leak):** When the SAME unit exists as an INCOMPLETE VAC row
-(`Units Completed? = False`) and a COMPLETE foreman row (`Units Completed? = True`) — the realistic
-two-sheet case — the VAC row poisoned the exclusion set, then was itself dropped at the
-`units_completed_checked` gate (never billed on the VacCrew sheet). The foreman's completed copy was
-then excluded as a "VAC-claimed duplicate." Net: the completed, billable unit appeared on NO sheet
-and was billed to NOBODY. This silently violated the PR #274 operator contract documented one entry
-above ("a unit is VAC-claimed only when `Units Completed?` is checked"): that gate was applied in the
-consumer loop but MISSED in the new pre-pass builder.
+**Reachability (corrected during PR #278 review — Copilot cross-reference, verified):** This is NOT
+an active revenue leak in the current pipeline. `__is_vac_crew` is assigned in exactly ONE place
+(`get_all_source_rows`, line 5483) from `is_vac_crew_row = bool(vac_crew_name and
+vac_crew_completed_checked and units_completed_checked)` (line 5464), where
+`units_completed_checked = is_checked(row_data.get('Units Completed?'))` (line 5366) — the IDENTICAL
+predicate the guard uses. So no production row can reach the pre-pass with `__is_vac_crew=True` and
+`Units Completed?` unchecked; the guard is logically unreachable today. (Matches the PR #274 operator
+note one entry above: the `_VacCrew_` files only exist because detection already required
+`Units Completed?`.) The initial daily-review framing as a HIGH revenue-leak bug read the pre-pass
+in isolation and missed this upstream coupling — corrected here for the record.
 
-**Rule established:** Any pre-pass that mirrors a downstream emission/admission gate MUST replay that
-gate's full predicate. The exclusion-set builder now `continue`s on
-`not is_checked(_vr.get('Units Completed?'))`, byte-for-byte the same gate the emission loop uses —
-so a unit enters `_vac_claimed_units` only when the VAC crew will actually bill it. Incomplete VAC
-rows no longer suppress anything.
+**Why keep it (defense-in-depth + regression lock):** Were line 5464 ever decoupled (detection split
+from `units_completed_checked`), an incomplete VAC row would be dropped at the emission gate (never
+billed on VacCrew) yet could still suppress the foreman/helper copy of the same unit — billing a
+completed unit to nobody. The guard forecloses that, and the regression test locks it.
+
+**Rule (reaffirmed):** Any pre-pass that mirrors a downstream emission/admission gate MUST replay
+that gate's full predicate, even when an upstream invariant currently makes the gap unreachable —
+the invariant can drift; the pre-pass should not silently depend on it.
 
 **Fix:** `generate_weekly_pdfs.py` (one `is_checked` guard + comment in the `_vac_claimed_units`
 pre-pass). Regression test `tests/test_vac_crew_exclusion_leak.py::TestVacCrewRequiresUnitsCompleted
-::test_incomplete_vac_row_does_not_suppress_completed_foreman` — proven to FAIL on the pre-fix code
-(foreman unit lands in an empty set) and PASS after. Full suite 1056 passed / 29 skipped / 0
-failures; `py_compile` OK. Surgical/additive: no change to grouping keys, hashing, filenames,
-attachment cleanup, or the billing-audit attribution chain; no `@cell`;
-`safe_merge_cells`/`oddFooter`/`PARALLEL_WORKERS` untouched.
+::test_incomplete_vac_row_does_not_suppress_completed_foreman` synthetically constructs the
+`__is_vac_crew=True, Units Completed?=False` state the upstream pipeline prevents — proven to FAIL on
+the pre-fix code (foreman unit lands in an empty set) and PASS after. Full suite 1056 passed / 29
+skipped / 0 failures; `py_compile` OK. Surgical/additive: no behavioral change in production (guard
+unreachable today), none to grouping keys, hashing, filenames, attachment cleanup, or the
+billing-audit attribution chain; no `@cell`; `safe_merge_cells`/`oddFooter`/`PARALLEL_WORKERS`
+untouched. PR #278.

--- a/memory-bank/living-ledger.md
+++ b/memory-bank/living-ledger.md
@@ -3836,3 +3836,33 @@ cross-sheet duplicates, all 26 of Chris's own Point 11 units retained. Suite 105
 failures; `py_compile` OK. Hash key NOT shortened (dropping a leaked row changes the affected
 `_User_`/`_VacCrew_` group hashes → expected regeneration, not a regression). No `@cell`;
 `safe_merge_cells`/`oddFooter`/`PARALLEL_WORKERS` untouched. PR #274.
+
+[2026-06-16 00:00] **VAC exclusion-set pre-pass MUST gate on `Units Completed?` — an incomplete VAC row was poisoning the foreman's completed copy (revenue leak)**
+
+**What:** Follow-up to PR #274. The cross-row reconciliation pre-pass that builds
+`_vac_claimed_units` in `group_source_rows` added EVERY `__is_vac_crew` row's `(WR, week, Point,
+CU)` to the exclusion set without checking `Units Completed?`. The per-row emission loop below it,
+however, drops any row whose `Units Completed?` is unchecked (the `units_completed_checked` gate).
+
+**Bug (HIGH, revenue leak):** When the SAME unit exists as an INCOMPLETE VAC row
+(`Units Completed? = False`) and a COMPLETE foreman row (`Units Completed? = True`) — the realistic
+two-sheet case — the VAC row poisoned the exclusion set, then was itself dropped at the
+`units_completed_checked` gate (never billed on the VacCrew sheet). The foreman's completed copy was
+then excluded as a "VAC-claimed duplicate." Net: the completed, billable unit appeared on NO sheet
+and was billed to NOBODY. This silently violated the PR #274 operator contract documented one entry
+above ("a unit is VAC-claimed only when `Units Completed?` is checked"): that gate was applied in the
+consumer loop but MISSED in the new pre-pass builder.
+
+**Rule established:** Any pre-pass that mirrors a downstream emission/admission gate MUST replay that
+gate's full predicate. The exclusion-set builder now `continue`s on
+`not is_checked(_vr.get('Units Completed?'))`, byte-for-byte the same gate the emission loop uses —
+so a unit enters `_vac_claimed_units` only when the VAC crew will actually bill it. Incomplete VAC
+rows no longer suppress anything.
+
+**Fix:** `generate_weekly_pdfs.py` (one `is_checked` guard + comment in the `_vac_claimed_units`
+pre-pass). Regression test `tests/test_vac_crew_exclusion_leak.py::TestVacCrewRequiresUnitsCompleted
+::test_incomplete_vac_row_does_not_suppress_completed_foreman` — proven to FAIL on the pre-fix code
+(foreman unit lands in an empty set) and PASS after. Full suite 1056 passed / 29 skipped / 0
+failures; `py_compile` OK. Surgical/additive: no change to grouping keys, hashing, filenames,
+attachment cleanup, or the billing-audit attribution chain; no `@cell`;
+`safe_merge_cells`/`oddFooter`/`PARALLEL_WORKERS` untouched.

--- a/tests/test_vac_crew_exclusion_leak.py
+++ b/tests/test_vac_crew_exclusion_leak.py
@@ -183,14 +183,17 @@ class TestVacCrewRequiresUnitsCompleted(unittest.TestCase):
         )
 
     def test_incomplete_vac_row_does_not_suppress_completed_foreman(self):
-        """Cross-row poisoning guard.
+        """Cross-row poisoning guard (defense-in-depth).
 
-        A VAC row for a unit is NOT completed (``Units Completed?``
-        unchecked), so it is dropped at the grouping gate and never billed
-        on the VacCrew sheet. The foreman's copy of the SAME unit IS
-        completed. The incomplete VAC row must NOT add the unit to the
-        VAC-claimed exclusion set; otherwise the completed foreman copy is
-        wrongly dropped and the unit is billed to nobody (revenue leak).
+        Synthetic state: a row flagged ``__is_vac_crew`` whose
+        ``Units Completed?`` is unchecked. In production this state is
+        currently UNREACHABLE — upstream detection (``get_all_source_rows``
+        ~L5464) only sets ``__is_vac_crew`` when ``Units Completed?`` is
+        already checked — so this test constructs it directly to lock the
+        pre-pass guard against a future decoupling of that detection.
+        Without the guard, the incomplete VAC row adds the unit to the
+        VAC-claimed exclusion set, the completed foreman copy of the SAME
+        unit is wrongly dropped, and a completed unit is billed to nobody.
         """
         vac = _vac_row('Point 11', 'ANC-DSC-16-96-D1')
         vac['Units Completed?'] = False

--- a/tests/test_vac_crew_exclusion_leak.py
+++ b/tests/test_vac_crew_exclusion_leak.py
@@ -182,6 +182,36 @@ class TestVacCrewRequiresUnitsCompleted(unittest.TestCase):
             "any variant."
         )
 
+    def test_incomplete_vac_row_does_not_suppress_completed_foreman(self):
+        """Cross-row poisoning guard.
+
+        A VAC row for a unit is NOT completed (``Units Completed?``
+        unchecked), so it is dropped at the grouping gate and never billed
+        on the VacCrew sheet. The foreman's copy of the SAME unit IS
+        completed. The incomplete VAC row must NOT add the unit to the
+        VAC-claimed exclusion set; otherwise the completed foreman copy is
+        wrongly dropped and the unit is billed to nobody (revenue leak).
+        """
+        vac = _vac_row('Point 11', 'ANC-DSC-16-96-D1')
+        vac['Units Completed?'] = False
+        rows = [
+            vac,
+            _foreman_row('Point 11', 'ANC-DSC-16-96-D1'),  # completed -> keep
+        ]
+        groups = generate_weekly_pdfs.group_source_rows(rows)
+        primary = _cus_for_variant(groups, 'primary')
+        vac_cus = _cus_for_variant(groups, 'vac_crew')
+        self.assertIn(
+            'ANC-DSC-16-96-D1', primary,
+            "An incomplete VAC row wrongly suppressed the foreman's "
+            "completed copy of the same unit -- the unit is now billed to "
+            "nobody."
+        )
+        self.assertNotIn(
+            'ANC-DSC-16-96-D1', vac_cus,
+            "An incomplete VAC row must not appear on the VacCrew sheet."
+        )
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Objective

Defense-in-depth hardening of the VAC-crew cross-row reconciliation in `group_source_rows` (follow-up to #274). The pre-pass that builds the `_vac_claimed_units` exclusion set did not replay the `Units Completed?` gate that the per-row emission loop applies. This PR makes the pre-pass replay that gate so the two stages agree.

**Reachability (corrected per the Copilot review on this PR):** this is **not an active production leak**. `__is_vac_crew` is set in exactly one place (`get_all_source_rows` L5483) from a conjunction that already requires `units_completed_checked` (L5464 → `is_checked('Units Completed?')` at L5366), so no production row reaches the pre-pass with `__is_vac_crew=True` and `Units Completed?` unchecked. The guard is therefore belt-and-suspenders today; its value is **future-proofing** against that upstream detection ever being decoupled, plus a **regression lock**. It also satisfies the repo rule that a pre-pass mirroring a downstream gate must replay that gate's full predicate.

_For completeness, the failure it forecloses: if an incomplete VAC row ever reached the pre-pass, it would be dropped at the emission gate (never billed on VacCrew) yet could still suppress the completed foreman/helper copy of the same unit — billing a completed unit to nobody._

## Changes Made

- **`generate_weekly_pdfs.py`** — add a `not is_checked(_vr.get('Units Completed?'))` `continue` guard to the `_vac_claimed_units` pre-pass, mirroring the emission gate; comment notes it is unreachable today and why it's kept.
- **`tests/test_vac_crew_exclusion_leak.py`** — `test_incomplete_vac_row_does_not_suppress_completed_foreman` synthetically constructs the `__is_vac_crew=True, Units Completed?=False` state (upstream-prevented in prod) to lock the guard. Proven to fail pre-fix and pass after.
- **`memory-bank/living-ledger.md`** — dated entry documenting the latent coupling, the verified upstream invariant, and the reaffirmed pre-pass rule.

## Production Safety Check

- **No behavioral change in production** — the guard is unreachable under the current upstream invariant; it only changes behavior if that invariant is later removed.
- Surgical/additive: no change to grouping keys, change-detection hashing, filenames, attachment cleanup, or the billing-audit attribution chain.
- Full suite **1056 passed / 29 skipped / 0 failures**; `py_compile` clean. No `@cell`; `safe_merge_cells` / `oddFooter` / `PARALLEL_WORKERS` untouched.

> **CI note:** the only red check, `code/snyk` ("Code test limit reached"), is a Snyk SAST **account-quota** error, not a finding against this diff (the dependency scan passed; no deps changed). It needs a quota bump/reset on the account side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SpA1rYgtQcTeJsyFR54oAP

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a single-line defense-in-depth guard to the `_vac_claimed_units` exclusion-set pre-pass in `group_source_rows`, ensuring it respects the same `Units Completed?` gate the downstream emission loop already enforces. The guard is provably unreachable today because the upstream detection at line 5464 already requires `units_completed_checked`, but it future-proofs the pre-pass against any future decoupling of that detection.

- **`generate_weekly_pdfs.py`**: `if not is_checked(_vr.get('Units Completed?')): continue` inserted into the `_vac_claimed_units` pre-pass loop with a thorough comment explaining the current reachability and the failure it forecloses.
- **`tests/test_vac_crew_exclusion_leak.py`**: `test_incomplete_vac_row_does_not_suppress_completed_foreman` synthetically constructs the upstream-prevented state to regression-lock the guard; both assertions are correct and necessary.
- **`memory-bank/living-ledger.md`**: Entry appended with proper `[YYYY-MM-DD HH:MM]` timestamp, documenting the invariant, the latent coupling, and the repo rule that a pre-pass must replay its downstream gate's full predicate.

<h3>Confidence Score: 5/5</h3>

The change is additive-only and provably unreachable in production today; merging it introduces no behavioral change to any billing output.

The upstream invariant at line 5464 guarantees no row can reach the pre-pass with __is_vac_crew=True and Units Completed? unchecked. The guard therefore changes nothing in production. The new test correctly constructs the synthetic unreachable state and locks the guard. No grouping keys, hashing, filenames, attachment cleanup, or attribution logic are touched.

No files require special attention. The only changed production file is the single guard line in generate_weekly_pdfs.py, which is thoroughly covered by the new test.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| generate_weekly_pdfs.py | Adds an is_checked guard to the _vac_claimed_units pre-pass; placement is correct and mirrors the downstream emission gate at line 6163; no other logic touched. |
| tests/test_vac_crew_exclusion_leak.py | New test synthetically constructs the unreachable __is_vac_crew=True, Units Completed?=False state and validates the guard prevents cross-row poisoning. |
| memory-bank/living-ledger.md | Appends a dated entry at the bottom per CLAUDE.md autonomous-memory rule; documents the upstream invariant, latent coupling, and test regression lock. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[group_source_rows: iterate rows] --> B{__is_vac_crew?}
    B -- No --> C[Skip in pre-pass]
    B -- Yes --> D{Units Completed? checked? NEW guard}
    D -- No --> E[continue: do NOT add to _vac_claimed_units]
    D -- Yes --> F[Add unit tuple to _vac_claimed_units]
    F --> G[Emission loop]
    G --> H{is_vac_crew_row?}
    H -- Yes --> I{Units Completed? checked? existing gate L6163}
    I -- No --> J[Drop: not billed]
    I -- Yes --> K[Route to vac_crew variant]
    H -- No --> L{Unit in _vac_claimed_units?}
    L -- Yes --> M[Drop foreman/helper copy]
    L -- No --> N[Route to primary/helper variant]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[group_source_rows: iterate rows] --> B{__is_vac_crew?}
    B -- No --> C[Skip in pre-pass]
    B -- Yes --> D{Units Completed? checked? NEW guard}
    D -- No --> E[continue: do NOT add to _vac_claimed_units]
    D -- Yes --> F[Add unit tuple to _vac_claimed_units]
    F --> G[Emission loop]
    G --> H{is_vac_crew_row?}
    H -- Yes --> I{Units Completed? checked? existing gate L6163}
    I -- No --> J[Drop: not billed]
    I -- Yes --> K[Route to vac_crew variant]
    H -- No --> L{Unit in _vac_claimed_units?}
    L -- Yes --> M[Drop foreman/helper copy]
    L -- No --> N[Route to primary/helper variant]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["docs: reframe VAC gate as defense-in-dep..."](https://github.com/jflo21/generate-weekly-pdfs-dsr-resiliency/commit/bcb50df2f2b6e630b57e79fc26f3968763a1d3fc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39492138)</sub>

<!-- /greptile_comment -->