### PR TITLE
fix: defer durable group-hash upsert until upload success (WR 90968595 skip-gate deadlock)

### DIFF
--- a/.claude/project-state.md
+++ b/.claude/project-state.md
@@ -6,9 +6,10 @@ write-back reminder). Keep it terse; link to history rather than duplicating it.
 
 ## Current milestone
 **v1.3.1 — Smartsheet API resilience & silent-failure hardening** (follow-up to
-Phase 09, **IN REVIEW**). Targeted fix on branch
-`fix/api-resilience-silent-failures` (cut fresh from `origin/master`). Two
-changes, both TDD'd, all 6 gates green:
+Phase 09, **✅ COMPLETE & MERGED, PR #281 → `8c51a3c`** on 2026-07-01 UTC).
+Shipped from `fix/api-resilience-silent-failures` (cut fresh from
+`origin/master`; branch deleted on merge). Three change areas, all TDD'd, all 6
+gates green, PII scrubs dummy-transport-verified:
 1. **Transient-retry resilience (the API errors).** New `pipeline/retry.py`
    `smartsheet_call_with_retry()` — retries the transients the SDK does NOT
    itself drive to success (generic `ApiError` **code 4000**, server timeout,
@@ -42,14 +43,40 @@ changes, both TDD'd, all 6 gates green:
    `no_history` fallback was silent — `resolve_claimer` returns
    `('use', current, 'current', 'no_history')` and the `action=='use'` branch
    zeroed the reason, so the per-WR WARNING never fired. One-line propagate-
-   the-reason fix; the 2 dead-path tests (mocked an impossible `action`) were
+   the-reason fix + reason-branched remediation (`no_history` vs `fetch_failure`
+   vs `unavailable`); the 2 dead-path tests (mocked an impossible `action`)
    rewritten to the **real** `resolve_claimer` contract (red-first proven).
+3. **Sentry PII hardening across all THREE data planes** (review-driven).
+   Row PII (WR/week/foreman/dept/job/price) must never reach Sentry. Closed:
+   (a) **event frames** → `before_send` `_scrub_sheet_drop_frame_vars` (a scope
+   event-processor runs too early — `attach_stacktrace` appends thread frames
+   after it); (b) **breadcrumb `message`** → `before_breadcrumb` drops any crumb
+   whose message hits `_PII_LOG_MARKERS` (`LoggingIntegration(level=INFO)` turns
+   every INFO/WARNING into a breadcrumb *unconditionally*, independent of the
+   `SENTRY_ENABLE_LOGS` gate); (c) **breadcrumb `data`** → same hook strips
+   row-identifier keys via the new `_PII_BREADCRUMB_DATA_KEYS` registry (manual
+   crumbs carry PII in `data` under a benign message — e.g. the skip/regenerate
+   crumbs). All three empirically verified with a real `sentry_sdk.Client` +
+   dummy transport.
 
-**Status:** implemented + `run_6_gates.sh` exit 0 (G1 177 names · G2 107 facade
-· **G3 1130 pytest** +130 subtests · G4 mypy 56→56 · G5 py_compile · G6 21-key
-TEST_MODE run). PR #281 open; adversarial self-review clean + first reviewer
-pass resolved (Copilot doc-accuracy nit + Codex P2 retry-cache-bypass). See
-`memory-bank/living-ledger.md` (newest entry) for the full what/why/rules.
+**Deferred (dedicated PR):** the retry-idempotency gap in
+`SUPABASE_HASH_STORE_AUTHORITATIVE` clean-filename mode is **not solvable by
+attachment inspection** (clean names carry no timestamp/hash, so a freshly
+committed file is indistinguishable from a stale same-identity one). Kept the
+safe behavior-preserving baseline (benign self-healing duplicate on a rare
+retry, reconciled next run); the proper fix (upload-then-delete-by-attachment-
+age) changes the delete→upload guardrail.
+
+**Status:** MERGED. `run_6_gates.sh` exit 0 at merge (G1 178 names · G2 108
+facade · **G3 1149 pytest** +130 subtests · G4 mypy 56→56 · G5 py_compile · G6
+21-key TEST_MODE run). **All findings across 8 reviewer passes resolved**
+(4 real Codex fixes: before_send frame scrub · attribution `unavailable`≠
+`no_history` · breadcrumb message-scrub · breadcrumb data-scrub; 2 sys.path
+test bootstraps; 3 Copilot doc-accuracy nits incl. the retry.py 4000-vs-
+InternalServerError contract). 0 unresolved review threads; final Copilot
+review generated no new comments. Production guardrails UNCHANGED (change-key,
+delete→upload order, `@cell`=0, `PARALLEL_WORKERS≤8`, filename/attachment). See
+`memory-bank/living-ledger.md` (newest entries) for the full what/why/rules.
 
 ## History pointer
 **Phase 09 — engine modularization (✅ COMPLETE & MERGED, PR #280 → `889ca2e`).**

--- a/.claude/project-state.md
+++ b/.claude/project-state.md
@@ -1,6 +1,6 @@
 # Project State — Generate-Weekly-PDFs-DSR-Resiliency
 
-_Last updated: 2026-06-30 · **overwrite-in-place each session** (this is the
+_Last updated: 2026-07-06 · **overwrite-in-place each session** (this is the
 canonical "where the project stands" landing spot for the global Stop
 write-back reminder). Keep it terse; link to history rather than duplicating it._
 
@@ -77,6 +77,21 @@ InternalServerError contract). 0 unresolved review threads; final Copilot
 review generated no new comments. Production guardrails UNCHANGED (change-key,
 delete→upload order, `@cell`=0, `PARALLEL_WORKERS≤8`, filename/attachment). See
 `memory-bank/living-ledger.md` (newest entries) for the full what/why/rules.
+
+## Active work
+**🔧 WR 90968595 missing-rows bug: ROOT CAUSE CONFIRMED, fix in PR (2026-07-06).**
+Not attribution/filtering — a crash-consistency bug in the Sub-project E hash
+store: failed run 28752355941 (7/5, runner lost) upserted the new group hash
+during emission but died before the upload phase, so under authoritative clean
+filenames the skip gate deadlocks ("unchanged + attachment exists") and the 7/5
+ProMax rows never publish; regen can't recover. Fix: `orchestrate.py` defers hash
+upserts and flushes ONLY after the group's upload legs succeed (withhold on
+error/dry-run → regenerate next run). 4 regression tests; suite 1153 passed +130
+subtests. **Pending:** merge fix PR (stacked on #282) → one-time remediation
+`workflow_dispatch` `advanced_options=regen_weeks:070526` → verify the 7/5 rows in
+the regenerated file → archive debug session `wr-90968595-rows-not-pulled` +
+apply the held second-brain write-back packet. Full rule: newest
+`memory-bank/living-ledger.md` entry.
 
 ## History pointer
 **Phase 09 — engine modularization (✅ COMPLETE & MERGED, PR #280 → `889ca2e`).**

--- a/docs/AI_CONTEXT_RESUME.md
+++ b/docs/AI_CONTEXT_RESUME.md
@@ -9,7 +9,7 @@
 > Codex mirror [`/AGENTS.md`](../AGENTS.md)). This file is the *status / resume*
 > layer, not the rulebook.
 
-_Last updated: 2026-06-26._
+_Last updated: 2026-06-30._
 
 > **Live status now lives in [`.claude/project-state.md`](../.claude/project-state.md)**
 > (overwritten each session) and [`.planning/STATE.md`](../.planning/STATE.md). This
@@ -85,6 +85,18 @@ Sequencing — **A → B → C → D → E**:
 
 ## Recent work completed (most recent first)
 
+- **v1.3.1 — Smartsheet API resilience & silent-failure/PII hardening** —
+  new `pipeline/retry.py smartsheet_call_with_retry` (bounded transient retry
+  for `ApiError` code 4000 / typed `should_retry` / rate-limit / the SDK's
+  transport-drop wrappers) on the discovery + per-sheet fetch hot path; a
+  dropped source sheet is now LOUD but PII-safe (`sentry_capture_sheet_drop`)
+  instead of a silent `return None`. Also un-silenced the F1 `no_history`
+  attribution WARNING and scrubbed row PII from Sentry across all three planes
+  (event frames via `before_send`; breadcrumb `message` + `data` via
+  `before_breadcrumb`). Additive/surgical — billing behavior unchanged; 6 gates
+  green (G3 1149); PII scrubs dummy-transport-verified; all 8 reviewer passes
+  resolved. Merged as **PR #281** → commit `8c51a3c`. Deferred to its own PR:
+  retry-idempotency in `SUPABASE_HASH_STORE_AUTHORITATIVE` clean-filename mode.
 - **Subproject C** (`vac_crew` claim attribution) — implemented via
   brainstorm → spec → plan → subagent-driven TDD; final comprehensive review
   = READY TO MERGE; **PR #219** opened against `master`. Suite: 809 passed.

--- a/memory-bank/living-ledger.md
+++ b/memory-bank/living-ledger.md
@@ -4603,3 +4603,41 @@ tag + `before_send` mechanism accurately.
 breadcrumb message-scrub · breadcrumb data-scrub; 2 sys.path bootstraps; 2 Copilot doc-accuracy nits). 6 gates
 green. Breadcrumb message+data scrub dummy-transport-verified. Next: push → confirm Codex's review of this tip is
 silent → merge to `master`.
+
+---
+
+## [2026-06-30 21:49] — MERGED: v1.3.1 shipped to `master` as `8c51a3c` (closes the API-resilience / PII loop)
+
+**MERGE — v1.3.1 (Smartsheet API-resilience & silent-failure/PII hardening) is MERGED to `master` as squash
+commit `8c51a3c`** (from `fix/api-resilience-silent-failures`, branch deleted on merge; `docs-changelog.yml`
+auto-logged the merge as `666e551`). This closes the forward-looking "Next: push → … merge to `master`" clause
+that ended each of the four preceding 2026-06-30 entries (17:45 main · 19:48 sys.path · 20:10 breadcrumb plane ·
+20:40 breadcrumb `data`). The work itself is documented there and is NOT repeated here — this entry only records
+that it landed.
+
+**Reviewer loop closed — 8 automated passes, every finding resolved.** 4 real Codex functional/security fixes
+(`before_send` frame scrub · attribution `unavailable`≠`no_history` · breadcrumb `message` scrub · breadcrumb
+`data` key-scrub), 2 `sys.path` test-bootstrap fixes, and 3 Copilot doc-accuracy nits (incl. the `retry.py`
+4000-vs-`InternalServerError` contract). 0 unresolved review threads; the final Copilot pass generated no new
+comments. Codex's auto-review was exhausted after 8 passes (an explicit `@codex review` drew no response), so
+the merge gate was: 0 unresolved threads + all checks green + `MERGEABLE`/`CLEAN` + Copilot's final clean pass.
+
+**LESSON — the merge gate is a whole-PR property, not a per-tip delta.** The per-push watch loop had a blind
+spot: it only inspected findings created *after each push*, so three standing Copilot `retry.py` doc threads
+raised on earlier tips stayed invisible until a full `reviewThreads(isResolved==false && isOutdated==false)`
+audit right before merge surfaced them. "No review comments" means the whole unresolved-thread SET is empty —
+audit the set, not the delta, before merging.
+
+**Verification at merge:** `run_6_gates.sh` exit 0 — G1 178 · G2 108 · G3 1149 (+130 subtests) · G4 mypy 56→56
+· G5 py_compile · G6 21-key TEST_MODE run; all three Sentry PII scrubs dummy-transport-verified. Production
+guardrails UNCHANGED (change-detection key · delete→upload order · `@cell`=0 · `PARALLEL_WORKERS≤8` ·
+filename/attachment logic).
+
+**Deferred (own PR):** retry-idempotency in `SUPABASE_HASH_STORE_AUTHORITATIVE` clean-filename mode — not
+solvable by attachment inspection; the real fix (upload-then-delete-by-attachment-age) changes the delete→upload
+guardrail.
+
+**Position:** ✅ v1.3.1 MERGED (`8c51a3c`). Closeout follow-up PR #282 bumps `.claude/project-state.md`, this
+ledger, and `docs/AI_CONTEXT_RESUME.md` to the merged state; second brain (project page, current-state,
+dashboard, log) updated the same session. Ultimate proof still pending: the next scheduled 2h production cron
+surviving a real code-4000 blip without dropping a source sheet.

--- a/memory-bank/living-ledger.md
+++ b/memory-bank/living-ledger.md
@@ -4641,3 +4641,58 @@ guardrail.
 ledger, and `docs/AI_CONTEXT_RESUME.md` to the merged state; second brain (project page, current-state,
 dashboard, log) updated the same session. Ultimate proof still pending: the next scheduled 2h production cron
 surviving a real code-4000 blip without dropping a source sheet.
+
+## [2026-07-06 14:30] Debug session opened: WR 90968595 late-arriving ProMax rows missing from main-file Excel
+
+**Symptom (operator-reported):** WR 909-685-95's current-week Excel generates, and its 7/2 snapshot rows are
+present, but rows that arrived from ProMax on **2026-07-05** (units claimed by the foreman + department
+members, dept number and "Units Completed?" checkboxes populated) are **absent — and stay absent on forced
+regeneration**. Main foreman (primary) variant affected.
+
+**Why it matters:** missing claimed units = missing billed revenue for that WR/week; regen-resistance means an
+operator cannot self-heal it with `REGEN_WEEKS`/`RESET_HASH_HISTORY`.
+
+**Diagnostic read:** regeneration bypassing change-detection but still excluding the rows implicates **row
+filtering or claim attribution upstream of grouping**, not stale hashes. Seeded hypotheses (ranked): (1) the
+parked Phase 09 frozen-claim-attribution gap — "late backfill froze wrong foreman" (Wave 5 parked); (2) helper
+dual-checkbox exclusion (both "Helping Foreman Completed Unit?" + "Units Completed?" checked → main-file
+exclusion by design); (3) Weekly Reference Logged Date vs Snapshot Date filtering dropping the 7/5 rows from
+the week-ending group.
+
+**State:** GSD debug session `.planning/debug/wr-90968595-rows-not-pulled.md` (goal: find_and_fix,
+investigation read-only, fix gated on Juan's checkpoint + full pytest). Root cause NOT yet confirmed — do not
+change grouping/attribution code from this entry alone; wait for the session's evidence-backed resolution.
+
+## [2026-07-06 15:05] RESOLVED root cause + NEW RULE: durable group hash may only advance after upload success (WR 90968595 incident)
+
+**Root cause (confirmed):** crash-consistency bug in the Sub-project E authoritative hash store. The per-group
+content hash was upserted to `billing_audit.group_content_hash` in the EMISSION loop, but attachment uploads
+run later in the deferred batch phase. Failed run **28752355941** (2026-07-05, "hosted runner lost
+communication") died after upserting hash `561017c7` for WR 90968595 / week 2026-07-05 / primary but before
+the upload phase replaced the attachment. Under `SUPABASE_HASH_STORE_AUTHORITATIVE=1` filenames are clean
+(hash-less), so the skip gate can only verify an attachment EXISTS, not that it is current → every later run:
+computed==stored + attachment exists → **skip forever**. Regeneration cannot recover by design; the 7/5 ProMax
+rows were fetched and grouped correctly every run — the file was simply never re-published. Discriminator that
+killed all other hypotheses (fetch-gate drop, frozen attribution, week-ending math, helper dual-checkbox): the
+stored hash flipped `2ececf55→561017c7` with zero generation/upload lines in any successful run's log.
+
+**RULE (billing-critical, do not regress):** the durable group hash in `billing_audit.group_content_hash` is a
+claim that "this content is what is attached in Smartsheet." It may only be written AFTER the group's
+attachment upload succeeds — never in the emission loop. `orchestrate.py` now defers upserts to
+`_deferred_hash_upserts` and flushes after the parallel upload phase, gated per group on ALL its upload legs
+returning `'uploaded'`/`'skipped'`; `'error'`, `'skip_upload'` (SKIP_UPLOAD dry-run), and missing-task cases
+WITHHOLD the hash (WARNING logged) so the group regenerates next run. Fail-safe direction: one extra
+regenerate, never a stale file reported as current. Regression guard:
+`tests/test_subproject_e_hash_store.py::TestCrashConsistencyDeferredFlush` (4 tests; ordering assertion fails
+against pre-fix code). Bonus closure: local SKIP_UPLOAD dry-runs with prod Supabase creds can no longer poison
+change detection.
+
+**One-time remediation (after the fix merges):** `workflow_dispatch` with `advanced_options` =
+`regen_weeks:070526` — bypasses the poisoned skip gate for week 07/05/26 and force-replaces attachments,
+healing WR 90968595 and any other groups the failed run poisoned. Verify the regenerated
+`WR_90968595_WeekEnding_070526` file contains the July 5th ProMax rows. (`reset_wr_list:90968595` also works
+but purges ALL weeks' attachments for that WR — broader than needed.)
+
+**Ops lesson:** a failed Actions run ("runner lost communication") can now be loud in the ledger — any group
+it emitted-but-did-not-upload was, pre-fix, permanently stale. Post-fix the withheld-hash WARNING + next-run
+regenerate make this self-healing.

--- a/memory-bank/living-ledger.md
+++ b/memory-bank/living-ledger.md
@@ -4696,3 +4696,21 @@ but purges ALL weeks' attachments for that WR — broader than needed.)
 **Ops lesson:** a failed Actions run ("runner lost communication") can now be loud in the ledger — any group
 it emitted-but-did-not-upload was, pre-fix, permanently stale. Post-fix the withheld-hash WARNING + next-run
 regenerate make this self-healing.
+
+## [2026-07-06 20:45] Follow-up (Codex P2, PR #283): the LOCAL json hash_history obeys the same upload-success gate
+
+**Gap found in review:** the 15:05 fix deferred only the Supabase upsert. The local
+`generated_docs/hash_history.json` entry was still written in the emission loop and persisted by
+`save_hash_history` at end of run — so a withheld group (upload `'error'` or SKIP_UPLOAD dry-run) still
+advanced the json cache. The skip gate's documented decision table falls back to that json cache on a Supabase
+outage (`fetch_failure`/`unavailable`) and uses it as the sole decider when `SUPABASE_HASH_STORE_AUTHORITATIVE`
+is OFF — in either mode the stale group could be skipped as "unchanged + attachment exists," the same
+staleness one layer down.
+
+**RULE (extends the 15:05 rule):** BOTH hash layers — `billing_audit.group_content_hash` AND the local
+`hash_history` json — may only advance after ALL of the group's upload legs return `'uploaded'`/`'skipped'`.
+`orchestrate.py` collects json entries in `_deferred_history_updates` and applies them in the same
+post-upload flush, NOT gated on `SUPABASE_HASH_STORE_WRITE_ENABLED` (the json contract holds in every mode).
+TEST_MODE keeps the immediate write — no upload phase exists there and the documented intent is seeding
+future prod runs. Regression guard: the three `test_json_*` tests in
+`TestCrashConsistencyDeferredFlush` (`tests/test_subproject_e_hash_store.py`).

--- a/memory-bank/living-ledger.md
+++ b/memory-bank/living-ledger.md
@@ -4714,3 +4714,30 @@ post-upload flush, NOT gated on `SUPABASE_HASH_STORE_WRITE_ENABLED` (the json co
 TEST_MODE keeps the immediate write — no upload phase exists there and the documented intent is seeding
 future prod runs. Regression guard: the three `test_json_*` tests in
 `TestCrashConsistencyDeferredFlush` (`tests/test_subproject_e_hash_store.py`).
+
+## [2026-07-06 21:00] Review closures (PR #283): reduced_sub PPP-leg skip-gate check + repair-path hash invalidation
+
+**Gap 1 (Codex P2 + Greptile P1, pre-existing):** a `reduced_sub`/`reduced_sub_helper` group degrades to a
+single TARGET upload leg when the WR is absent from the PPP map (`_build_upload_tasks_for_group` emits one
+task), so the all-legs flush gate cannot see the never-emitted leg — the hash flushes on TARGET success, and
+once the WR later appears on the PPP sheet the skip gate ("unchanged + TARGET attachment exists") never
+publishes the PPP file until the group's content changes. **Fix (chosen over withholding, which would
+regenerate + delete/re-upload every 2h run for WRs legitimately absent from the PPP sheet):** the skip gate
+now ALSO requires the PPP attachment whenever the WR is CURRENTLY in `target_map_ppp` (uses the shared
+prefetch `attachment_cache`; per-row fallback otherwise). One regeneration converges when the WR appears; no
+churn while absent; fail-safe direction only (can force regeneration, never adds a skip).
+
+**Gap 2 (Codex P2, repair path):** withholding the new hash on upload `'error'` is insufficient when a
+forced/regen run repairs a group whose STORED hash already equals the computed one (exactly the
+`regen_weeks:070526` remediation scenario) — the stale matching hash lets the next non-forced run skip, and
+the repair never retries. **Fix:** groups withheld due to a REAL `'error'` leg now invalidate BOTH layers:
+the json entry is popped, and the durable row is overwritten with a `withheld:<hash>` sentinel via the
+existing fail-safe `upsert_group_hash` (can never equal a computed SHA256 → lookup mismatch → regenerate; the
+next successful upload overwrites it). `'skip_upload'` (SKIP_UPLOAD dry-run) does NOT invalidate — a local
+dry run must never mutate prod change-detection state in either direction.
+
+**RULE:** any future upload-outcome value must be classified into exactly one of: publish-success
+(`'uploaded'`/`'skipped'` → flush), real-failure (`'error'` → withhold + invalidate), or
+no-op (`'skip_upload'` → withhold, touch nothing). Regression guards:
+`test_skip_gate_requires_ppp_attachment_for_reduced_sub`, `test_error_legs_invalidate_both_hash_layers`
+(`tests/test_subproject_e_hash_store.py::TestCrashConsistencyDeferredFlush`).

--- a/pipeline/orchestrate.py
+++ b/pipeline/orchestrate.py
@@ -1091,6 +1091,16 @@ def main():  # pyright: ignore[reportGeneralTypeIssues]
         # exists" forever (root cause of the WR 90968595 / week 070526
         # incident, failed run 28752355941).
         _deferred_hash_upserts = []
+        # Codex P2 (PR #283): the LOCAL json hash_history entry is
+        # deferred through the SAME gate. The json cache is the
+        # documented fallback the skip gate consults on Supabase
+        # outage (fetch_failure/unavailable) and the sole decider when
+        # authoritative mode is OFF — persisting it at emission would
+        # let a failed/dry-run upload still be skipped as "unchanged"
+        # next run through that fallback, the same staleness one layer
+        # down. TEST_MODE keeps the immediate write (no upload phase
+        # exists there; see the emission-site comment).
+        _deferred_history_updates = []
 
         _phase_group_start = datetime.datetime.now()
         _time_budget_exceeded = False
@@ -1921,8 +1931,17 @@ def main():  # pyright: ignore[reportGeneralTypeIssues]
                     )
                     _upload_tasks.extend(_new_upload_tasks)
 
-                # Update hash history with variant-aware key (even in TEST_MODE so future prod runs can leverage)
-                hash_history[history_key] = {
+                # Update hash history with variant-aware key. TEST_MODE
+                # writes immediately (documented intent: "so future
+                # prod runs can leverage"; there is no upload phase to
+                # defer against). Production defers the entry through
+                # the post-upload flush gate — the json cache is the
+                # skip gate's fallback when Supabase is unreachable and
+                # its sole source when authoritative mode is OFF, so it
+                # must obey the same "hash advances only after ALL
+                # upload legs succeed" contract as the durable store
+                # (Codex P2, PR #283).
+                _history_entry = {
                     'hash': data_hash,
                     'rows': len(group_rows),
                     'updated_at': datetime.datetime.now(datetime.timezone.utc).isoformat(),
@@ -1931,7 +1950,15 @@ def main():  # pyright: ignore[reportGeneralTypeIssues]
                     'variant': variant,
                     'identifier': identifier,
                 }
-                history_updates += 1
+                if TEST_MODE:
+                    hash_history[history_key] = _history_entry
+                    history_updates += 1
+                else:
+                    _deferred_history_updates.append({
+                        'group_key': group_key,
+                        'history_key': history_key,
+                        'entry': _history_entry,
+                    })
 
                 # Sub-project E: durable per-group content hash for
                 # Supabase (billing_audit.group_content_hash). Gated on
@@ -2145,7 +2172,7 @@ def main():  # pyright: ignore[reportGeneralTypeIssues]
             # delete-then-upload next run, never a stale file reported
             # as current. upsert_group_hash is fail-safe/no-op when
             # Supabase is unavailable and never raises past the guard.
-            if (
+            if _deferred_history_updates or (
                 SUPABASE_HASH_STORE_WRITE_ENABLED
                 and _deferred_hash_upserts
             ):
@@ -2156,32 +2183,55 @@ def main():  # pyright: ignore[reportGeneralTypeIssues]
                     _group_upload_ok[_gk] = (
                         _group_upload_ok.get(_gk, True) and _ok
                     )
-                _hashes_flushed = 0
-                _hashes_withheld = 0
-                for _rec in _deferred_hash_upserts:
+                # Local json cache first (Codex P2, PR #283): it is the
+                # fallback layer the skip gate consults on Supabase
+                # outage and the sole decider with authoritative OFF,
+                # so it must never advance for a withheld group. Note
+                # this flush is NOT gated on the Supabase write flag —
+                # the json contract holds in every mode.
+                _json_withheld = 0
+                for _rec in _deferred_history_updates:
                     if not _group_upload_ok.get(_rec['group_key']):
-                        _hashes_withheld += 1
+                        _json_withheld += 1
                         continue
-                    try:
-                        _billing_audit_writer.upsert_group_hash(
-                            _rec['wr_num'], _rec['week_iso'],
-                            _rec['variant'], _rec['identifier'],
-                            _rec['data_hash'],
-                        )
-                        _hashes_flushed += 1
-                    except Exception:
-                        logging.exception(
-                            "E hash write failed (non-fatal)")
-                if _hashes_withheld:
+                    hash_history[_rec['history_key']] = _rec['entry']
+                    history_updates += 1
+                if _json_withheld:
                     logging.warning(
-                        f"⚠️ Durable hash withheld for {_hashes_withheld} "
-                        f"group(s) whose upload did not complete — they "
-                        f"will regenerate next run"
+                        f"⚠️ Local hash-history entry withheld for "
+                        f"{_json_withheld} group(s) whose upload did "
+                        f"not complete — they will regenerate next run"
                     )
-                logging.info(
-                    f"🧾 Durable hash store: {_hashes_flushed} flushed, "
-                    f"{_hashes_withheld} withheld"
-                )
+                if (
+                    SUPABASE_HASH_STORE_WRITE_ENABLED
+                    and _deferred_hash_upserts
+                ):
+                    _hashes_flushed = 0
+                    _hashes_withheld = 0
+                    for _rec in _deferred_hash_upserts:
+                        if not _group_upload_ok.get(_rec['group_key']):
+                            _hashes_withheld += 1
+                            continue
+                        try:
+                            _billing_audit_writer.upsert_group_hash(
+                                _rec['wr_num'], _rec['week_iso'],
+                                _rec['variant'], _rec['identifier'],
+                                _rec['data_hash'],
+                            )
+                            _hashes_flushed += 1
+                        except Exception:
+                            logging.exception(
+                                "E hash write failed (non-fatal)")
+                    if _hashes_withheld:
+                        logging.warning(
+                            f"⚠️ Durable hash withheld for {_hashes_withheld} "
+                            f"group(s) whose upload did not complete — they "
+                            f"will regenerate next run"
+                        )
+                    logging.info(
+                        f"🧾 Durable hash store: {_hashes_flushed} flushed, "
+                        f"{_hashes_withheld} withheld"
+                    )
 
         # Validation summary
         summaries = validate_group_totals(groups)

--- a/pipeline/orchestrate.py
+++ b/pipeline/orchestrate.py
@@ -1829,6 +1829,47 @@ def main():  # pyright: ignore[reportGeneralTypeIssues]
                                 )
                                 if not has_attachment:
                                     can_skip = False
+                            # Codex P2 / Greptile P1 (PR #283):
+                            # reduced_sub groups fan out to a second
+                            # upload leg on the subcontractor PPP
+                            # sheet. When the WR was absent from the
+                            # PPP map at upload time, that leg was
+                            # never attempted — so "unchanged +
+                            # TARGET attachment exists" is not
+                            # sufficient to skip once the WR appears
+                            # on the PPP sheet. Require the PPP
+                            # attachment too whenever the WR is
+                            # CURRENTLY in the PPP map; a WR (still)
+                            # absent from the map adds no requirement,
+                            # so legitimately single-leg groups do not
+                            # churn. Fail-safe direction only: this
+                            # can force a regeneration (which uploads
+                            # both legs and converges), never add a
+                            # skip.
+                            if (
+                                can_skip
+                                and variant in (
+                                    'reduced_sub', 'reduced_sub_helper',
+                                )
+                                and target_map_ppp
+                            ):
+                                _ppp_skip_row = target_map_ppp.get(
+                                    str(wr_num)
+                                )
+                                if (
+                                    _ppp_skip_row is not None
+                                    and not _has_existing_week_attachment(
+                                        client,
+                                        SUBCONTRACTOR_PPP_SHEET_ID,
+                                        _ppp_skip_row,
+                                        str(wr_num), week_raw, variant,
+                                        file_identifier,
+                                        cached_attachments=attachment_cache.get(
+                                            _ppp_skip_row.id
+                                        ),
+                                    )
+                                ):
+                                    can_skip = False
                         if can_skip:
                             logging.info(f"⏩ Skip (unchanged + attachment exists) {variant} WR {wr_num} week {week_raw} hash {data_hash}")
                             _groups_skipped += 1
@@ -2177,12 +2218,31 @@ def main():  # pyright: ignore[reportGeneralTypeIssues]
                 and _deferred_hash_upserts
             ):
                 _group_upload_ok: dict = {}
+                _group_had_error: dict = {}
                 for _task, _res in zip(_upload_tasks, upload_results):
                     _gk = _task.get('group_key')
                     _ok = _res in ('uploaded', 'skipped')
                     _group_upload_ok[_gk] = (
                         _group_upload_ok.get(_gk, True) and _ok
                     )
+                    if _res == 'error':
+                        _group_had_error[_gk] = True
+                # Codex P2 (PR #283, repair-path): withholding the NEW
+                # hash is not enough when a forced/regen run was
+                # repairing a group whose STORED hash already equals
+                # the computed one (exactly the incident-remediation
+                # scenario) — if the re-upload then fails, the stale
+                # stored hash would let the next non-forced run skip
+                # the group and the repair would never retry. For
+                # groups withheld due to a REAL upload 'error' we
+                # therefore actively invalidate both layers: pop the
+                # json entry, and overwrite the durable row with a
+                # 'withheld:'-prefixed sentinel that can never equal a
+                # computed SHA256 (lookup mismatches -> regenerate;
+                # the next successful upload overwrites it).
+                # 'skip_upload' (SKIP_UPLOAD dry-run) does NOT
+                # invalidate — a local dry run must never mutate prod
+                # change-detection state in either direction.
                 # Local json cache first (Codex P2, PR #283): it is the
                 # fallback layer the skip gate consults on Supabase
                 # outage and the sole decider with authoritative OFF,
@@ -2193,6 +2253,11 @@ def main():  # pyright: ignore[reportGeneralTypeIssues]
                 for _rec in _deferred_history_updates:
                     if not _group_upload_ok.get(_rec['group_key']):
                         _json_withheld += 1
+                        if _group_had_error.get(_rec['group_key']):
+                            if hash_history.pop(
+                                _rec['history_key'], None,
+                            ) is not None:
+                                history_updates += 1
                         continue
                     hash_history[_rec['history_key']] = _rec['entry']
                     history_updates += 1
@@ -2211,6 +2276,18 @@ def main():  # pyright: ignore[reportGeneralTypeIssues]
                     for _rec in _deferred_hash_upserts:
                         if not _group_upload_ok.get(_rec['group_key']):
                             _hashes_withheld += 1
+                            if _group_had_error.get(_rec['group_key']):
+                                try:
+                                    _billing_audit_writer.upsert_group_hash(
+                                        _rec['wr_num'], _rec['week_iso'],
+                                        _rec['variant'],
+                                        _rec['identifier'],
+                                        'withheld:' + _rec['data_hash'],
+                                    )
+                                except Exception:
+                                    logging.exception(
+                                        "E hash invalidation failed "
+                                        "(non-fatal)")
                             continue
                         try:
                             _billing_audit_writer.upsert_group_hash(

--- a/pipeline/orchestrate.py
+++ b/pipeline/orchestrate.py
@@ -1080,6 +1080,17 @@ def main():  # pyright: ignore[reportGeneralTypeIssues]
         _groups_errored = 0
         _api_calls_count = 0
         _upload_tasks = []  # Collect upload tasks for parallel processing
+        # Sub-project E crash-consistency (2026-07-06): per-group durable
+        # hash upserts are DEFERRED until after this group's attachment
+        # upload actually succeeds. Records are appended in the emission
+        # loop and flushed after the parallel upload phase. Writing the
+        # hash before the upload executes lets a mid-run crash (e.g. a
+        # lost runner) mark content as published while Smartsheet still
+        # holds the stale attachment — with clean (hash-less) filenames
+        # the skip gate then deadlocks on "unchanged + attachment
+        # exists" forever (root cause of the WR 90968595 / week 070526
+        # incident, failed run 28752355941).
+        _deferred_hash_upserts = []
 
         _phase_group_start = datetime.datetime.now()
         _time_budget_exceeded = False
@@ -1922,39 +1933,38 @@ def main():  # pyright: ignore[reportGeneralTypeIssues]
                 }
                 history_updates += 1
 
-                # Sub-project E: shadow-write the durable per-group content
-                # hash to Supabase alongside the local json cache. Gated on
-                # SUPABASE_HASH_STORE_WRITE_ENABLED (default ON) — harmless
-                # while the store is not yet authoritative: it just populates
-                # billing_audit.group_content_hash so the eventual
-                # authoritative flip has data to read. ``upsert_group_hash``
-                # is fail-safe (returns a no-op when Supabase is unavailable /
-                # TEST_MODE and never raises); the extra guard keeps a future
-                # regression from breaking the generation path. ``week_iso``
-                # is the ISO DATE the column expects (NOT the MMDDYY
-                # week_raw), kept consistent with lookup_group_hash in the
-                # skip gate above.
+                # Sub-project E: durable per-group content hash for
+                # Supabase (billing_audit.group_content_hash). Gated on
+                # SUPABASE_HASH_STORE_WRITE_ENABLED (default ON).
+                # CRASH-CONSISTENCY (2026-07-06): the upsert is NOT
+                # executed here — the record is deferred and flushed
+                # after the parallel upload phase, and ONLY for groups
+                # whose attachment upload succeeded. The store's contract
+                # is "hash of the content currently attached in
+                # Smartsheet"; writing it before the upload executes
+                # breaks that contract on any mid-run crash and (in
+                # authoritative clean-filename mode) permanently deadlocks
+                # the skip gate for the affected group. ``week_iso`` is
+                # the ISO DATE the column expects (NOT the MMDDYY
+                # week_raw), kept consistent with lookup_group_hash in
+                # the skip gate above; it is guarded truthy because
+                # week_ending is a DATE column and an empty string would
+                # be a PostgREST type error that could trip the per-op
+                # circuit breaker.
                 if (
                     SUPABASE_HASH_STORE_WRITE_ENABLED
                     and BILLING_AUDIT_AVAILABLE
                     and not TEST_MODE
                     and week_iso
                 ):
-                    # ``week_iso`` is guarded truthy: week_ending is a DATE
-                    # column, so an empty string (missing __week_ending_date)
-                    # would be a PostgREST type error that could trip the
-                    # per-op circuit breaker. Skipping the shadow write for
-                    # such an edge-case group is harmless — the json cache
-                    # and (until authoritative) the filename hash still drive
-                    # change detection.
-                    try:
-                        _billing_audit_writer.upsert_group_hash(
-                            wr_num, week_iso, variant,
-                            identifier or '', data_hash,
-                        )
-                    except Exception:
-                        logging.exception(
-                            "E shadow hash write failed (non-fatal)")
+                    _deferred_hash_upserts.append({
+                        'group_key': group_key,
+                        'wr_num': wr_num,
+                        'week_iso': week_iso,
+                        'variant': variant,
+                        'identifier': identifier or '',
+                        'data_hash': data_hash,
+                    })
                 
             except Exception as e:
                 _groups_errored += 1
@@ -2115,6 +2125,63 @@ def main():  # pyright: ignore[reportGeneralTypeIssues]
 
             _upload_elapsed = (datetime.datetime.now() - _upload_start).total_seconds()
             logging.info(f"⚡ Upload phase complete: {_groups_uploaded} uploaded, {_upload_errors} errors in {_upload_elapsed:.1f}s (parallel w/{PARALLEL_WORKERS} workers)")
+
+            # Sub-project E crash-consistency flush (2026-07-06): persist
+            # the durable group hash ONLY for groups whose attachment
+            # upload actually completed in THIS run. Outcome semantics:
+            #   'uploaded'    -> attachment replaced, hash is now true
+            #   'skipped'     -> delete helper verified the existing
+            #                    attachment already matches this hash
+            #   'skip_upload' -> SKIP_UPLOAD dry-run: nothing published,
+            #                    hash MUST NOT advance (a dry run with
+            #                    prod Supabase creds would otherwise
+            #                    poison change detection exactly like a
+            #                    mid-run crash)
+            #   'error'       -> upload failed: withhold the hash so the
+            #                    next run regenerates and re-uploads
+            # A reduced_sub fan-out group produces TWO tasks; the hash
+            # advances only when EVERY leg succeeded. Withholding on
+            # failure fails safe: worst case is one extra regenerate +
+            # delete-then-upload next run, never a stale file reported
+            # as current. upsert_group_hash is fail-safe/no-op when
+            # Supabase is unavailable and never raises past the guard.
+            if (
+                SUPABASE_HASH_STORE_WRITE_ENABLED
+                and _deferred_hash_upserts
+            ):
+                _group_upload_ok: dict = {}
+                for _task, _res in zip(_upload_tasks, upload_results):
+                    _gk = _task.get('group_key')
+                    _ok = _res in ('uploaded', 'skipped')
+                    _group_upload_ok[_gk] = (
+                        _group_upload_ok.get(_gk, True) and _ok
+                    )
+                _hashes_flushed = 0
+                _hashes_withheld = 0
+                for _rec in _deferred_hash_upserts:
+                    if not _group_upload_ok.get(_rec['group_key']):
+                        _hashes_withheld += 1
+                        continue
+                    try:
+                        _billing_audit_writer.upsert_group_hash(
+                            _rec['wr_num'], _rec['week_iso'],
+                            _rec['variant'], _rec['identifier'],
+                            _rec['data_hash'],
+                        )
+                        _hashes_flushed += 1
+                    except Exception:
+                        logging.exception(
+                            "E hash write failed (non-fatal)")
+                if _hashes_withheld:
+                    logging.warning(
+                        f"⚠️ Durable hash withheld for {_hashes_withheld} "
+                        f"group(s) whose upload did not complete — they "
+                        f"will regenerate next run"
+                    )
+                logging.info(
+                    f"🧾 Durable hash store: {_hashes_flushed} flushed, "
+                    f"{_hashes_withheld} withheld"
+                )
 
         # Validation summary
         summaries = validate_group_totals(groups)

--- a/tests/test_subproject_e_hash_store.py
+++ b/tests/test_subproject_e_hash_store.py
@@ -777,5 +777,60 @@ class TestBillingAuditImportFailureBindsWriterNone(unittest.TestCase):
         )
 
 
+class TestCrashConsistencyDeferredFlush(unittest.TestCase):
+    """2026-07-06 WR 90968595 / week 070526 incident regression guard.
+
+    The durable group hash (billing_audit.group_content_hash) must be
+    persisted ONLY after the group's attachment upload succeeds. Run
+    28752355941 (runner lost mid-run) upserted the new hash during the
+    emission loop, died before the deferred upload phase executed, and
+    left the store claiming the new content was published while
+    Smartsheet kept the stale attachment — with authoritative clean
+    (hash-less) filenames the skip gate then deadlocked on
+    "unchanged + attachment exists" on every subsequent run.
+    """
+
+    def setUp(self):
+        import pipeline.orchestrate
+        self.src = inspect.getsource(pipeline.orchestrate)
+
+    def test_emission_loop_defers_instead_of_upserting(self):
+        # The generation path appends a deferred record (still gated on
+        # the write flag); the inline upsert must not come back.
+        self.assertRegex(
+            self.src,
+            r"SUPABASE_HASH_STORE_WRITE_ENABLED[\s\S]{0,1200}"
+            r"_deferred_hash_upserts\.append\(",
+        )
+
+    def test_upsert_not_called_before_upload_phase(self):
+        # No writer upsert call may exist before the parallel upload
+        # phase begins — a crash in that window must never be able to
+        # advance the durable store.
+        _pre_upload = self.src[: self.src.index("PARALLEL UPLOAD PHASE")]
+        self.assertNotIn(
+            "_billing_audit_writer.upsert_group_hash(", _pre_upload
+        )
+
+    def test_flush_consults_upload_results(self):
+        # The only upsert call site must live after upload_results is
+        # produced by the executor.
+        _post_results = self.src[
+            self.src.index("upload_results = list("):
+        ]
+        self.assertIn(
+            "_billing_audit_writer.upsert_group_hash(", _post_results
+        )
+
+    def test_skip_upload_dry_run_withholds_hash(self):
+        # 'skip_upload' (SKIP_UPLOAD dry-run) and 'error' must NOT count
+        # as publish success — only a replaced attachment ('uploaded')
+        # or a verified-current one ('skipped') may advance the store.
+        self.assertRegex(
+            self.src,
+            r"_res in \('uploaded', 'skipped'\)",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_subproject_e_hash_store.py
+++ b/tests/test_subproject_e_hash_store.py
@@ -875,8 +875,57 @@ class TestCrashConsistencyDeferredFlush(unittest.TestCase):
         self.assertRegex(
             _post_results,
             r"if not _group_upload_ok\.get\(_rec\['group_key'\]\):"
-            r"[\s\S]{0,200}"
+            r"[\s\S]{0,400}"
             r"hash_history\[_rec\['history_key'\]\] = _rec\['entry'\]",
+        )
+
+    # ── Codex P2 / Greptile P1 (PR #283): missing PPP upload leg ─────
+    # A reduced_sub group degrades to a single TARGET task when the WR
+    # is absent from the PPP map, so the all-legs flush gate cannot see
+    # the never-emitted leg. The skip gate therefore must ALSO require
+    # the PPP attachment whenever the WR is currently in the PPP map —
+    # one regeneration then converges when the WR appears there, with
+    # no churn while it is legitimately absent.
+
+    def test_skip_gate_requires_ppp_attachment_for_reduced_sub(self):
+        _pre_upload = self.src[: self.src.index("PARALLEL UPLOAD PHASE")]
+        self.assertRegex(
+            _pre_upload,
+            r"can_skip\s*\n\s*and variant in \(\s*\n\s*"
+            r"'reduced_sub', 'reduced_sub_helper',"
+            r"[\s\S]{0,300}target_map_ppp\.get\("
+            r"[\s\S]{0,600}SUBCONTRACTOR_PPP_SHEET_ID"
+            r"[\s\S]{0,600}can_skip = False",
+        )
+
+    # ── Codex P2 (PR #283): repair-path stale-hash invalidation ──────
+    # When a forced/regen run repairs a group whose stored hash already
+    # equals the computed one and the upload then FAILS, withholding
+    # the new write leaves the stale matching hash in place — the next
+    # non-forced run would skip the group and the repair never retries.
+    # Groups withheld due to a real 'error' leg must invalidate BOTH
+    # layers; SKIP_UPLOAD dry-runs must not mutate anything.
+
+    def test_error_legs_invalidate_both_hash_layers(self):
+        _post_results = self.src[
+            self.src.index("upload_results = list("):
+        ]
+        # _group_had_error is derived from 'error' results ONLY —
+        # 'skip_upload' dry-runs never invalidate.
+        self.assertRegex(
+            _post_results,
+            r"if _res == 'error':\s*\n\s*_group_had_error\[_gk\] = True",
+        )
+        # json layer: withheld-with-error pops the stale entry.
+        self.assertRegex(
+            _post_results,
+            r"if _group_had_error\.get\(_rec\['group_key'\]\):"
+            r"[\s\S]{0,200}hash_history\.pop\(",
+        )
+        # durable layer: withheld-with-error overwrites the row with a
+        # sentinel that can never equal a computed SHA256.
+        self.assertIn(
+            "'withheld:' + _rec['data_hash']", _post_results,
         )
 
 

--- a/tests/test_subproject_e_hash_store.py
+++ b/tests/test_subproject_e_hash_store.py
@@ -831,6 +831,54 @@ class TestCrashConsistencyDeferredFlush(unittest.TestCase):
             r"_res in \('uploaded', 'skipped'\)",
         )
 
+    # ── Codex P2 follow-up (PR #283): local json parity ──────────────
+    # The json hash_history cache is the skip gate's fallback on a
+    # Supabase outage and its sole source with authoritative OFF, so
+    # it must obey the SAME "advance only after upload success"
+    # contract as the durable store — otherwise a failed/dry-run
+    # upload is still skippable as "unchanged" through the fallback.
+
+    def test_json_hash_history_deferred_in_production(self):
+        # The emission loop may write hash_history immediately ONLY on
+        # the TEST_MODE branch (no upload phase exists there); the
+        # production branch must defer the entry instead.
+        _pre_upload = self.src[: self.src.index("PARALLEL UPLOAD PHASE")]
+        self.assertRegex(
+            _pre_upload,
+            r"if TEST_MODE:\s*\n\s*"
+            r"hash_history\[history_key\] = _history_entry",
+        )
+        self.assertIn(
+            "_deferred_history_updates.append(", _pre_upload,
+        )
+        # No unconditional emission-time write may come back.
+        self.assertNotRegex(
+            _pre_upload,
+            r"hash_history\[history_key\] = \{",
+        )
+
+    def test_json_flush_not_gated_on_supabase_flag(self):
+        # The json flush must run in EVERY mode — including
+        # SUPABASE_HASH_STORE_WRITE_ENABLED=false — because the json
+        # contract is independent of the durable store.
+        self.assertRegex(
+            self.src,
+            r"if _deferred_history_updates or \(",
+        )
+
+    def test_json_flush_consults_upload_results(self):
+        # The deferred json entries are applied only after
+        # upload_results exists, gated per group on _group_upload_ok.
+        _post_results = self.src[
+            self.src.index("upload_results = list("):
+        ]
+        self.assertRegex(
+            _post_results,
+            r"if not _group_upload_ok\.get\(_rec\['group_key'\]\):"
+            r"[\s\S]{0,200}"
+            r"hash_history\[_rec\['history_key'\]\] = _rec\['entry'\]",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Objective

Fix the WR 90968595 / week-ending 07/05/26 missing-rows incident: rows that arrived from ProMax on 7/5 were never published to the weekly Excel, and forced regeneration could not recover them. Root cause is a crash-consistency bug in the Sub-project E authoritative Supabase hash store — the per-group content hash was written during the emission loop, before the deferred upload phase. Failed run 28752355941 (2026-07-05, "hosted runner lost communication") upserted the new hash and died before uploading, so under `SUPABASE_HASH_STORE_AUTHORITATIVE=1` (clean, hash-less filenames) the skip gate deadlocked on "unchanged + attachment exists" on every subsequent run.

## Changes Made

- `pipeline/orchestrate.py` — hash upserts are collected in `_deferred_hash_upserts` during emission and flushed **after** the parallel upload phase, gated per group on ALL upload legs returning `'uploaded'`/`'skipped'`. `'error'`, `'skip_upload'` (SKIP_UPLOAD dry-run), and missing-task cases withhold the hash with a WARNING so the group regenerates next run.
- `pipeline/orchestrate.py` (Codex review follow-up, 79f0348) — the **local json `hash_history` entry is deferred through the same gate** (`_deferred_history_updates`, applied in the post-upload flush). The json cache is the skip gate's fallback on a Supabase outage and its sole source with authoritative mode OFF, so it must obey the same "advance only after upload success" contract. The json flush is not gated on `SUPABASE_HASH_STORE_WRITE_ENABLED`; TEST_MODE keeps the immediate write (no upload phase exists there).
- `pipeline/orchestrate.py` (Codex P2 + Greptile P1 follow-up, c6c021a) — **reduced_sub PPP-leg skip-gate check**: the "unchanged" skip now also requires the PPP-sheet attachment whenever the WR is currently in `target_map_ppp`, closing the pre-existing gap where a group whose PPP leg was never emitted (WR absent from the PPP map at upload time) would skip forever once the WR later appeared there. Converges with one regeneration; no churn while the WR is legitimately absent.
- `pipeline/orchestrate.py` (Codex P2 follow-up, c6c021a) — **repair-path invalidation**: groups withheld due to a real upload `'error'` now invalidate both hash layers (json entry popped; durable row overwritten with a `withheld:<hash>` sentinel that can never match a computed SHA256), so a failed forced-regen repair is retried on the next run instead of being skipped by the still-matching stale hash. `SKIP_UPLOAD` dry-runs touch nothing in either direction.
- `tests/test_subproject_e_hash_store.py` — `TestCrashConsistencyDeferredFlush` regression class (9 tests: 4 Supabase deferral, 3 json parity, 1 PPP skip-gate, 1 error invalidation); the "no upsert before the upload phase" assertion fails against pre-fix code.
- `memory-bank/living-ledger.md` — incident root cause, the new billing-critical rules (both hash layers advance only after upload success; upload-outcome classification), and the one-time remediation procedure.
- `.claude/project-state.md` — active-work status updated.

## Production Safety Check

Existing production logic remains unbroken. Generation, grouping, filtering, and the upload worker are untouched — the durable-hash timing moved, and the skip gate gained one strictly fail-safe requirement (it can force a regeneration, never add a skip). A group whose upload fails now regenerates next run (previously it could go permanently stale — that was the bug). Local `SKIP_UPLOAD` dry-runs can no longer poison change detection in either hash layer, and also never invalidate prod state. Guardrails intact: change-detection key, helper dual-checkbox exclusion, delete-then-upload ordering, `PARALLEL_WORKERS≤8`, no `@cell`. Validation: `pytest tests/` → **1158 passed, 130 subtests**; `py_compile` clean.

## Post-merge remediation (one-time, operator action)

The poisoned store row is not self-healing. After merge, trigger `workflow_dispatch` on `weekly-excel-generation.yml` with `advanced_options` = `regen_weeks:070526`, then verify the regenerated `WR_90968595_WeekEnding_070526` attachment contains the July 5th ProMax rows.

> **Note:** stacked on #282 (`chore/mark-281-merged`) — merge #282 first and this PR reduces to the fix commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes when group hashes are saved after Excel uploads. The main changes are:

- Deferred Supabase group-hash upserts until the upload phase succeeds.
- Deferred local `hash_history` JSON updates through the same upload-success gate.
- Added upload-error invalidation so failed repair runs regenerate on the next run.
- Tightened reduced-sub skip checks to require the PPP attachment when the WR is present on the PPP sheet.
- Added tests and incident documentation for the WR 90968595 missing-rows case.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with low risk.

The changed code is localized to upload bookkeeping and hash persistence timing. The prior missing PPP-leg concern is addressed by the new PPP attachment check in the skip gate. No blocking correctness or security issues were found.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Executed the focused crash-consistency regression test for the hash deferral feature and observed 9 tests passing in 0.37s.
- Validated Python compilation for the hash-deferral feature and confirmed the compile step exited with code 0.
- Ran the broader hash-store pytest suite and observed 67 tests passing in 0.54s.

<a href="https://app.greptile.com/trex/runs/13455056/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pipeline/orchestrate.py | Defers local JSON and Supabase group-hash writes until post-upload success, adds error invalidation, and tightens reduced-sub PPP skip verification. |
| tests/test_subproject_e_hash_store.py | Adds tests for deferred hash flushing, JSON parity, PPP skip-gate behavior, and upload-error invalidation. |
| memory-bank/living-ledger.md | Documents the incident root cause, deferred-hash rule for both hash layers, remediation steps, and review follow-up closures. |
| .claude/project-state.md | Updates current project status to reflect merged v1.3.1 work and active WR 90968595 remediation/fix status. |
| docs/AI_CONTEXT_RESUME.md | Adds recent v1.3.1 API resilience and PII hardening context to the resume documentation. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
  participant G as Group emission loop
  participant U as Upload task queue
  participant S as Smartsheet upload phase
  participant H as Local hash_history JSON
  participant D as Supabase group_content_hash

  G->>G: Compute group data_hash
  G->>U: Enqueue upload task(s)
  G->>H: Defer history entry
  G->>D: Defer durable hash upsert
  U->>S: Execute upload legs in parallel
  S-->>U: uploaded / skipped / skip_upload / error
  alt all legs uploaded or skipped
      U->>H: Persist deferred history entry
      U->>D: Upsert computed group hash
  else at least one real error
      U->>H: Withhold and pop stale history entry
      U->>D: "Write withheld:<hash> sentinel"
  else dry-run skip_upload or missing task
      U->>H: Withhold without mutation
      U->>D: Withhold without mutation
  end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
  participant G as Group emission loop
  participant U as Upload task queue
  participant S as Smartsheet upload phase
  participant H as Local hash_history JSON
  participant D as Supabase group_content_hash

  G->>G: Compute group data_hash
  G->>U: Enqueue upload task(s)
  G->>H: Defer history entry
  G->>D: Defer durable hash upsert
  U->>S: Execute upload legs in parallel
  S-->>U: uploaded / skipped / skip_upload / error
  alt all legs uploaded or skipped
      U->>H: Persist deferred history entry
      U->>D: Upsert computed group hash
  else at least one real error
      U->>H: Withhold and pop stale history entry
      U->>D: "Write withheld:<hash> sentinel"
  else dry-run skip_upload or missing task
      U->>H: Withhold without mutation
      U->>D: Withhold without mutation
  end
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: PPP-leg skip-gate check + error-pat..."](https://github.com/jflo21/generate-weekly-pdfs-dsr-resiliency/commit/c6c021aac3a2ac2dcf243a8760a403753c60f8a6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42182569)</sub>

<!-- /greptile_comment -->