### PR TITLE
fix: retry Smartsheet 5xx + widen cron margin

### DIFF
--- a/.claude/project-state.md
+++ b/.claude/project-state.md
@@ -4,6 +4,30 @@ _Last updated: 2026-07-06 · **overwrite-in-place each session** (this is the
 canonical "where the project stands" landing spot for the global Stop
 write-back reminder). Keep it terse; link to history rather than duplicating it._
 
+## Latest work (2026-07-09) — Sentry fixes SHIPPED to PR
+**GSD quick task `260709-oa7` COMPLETE** on branch
+`fix/sentry-503-retry-cron-margin` (cut from `origin/master` @ `c563b90`; the
+parked `fix/hash-store-crash-consistency` branch is untouched). Two Sentry
+issues root-caused and fixed TDD-first (red proven before green):
+1. **GENERATE-WEEKLY-EXCEL-89** (`1791246`) — HTTP 503 on `get_sheet` arrives
+   as generic `ApiError` code 0 / `status_code` 503 (`shouldRetry:false` is an
+   unparseable-body artifact), which `pipeline/retry.py` classified as
+   permanent (only result code 4000 retried) → source sheet dropped with 0
+   rows. Fix: new `_RETRYABLE_HTTP_STATUS = {500, 502, 503, 504}` +
+   `_http_status_code()` extractor; permanent codes/4xx still fail fast;
+   bounded-sleep contract unchanged. 5 new tests, 17/17 in
+   `tests/test_smartsheet_retry.py`.
+2. **GENERATE-WEEKLY-EXCEL-6V** (`7469204`) — cron monitor `checkin_margin: 5`
+   vs observed GH Actions cron start delays of 25–57 min (24/25 recent runs
+   succeeded) → 78 false "missed check-in" events/14d. Fix: margin 5 → 60 in
+   `pipeline/observability.py::_build_cron_monitor_config` (+ test flip).
+Full suite on this host: 1163 passed / 1 failed —
+`test_startup_banner_printed_once`, **verified pre-existing on pristine
+`origin/master`** (Windows cp1252 subprocess decode of the emoji banner;
+green in Ubuntu CI). Commit bodies carry `Fixes GENERATE-WEEKLY-EXCEL-89/-6V`
+so Sentry auto-resolves on merge. Next: merge PR, then confirm the next
+scheduled run fetches all sheets and the missed-check-in noise stops.
+
 ## Current milestone
 **v1.3.1 — Smartsheet API resilience & silent-failure hardening** (follow-up to
 Phase 09, **✅ COMPLETE & MERGED, PR #281 → `8c51a3c`** on 2026-07-01 UTC).

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -37,7 +37,7 @@ Status: 09-06 (Wave 6: orchestrate + thin facade) complete — PHASE 09 COMPLETE
   change; all 7 waves independently 6-gate-verified. Next: /gsd-verify-work 09,
   then PR / milestone close. (Phase 08 SDK 4.0.0 migration still outstanding — same
   file, so it could not run concurrently; now unblocked.)
-Last activity: 2026-06-26
+Last activity: 2026-07-09 - Completed quick task 260709-oa7: Sentry 5xx ApiError retry gap + cron checkin_margin fixes
 
 ### Infrastructure Topology (discovered 2026-06-01 via Supabase MCP) — READ BEFORE PHASE 05
 
@@ -203,6 +203,7 @@ See PROJECT.md `<decisions>` table for the full 30+ entry log.
 
 | # | Description | Date | Commit | Directory |
 |---|-------------|------|--------|-----------|
+| 260709-oa7 | Fix Sentry 503 ApiError retry gap (GENERATE-WEEKLY-EXCEL-89) and cron checkin_margin 5→60 (GENERATE-WEEKLY-EXCEL-6V) | 2026-07-09 | 1791246, 7469204 | [260709-oa7](./quick/260709-oa7-fix-sentry-503-apierror-retry-gap-and-cr/) |
 | 260528-lu6 | Reconcile AGENTS.md into a lean pointer mirroring CLAUDE.md | 2026-05-28 | d30be0e | [260528-lu6](./quick/260528-lu6-reconcile-agents-md-into-a-lean-pointer-/) |
 | 260528-mdc | Add warn-only ruff + mypy lint tooling and isolated CI workflow | 2026-05-28 | 7f8dbfb | [260528-mdc](./quick/260528-mdc-add-warn-only-ruff-and-mypy-lint-tooling/) |
 | 260601-iqq | Fix stale Living Ledger test file paths blocking pre-push gate (repoint to memory-bank/living-ledger.md; update E authoritative-flag test to active '1') | 2026-06-01 | eed82a1 | [260601-iqq-fix-stale-living-ledger-test-file-paths-](./quick/260601-iqq-fix-stale-living-ledger-test-file-paths-/) |

--- a/.planning/quick/260709-oa7-fix-sentry-503-apierror-retry-gap-and-cr/260709-oa7-PLAN.md
+++ b/.planning/quick/260709-oa7-fix-sentry-503-apierror-retry-gap-and-cr/260709-oa7-PLAN.md
@@ -1,0 +1,234 @@
+---
+phase: quick-260709-oa7
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - pipeline/retry.py
+  - tests/test_smartsheet_retry.py
+  - pipeline/observability.py
+  - tests/test_cron_monitor_config.py
+autonomous: true
+requirements:
+  - GENERATE-WEEKLY-EXCEL-89
+  - GENERATE-WEEKLY-EXCEL-6V
+
+must_haves:
+  truths:
+    - "A Smartsheet get_sheet returning HTTP 503 (generic ApiError, result code 0, status_code 503) is retried and can succeed on a later attempt instead of dropping the source sheet with 0 rows"
+    - "HTTP 500/502/504 wrapped as generic ApiError are retried the same way as 503"
+    - "A permanent ApiError (e.g. code 1006 not-found, status 404) still raises immediately on attempt 1 with no backoff — fail-fast preserved"
+    - "A 5xx ApiError that never recovers re-raises after exhausting max_attempts"
+    - "The Sentry cron monitor checkin_margin is 60 minutes (was 5), absorbing GitHub Actions' observed 25-57 min scheduling delay so no more false missed-check-in alerts"
+    - "The retry helper's bounded-sleep contract (max_total_sleep) and non-transient fail-fast behavior are unchanged"
+  artifacts:
+    - path: "pipeline/retry.py"
+      provides: "_RETRYABLE_HTTP_STATUS frozenset + _http_status_code extractor + widened ApiError branch"
+      contains: "_RETRYABLE_HTTP_STATUS"
+    - path: "tests/test_smartsheet_retry.py"
+      provides: "Failing-first tests for 5xx-status retry and 4xx fail-fast"
+      contains: "status_code"
+    - path: "pipeline/observability.py"
+      provides: "_build_cron_monitor_config with checkin_margin 60"
+      contains: "checkin_margin"
+    - path: "tests/test_cron_monitor_config.py"
+      provides: "Assertion updated to checkin_margin == 60"
+      contains: "checkin_margin"
+  key_links:
+    - from: "pipeline/retry.py except ss_exc.ApiError branch"
+      to: "_RETRYABLE_HTTP_STATUS"
+      via: "status = _http_status_code(exc); raise only if code not retryable AND status not retryable"
+      pattern: "_RETRYABLE_HTTP_STATUS"
+    - from: "generate_weekly_pdfs._build_cron_monitor_config"
+      to: "pipeline/observability.py _build_cron_monitor_config"
+      via: "facade re-export; source of checkin_margin value"
+      pattern: "checkin_margin.*60"
+---
+
+<objective>
+Fix two diagnosed production Sentry issues in the Python billing pipeline. Diagnosis is
+COMPLETE and locked — this plan is implementation only, no re-investigation.
+
+1. **GENERATE-WEEKLY-EXCEL-89 (billing-drop bug):** Smartsheet HTTP 5xx responses are
+   wrapped by the SDK as a generic `ApiError` with `result.code == 0` and
+   `result.status_code == 5xx`. `smartsheet_call_with_retry()` currently retries generic
+   `ApiError` only when the RESULT CODE is in `_RETRYABLE_API_CODES` ({4000}), so a 503
+   raised on attempt 1 with zero backoff dropped source sheet "Resiliency Promax Database
+   Backup 59" with 0 rows (missing billing). Widen the branch to ALSO retry when the HTTP
+   status code is a transient 5xx.
+
+2. **GENERATE-WEEKLY-EXCEL-6V (monitoring noise):** The Sentry cron monitor
+   `checkin_margin` is 5 minutes, but GitHub Actions starts these scheduled runs 25-57 min
+   late (jobs succeed), producing 78 false "missed check-in" events / 14 days. Raise the
+   margin to 60.
+
+Purpose: Stop silent billing-row loss on transient Smartsheet 5xx, and silence false cron
+alerts, without altering any grouping/hashing/filename/attachment logic or the retry
+helper's bounded-sleep / fail-fast contract.
+Output: Surgical, additive edits to `pipeline/retry.py` and `pipeline/observability.py`,
+each committed atomically with tests-first, referencing its Sentry issue for auto-resolve.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/STATE.md
+@CLAUDE.md
+
+<interfaces>
+<!-- Contracts the executor needs — extracted from the codebase. Use directly; no exploration. -->
+
+pipeline/retry.py (fix target 1) — existing shape the fix extends:
+- `_RETRYABLE_API_CODES: frozenset[int] = frozenset({4000})`  (line 88)
+- `_api_error_code(exc) -> int | None` — best-effort `return exc.error.result.code`,
+  `except AttributeError: return None`  (lines 114-124)
+- The failing branch to widen (lines 166-174):
+    except ss_exc.ApiError as exc:
+        code = _api_error_code(exc)
+        if code not in _RETRYABLE_API_CODES:
+            raise
+        last_exc = exc ; backoff = float(2 ** (attempt - 1)) + 0.5 ; kind = f"ApiError {code}"
+- DO NOT touch: `max_total_sleep` ceiling logic (lines 187-204), the `_TRANSIENT_EXC`
+  tuple, RateLimit branch, `is_transient_network_error`, or the exhaustion re-raise.
+
+tests/test_smartsheet_retry.py — existing fake-ApiError builder (lines 43-51):
+    def _api_error(code, message="api error"):
+        err = mock.Mock(); err.result.code = code
+        return ss_exc.ApiError(err, message)
+  New tests need a variant that ALSO sets `err.result.status_code = <int>`.
+  Assertion patterns already in file: `func.call_count`, `slept.call_count`,
+  `[c.args[0] for c in slept.call_args_list]`, `pytest.raises(ss_exc.ApiError)`,
+  `func.assert_called_once()`.
+
+pipeline/observability.py (fix target 2) — `_build_cron_monitor_config()` returns a dict
+with `"checkin_margin": 5` (line 708). Re-exported through
+`generate_weekly_pdfs._build_cron_monitor_config` (that facade is what the test imports).
+
+tests/test_cron_monitor_config.py — `test_runtime_and_threshold_fields` asserts
+`cfg["checkin_margin"] == 5` (line 53). Other assertions (max_runtime 180, thresholds,
+timezone UTC, schedule) must remain unchanged.
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Retry Smartsheet HTTP 5xx wrapped as generic ApiError (GENERATE-WEEKLY-EXCEL-89)</name>
+  <files>pipeline/retry.py, tests/test_smartsheet_retry.py</files>
+  <behavior>
+    Write these tests FIRST in tests/test_smartsheet_retry.py and confirm they FAIL (RED)
+    before editing pipeline/retry.py. Add a helper that builds an ApiError with BOTH
+    result.code AND result.status_code set (extend the existing `_api_error` pattern; set
+    status_code explicitly to an int — do not rely on the auto-Mock attribute).
+    - Test A: ApiError with code 0 + status_code 503 → retries and succeeds on attempt 2
+      (func called twice, one backoff sleep).
+    - Test B: same behavior parametrized over status_code in {500, 502, 504}.
+    - Test C: ApiError with a non-retryable code AND a 4xx status (code 1006, status 404)
+      → raises ss_exc.ApiError immediately, func called exactly once, no sleep. (Fail-fast
+      preserved for permanent errors.)
+    - Test D: ApiError code 0 + status_code 503 raised on every call → after max_attempts
+      re-raises ss_exc.ApiError with func.call_count == max_attempts.
+    Leave every existing test in the file passing unchanged (the 4000 code-path tests, the
+    permanent-1006 test, the max_total_sleep cap test, etc.).
+  </behavior>
+  <action>
+    In pipeline/retry.py, make the minimal additive change to retry transient HTTP 5xx that
+    the SDK surfaces as a generic ApiError (result code 0, status_code 5xx), per the locked
+    diagnosis for GENERATE-WEEKLY-EXCEL-89:
+    1. Add a new module constant next to `_RETRYABLE_API_CODES`:
+       `_RETRYABLE_HTTP_STATUS: frozenset[int] = frozenset({500, 502, 504, 503})` (values
+       are 500/502/503/504 — transient server-side statuses). Add a short comment noting
+       these are the 5xx statuses the SDK cannot parse into a result code, so it wraps them
+       as code-0 ApiError and never retries them — the real billing-drop gap.
+    2. Add a helper `_http_status_code(exc) -> int | None` mirroring `_api_error_code`:
+       best-effort `return exc.error.result.status_code`, `except AttributeError: return None`.
+       Docstring: ErrorResult carries a `status_code` property; None when absent → treated
+       as non-retryable.
+    3. In the `except ss_exc.ApiError` branch, after computing `code`, also compute
+       `status = _http_status_code(exc)`, and change the guard so it re-raises ONLY when the
+       error is neither a retryable code NOR a retryable HTTP status:
+       raise only if `code not in _RETRYABLE_API_CODES and status not in _RETRYABLE_HTTP_STATUS`.
+       When retrying, keep the existing backoff `float(2 ** (attempt - 1)) + 0.5`; set the
+       `kind` log tag to include both code and status (e.g. `f"ApiError code={code} http={status}"`)
+       so retry log lines identify a 5xx. Do NOT change any other branch, the max_total_sleep
+       ceiling, or the exhaustion re-raise.
+    4. Update the module docstring "Design contract" section to record the new rule: transient
+       HTTP 5xx (500/502/503/504) wrapped as a generic code-0 ApiError are now retried via
+       `_RETRYABLE_HTTP_STATUS`; permanent codes (1006/1002) and 4xx statuses still fail fast
+       on attempt 1. Reference GENERATE-WEEKLY-EXCEL-89 as the driving incident.
+    Note: `is_transient_network_error`, `_TRANSIENT_EXC`, the RateLimit long-backoff schedule,
+    and `max_total_sleep` are OFF LIMITS — additive change only.
+  </action>
+  <verify>
+    <automated>python -m py_compile pipeline/retry.py && python -m pytest tests/test_smartsheet_retry.py -v</automated>
+  </verify>
+  <done>New 5xx-status tests (A-D) pass, ALL pre-existing retry tests still pass, py_compile
+  clean. A code-0 status-503 ApiError retries; a code-1006 status-404 ApiError raises on
+  attempt 1 with a single call.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Raise Sentry cron checkin_margin 5 to 60 (GENERATE-WEEKLY-EXCEL-6V)</name>
+  <files>pipeline/observability.py, tests/test_cron_monitor_config.py</files>
+  <action>
+    Two-line config fix per the locked diagnosis for GENERATE-WEEKLY-EXCEL-6V (config value
+    change, not business logic):
+    1. In tests/test_cron_monitor_config.py, update the assertion in
+       `test_runtime_and_threshold_fields` from `assert cfg["checkin_margin"] == 5` to
+       `== 60`. Leave the other assertions in that test (max_runtime == 180, the two
+       thresholds) and every other test (timezone UTC, schedule match) unchanged. Running
+       the test now should FAIL (RED) because the source still returns 5.
+    2. In pipeline/observability.py `_build_cron_monitor_config()`, change
+       `"checkin_margin": 5,` to `"checkin_margin": 60,` and add an inline comment recording
+       the evidence: GitHub Actions starts these scheduled runs 25-57 min late (observed in
+       gh run history) though the jobs succeed; a 5-min margin fired 78 false missed-check-in
+       events / 14 days. 60 min absorbs the observed delay while staying well under the 2h
+       run interval, so a true no-show still alerts. Reference GENERATE-WEEKLY-EXCEL-6V.
+    Do NOT change `max_runtime`, the thresholds, `timezone`, `_CRON_MONITOR_SCHEDULE`, or any
+    surrounding function — surgical, single-value edit.
+  </action>
+  <verify>
+    <automated>python -m py_compile pipeline/observability.py generate_weekly_pdfs.py && python -m pytest tests/test_cron_monitor_config.py -v</automated>
+  </verify>
+  <done>`_build_cron_monitor_config()["checkin_margin"] == 60`; the updated assertion and all
+  other cron-config tests pass; py_compile clean for both modules.</done>
+</task>
+
+</tasks>
+
+<verification>
+Full-suite gate before push (repo policy — pytest must pass before push):
+
+```
+python -m py_compile generate_weekly_pdfs.py
+python -m pytest tests/ -v
+```
+
+Then two atomic Conventional-Commits commits (subject ≤ 50 chars), one per fix, on branch
+`fix/sentry-503-retry-cron-margin`:
+- Task 1 → subject e.g. `fix: retry Smartsheet HTTP 5xx ApiError`; body includes
+  `Fixes GENERATE-WEEKLY-EXCEL-89` (Sentry auto-resolves on merge).
+- Task 2 → subject e.g. `fix: widen cron checkin_margin to 60m`; body includes
+  `Fixes GENERATE-WEEKLY-EXCEL-6V`.
+Do not push directly to master; do not raise PARALLEL_WORKERS; do not touch
+grouping/hashing/filename/attachment code.
+</verification>
+
+<success_criteria>
+- Transient Smartsheet 5xx (code-0 ApiError with status_code in {500,502,503,504}) is
+  retried instead of dropping a source sheet with 0 rows.
+- Permanent errors (code 1006 / 4xx status) still fail fast on attempt 1 (fail-fast and
+  max_total_sleep contract intact).
+- Sentry cron `checkin_margin` is 60, ending the false missed-check-in alerts while a true
+  no-show inside the 2h interval still alerts.
+- `pytest tests/ -v` fully green; both modules py_compile clean.
+- Two atomic commits, each referencing its Sentry issue ID for auto-resolve.
+</success_criteria>
+
+<output>
+Create `.planning/quick/260709-oa7-fix-sentry-503-apierror-retry-gap-and-cr/260709-oa7-SUMMARY.md` when done.
+</output>

--- a/.planning/quick/260709-oa7-fix-sentry-503-apierror-retry-gap-and-cr/260709-oa7-SUMMARY.md
+++ b/.planning/quick/260709-oa7-fix-sentry-503-apierror-retry-gap-and-cr/260709-oa7-SUMMARY.md
@@ -1,0 +1,95 @@
+---
+phase: quick-260709-oa7
+plan: 01
+subsystem: infra
+tags: [smartsheet, retry, sentry, cron, observability, resiliency]
+
+requires: []
+provides:
+  - "smartsheet_call_with_retry() retries transient HTTP 5xx wrapped as a generic code-0 ApiError"
+  - "Sentry cron monitor checkin_margin raised from 5 to 60 minutes"
+affects: [pipeline-discovery, pipeline-fetch, sentry-cron-monitoring]
+
+tech-stack:
+  added: []
+  patterns:
+    - "ApiError retry guard widened to check BOTH result.code (_RETRYABLE_API_CODES) and result.status_code (_RETRYABLE_HTTP_STATUS) before fail-fast"
+
+key-files:
+  created: []
+  modified:
+    - pipeline/retry.py
+    - tests/test_smartsheet_retry.py
+    - pipeline/observability.py
+    - tests/test_cron_monitor_config.py
+
+key-decisions:
+  - "Retryable HTTP statuses fixed at {500, 502, 503, 504} per locked diagnosis — no new env var, additive frozenset constant mirroring _RETRYABLE_API_CODES"
+  - "checkin_margin raised to 60 (not a smaller value) to absorb the full observed 25-57 min GitHub Actions scheduling delay while staying under the 2h run interval"
+
+requirements-completed: [GENERATE-WEEKLY-EXCEL-89, GENERATE-WEEKLY-EXCEL-6V]
+
+duration: 12min
+completed: 2026-07-09
+---
+
+# Quick Task 260709-oa7: Sentry 503 Retry Gap + Cron Margin Summary
+
+**Widened `smartsheet_call_with_retry()`'s generic-ApiError branch to also retry transient HTTP 5xx (500/502/503/504) wrapped as a code-0 ApiError, and raised the Sentry cron `checkin_margin` from 5 to 60 minutes to match GitHub Actions' observed scheduling delay.**
+
+## Performance
+
+- **Duration:** ~12 min
+- **Tasks:** 2 completed
+- **Files modified:** 4
+
+## Accomplishments
+- `pipeline/retry.py`: added `_RETRYABLE_HTTP_STATUS` frozenset `{500, 502, 503, 504}` and `_http_status_code()` extractor; the `except ss_exc.ApiError` branch now re-raises only when the error is neither a retryable result code NOR a retryable HTTP status — fixing the gap that dropped source sheet "Resiliency Promax Database Backup 59" with 0 rows on a transient 503.
+- `pipeline/observability.py`: `_build_cron_monitor_config()["checkin_margin"]` raised 5 → 60, ending the 78 false missed-check-in Sentry events / 14 days caused by GitHub Actions' 25-57 min scheduling jitter.
+- Fail-fast preserved: a permanent code (1006) with a 4xx status (404) still raises on attempt 1 with zero backoff and zero sleep; `max_total_sleep` ceiling and exhaustion re-raise untouched.
+
+## Task Commits
+
+Each task was committed atomically, TDD RED confirmed before each GREEN implementation:
+
+1. **Task 1: Retry Smartsheet HTTP 5xx wrapped as generic ApiError (GENERATE-WEEKLY-EXCEL-89)** - `1791246` (fix)
+2. **Task 2: Raise Sentry cron checkin_margin 5 to 60 (GENERATE-WEEKLY-EXCEL-6V)** - `7469204` (fix)
+
+_No separate `test:`/`feat:` split commits — each task's test additions and source fix were committed together per the plan's TDD instruction (write RED, confirm failure, then implement GREEN, then commit once as a single `fix:` per task)._
+
+## Files Created/Modified
+- `pipeline/retry.py` - `_RETRYABLE_HTTP_STATUS` constant, `_http_status_code()` extractor, widened `ApiError` guard, updated design-contract docstring
+- `tests/test_smartsheet_retry.py` - `_api_error_with_status()` helper + 5 new tests (503 retry, 500/502/504 parametrized retry, permanent-code+4xx fail-fast, exhaustion re-raise)
+- `pipeline/observability.py` - `checkin_margin: 5` → `60` with inline evidence comment
+- `tests/test_cron_monitor_config.py` - `test_runtime_and_threshold_fields` assertion updated to `checkin_margin == 60`
+
+## Decisions Made
+- Kept the retryable-status set exactly as specified in the plan (`{500, 502, 503, 504}`) — no attempt to widen further (e.g. 429 is already handled by the separate `RateLimitExceededError` branch with its own long backoff schedule, so it was correctly left out).
+- Log `kind` tag changed from `f"ApiError {code}"` to `f"ApiError code={code} http={status}"` so retry log lines identify a 5xx distinctly from a 4000 code retry — purely additive to the log string, no behavior change.
+
+## Deviations from Plan
+
+None - plan executed exactly as written. Both tasks followed the RED→GREEN TDD sequence specified: new tests were added and confirmed failing before the source change, then the minimal additive fix was made and tests re-run green.
+
+## Issues Encountered
+
+**Full-suite gate — one pre-existing, out-of-scope failure (not fixed, per file-scope restriction):**
+`tests/test_entrypoint_no_double_import.py::TestEntrypointNoDoubleImport::test_startup_banner_printed_once` fails with `TypeError: unsupported operand type(s) for +: 'NoneType' and 'NoneType'` when run on this Windows host. Root cause: the test spawns `generate_weekly_pdfs.py` as a subprocess and captures output in text mode; a `subprocess.py` reader thread hits `UnicodeDecodeError: 'charmap' codec can't decode byte ...` because the parent's `subprocess.run(text=True)` decodes the child's UTF-8 emoji-banner bytes using the Windows cp1252 locale default (the test's `PYTHONIOENCODING=utf-8` only affects the child's own stdout encoding, not the parent's decode). This is a documented pre-existing Windows-only console-encoding quirk (`memory-bank/living-ledger.md` "Oracle carry-forward" note, line ~4062, already flags `PYTHONUTF8` forcing for the same cp1252-vs-emoji-banner class of issue) — unrelated to `pipeline/retry.py`, `pipeline/observability.py`, or either targeted test file, and outside this plan's explicit file-scope restriction (`pipeline/retry.py`, `pipeline/observability.py`, `tests/test_smartsheet_retry.py`, `tests/test_cron_monitor_config.py`). Not auto-fixed per the deviation-rules scope boundary. `tests/test_smartsheet_retry.py` (17/17) and `tests/test_cron_monitor_config.py` (5/5) — the two targeted files — are fully green; the broader suite is 1163 passed / 1 pre-existing environmental failure.
+
+## User Setup Required
+
+None - no external service configuration required. Both fixes are pure code changes; no new env vars, no dashboard steps.
+
+## Next Phase Readiness
+- Both Sentry issues (GENERATE-WEEKLY-EXCEL-89, GENERATE-WEEKLY-EXCEL-6V) have a corresponding `Fixes` reference in their commit body for auto-resolve on merge to `master`.
+- Recommend a maintainer separately investigate the pre-existing `test_entrypoint_no_double_import.py` Windows cp1252/UTF-8 subprocess-decode failure (unrelated to this task) — likely fix is `errors="replace"` or explicit `encoding="utf-8"` on `subprocess.run()` in that test, but that is out of scope here.
+
+---
+*Phase: quick-260709-oa7*
+*Completed: 2026-07-09*
+
+## Self-Check: PASSED
+
+All 5 claimed artifacts found on disk (`pipeline/retry.py`, `tests/test_smartsheet_retry.py`,
+`pipeline/observability.py`, `tests/test_cron_monitor_config.py`, this SUMMARY.md) and both
+commit hashes (`1791246`, `7469204`) verified present in `git log`.

--- a/memory-bank/living-ledger.md
+++ b/memory-bank/living-ledger.md
@@ -4741,3 +4741,50 @@ dry run must never mutate prod change-detection state in either direction.
 no-op (`'skip_upload'` → withhold, touch nothing). Regression guards:
 `test_skip_gate_requires_ppp_attachment_for_reduced_sub`, `test_error_legs_invalidate_both_hash_layers`
 (`tests/test_subproject_e_hash_store.py::TestCrashConsistencyDeferredFlush`).
+
+## [2026-07-09 17:35] Sentry triage: 5xx ApiError retry gap + cron check-in margin (in progress, quick task 260709-oa7)
+
+Root-caused the two open production Sentry issues against the codebase (branch
+`fix/sentry-503-retry-cron-margin`, cut from `origin/master`):
+
+1. **GENERATE-WEEKLY-EXCEL-89 (billing-drop bug).** The Smartsheet SDK wraps an
+   HTTP 5xx with an unparseable error body as a **generic `ApiError` with
+   `error.result.code == 0`, `should_retry: false`, and the real HTTP status in
+   `error.result.status_code`** (verified against installed SDK: `ErrorResult`
+   has a `status_code` property). `pipeline/retry.py` classified generic
+   `ApiError` as transient only for result code 4000, so a 503 on `get_sheet`
+   raised on attempt 1 with zero backoff and the source sheet ("Resiliency
+   Promax Database Backup 59", 2026-07-06) dropped with 0 rows. **Rule: 5xx
+   HTTP statuses on `ApiError` (500/502/503/504) are transient regardless of
+   result code — retry them; the SDK's `shouldRetry:false` on code-0 errors is
+   an artifact of the unparseable body, not a real retry verdict.** Fix: new
+   `_RETRYABLE_HTTP_STATUS` set + status-code extraction in
+   `smartsheet_call_with_retry`, TDD in `tests/test_smartsheet_retry.py`.
+2. **GENERATE-WEEKLY-EXCEL-6V (monitoring noise, 78 events/14d).** GitHub
+   Actions starts the scheduled billing runs **25–57 minutes late** (measured
+   from `gh run list`, 25 recent runs, 24 succeeded), but the Sentry Crons
+   monitor upserted from `_build_cron_monitor_config()` had
+   `checkin_margin: 5` — so nearly every *successful* run still fired a
+   "missed check-in" outage. **Rule: for GH-Actions-scheduled monitors the
+   check-in margin must absorb worst-case cron queue delay (observed ≤ ~60
+   min) while staying under the run interval (2 h) so true no-shows still
+   alert.** Fix: margin 5 → 60. (The monitor's earlier perpetual-miss incident
+   was the timezone mislabel — see the existing `_CRON_MONITOR_SCHEDULE`
+   comment; this is the second, delay-margin failure mode of the same issue.)
+
+Commits will carry `Fixes GENERATE-WEEKLY-EXCEL-89` / `Fixes
+GENERATE-WEEKLY-EXCEL-6V` so Sentry auto-resolves on merge. Entry to be
+finalized with commit hashes + full-suite result when the executor completes.
+
+## [2026-07-09 18:05] Quick task 260709-oa7 SHIPPED — closes the 5xx retry gap + cron margin
+
+Finalizing the 17:35 entry: commits `1791246` (retry HTTP 5xx ApiError, Fixes
+GENERATE-WEEKLY-EXCEL-89) and `7469204` (checkin_margin 5→60, Fixes
+GENERATE-WEEKLY-EXCEL-6V) on branch `fix/sentry-503-retry-cron-margin`.
+Validation: targeted suites 17/17 + 5/5; full suite 1163 passed / 1 failed —
+`test_entrypoint_no_double_import.py::test_startup_banner_printed_once`
+**reproduced identically on pristine origin/master in a temp worktree**
+(UnicodeDecodeError, Windows cp1252 decoding the UTF-8 emoji startup banner
+from a subprocess pipe; Ubuntu CI unaffected). Known-footgun note: that test
+harness should eventually pass `encoding='utf-8'` to its subprocess reader —
+separate test-infra fix, do not band-aid production code for it.

--- a/pipeline/observability.py
+++ b/pipeline/observability.py
@@ -705,7 +705,11 @@ def _build_cron_monitor_config() -> "MonitorConfig":
     return {
         "schedule": {"type": "crontab", "value": _CRON_MONITOR_SCHEDULE},
         "timezone": "UTC",
-        "checkin_margin": 5,
+        # 60 min absorbs GitHub Actions' observed 25-57 min scheduling delay
+        # for this job (jobs still succeed) while staying well under the 2h
+        # run interval, so a true no-show still alerts. A 5-min margin fired
+        # 78 false missed-check-in events / 14 days. GENERATE-WEEKLY-EXCEL-6V.
+        "checkin_margin": 60,
         "max_runtime": 180,
         "failure_issue_threshold": 1,
         "recovery_threshold": 1,

--- a/pipeline/retry.py
+++ b/pipeline/retry.py
@@ -17,6 +17,14 @@ Design contract
       ``should_retry`` typed exception to 4000, so it never retries it. This
       is the real gap-filler on the oversized-response discovery / per-sheet
       fetch path.
+    - generic ``ApiError`` with ``error.result.code == 0`` and a transient
+      HTTP status (500/502/503/504) — matched via ``_RETRYABLE_HTTP_STATUS``.
+      The SDK cannot parse a 5xx response body into a meaningful result
+      code, so it wraps it as a code-0 ``ApiError`` it never retries either.
+      This gap dropped source sheet "Resiliency Promax Database Backup 59"
+      with 0 rows on a transient 503 (GENERATE-WEEKLY-EXCEL-89). Permanent
+      codes (1006 not-found, 1002 auth) and 4xx statuses still fail fast on
+      attempt 1.
     - ``InternalServerError`` — a raw HTTP 500, retried transitively as an
       ``HttpError`` subclass via ``_TRANSIENT_EXC`` (it carries no
       ``should_retry`` flag). This is a DISTINCT failure from API code 4000;
@@ -87,6 +95,14 @@ _TRANSIENT_EXC: tuple[type[BaseException], ...] = (
 # once — retrying it would only burn the time budget.
 _RETRYABLE_API_CODES: frozenset[int] = frozenset({4000})
 
+# Transient HTTP 5xx statuses that the Smartsheet SDK cannot parse into a
+# meaningful ``error.result.code`` — it surfaces them as a generic ApiError
+# with code 0 and never retries them itself. This was the real billing-drop
+# gap: a 503 on the discovery / per-sheet fetch path raised on attempt 1
+# with zero backoff, dropping the whole source sheet's rows
+# (GENERATE-WEEKLY-EXCEL-89). 500/502/504 are wrapped the same way.
+_RETRYABLE_HTTP_STATUS: frozenset[int] = frozenset({500, 502, 503, 504})
+
 # Fallback only: class-name substring match for a RAW requests/urllib3/ssl
 # error that somehow escapes the SDK's wrapping (normally these arrive as the
 # types in _TRANSIENT_EXC above). Defense in depth; mirrors the inline list
@@ -120,6 +136,21 @@ def _api_error_code(exc: BaseException) -> int | None:
     """
     try:
         return exc.error.result.code  # type: ignore[attr-defined]
+    except AttributeError:
+        return None
+
+
+def _http_status_code(exc: BaseException) -> int | None:
+    """Best-effort extraction of a Smartsheet ``ApiError`` HTTP status code.
+
+    The SDK's ``ErrorResult`` carries a ``status_code`` property alongside
+    ``code`` — populated when the response was a raw HTTP error (e.g. 503)
+    the SDK could not parse into a meaningful ``code``. Returns the integer
+    status or None when absent, in which case it is treated as
+    non-retryable.
+    """
+    try:
+        return exc.error.result.status_code  # type: ignore[attr-defined]
     except AttributeError:
         return None
 
@@ -164,14 +195,20 @@ def smartsheet_call_with_retry(
             backoff = float(2 ** (attempt - 1)) + 0.5  # 1.5, 2.5, 4.5, ...
             kind = type(exc).__name__
         except ss_exc.ApiError as exc:
-            # Generic API error: retry ONLY the transient codes (4000); any
-            # other code is permanent and must surface immediately.
+            # Generic API error: retry the transient codes (4000) OR a
+            # transient HTTP 5xx the SDK wrapped as a code-0 ApiError
+            # (GENERATE-WEEKLY-EXCEL-89); any other code/status combo is
+            # permanent and must surface immediately.
             code = _api_error_code(exc)
-            if code not in _RETRYABLE_API_CODES:
+            status = _http_status_code(exc)
+            if (
+                code not in _RETRYABLE_API_CODES
+                and status not in _RETRYABLE_HTTP_STATUS
+            ):
                 raise
             last_exc = exc
             backoff = float(2 ** (attempt - 1)) + 0.5
-            kind = f"ApiError {code}"
+            kind = f"ApiError code={code} http={status}"
         except Exception as exc:  # noqa: BLE001 — narrowed by the guard below.
             if not is_transient_network_error(exc):
                 raise  # Non-transient (e.g. a real bug) — surface immediately.

--- a/tests/test_cron_monitor_config.py
+++ b/tests/test_cron_monitor_config.py
@@ -49,7 +49,7 @@ class TestBuildCronMonitorConfig:
     def test_runtime_and_threshold_fields(self):
         cfg = gwp._build_cron_monitor_config()
         assert cfg["max_runtime"] == 180
-        assert cfg["checkin_margin"] == 5
+        assert cfg["checkin_margin"] == 60
         assert cfg["failure_issue_threshold"] == 1
         assert cfg["recovery_threshold"] == 1
 

--- a/tests/test_smartsheet_retry.py
+++ b/tests/test_smartsheet_retry.py
@@ -51,6 +51,24 @@ def _api_error(code: int, message: str = "api error") -> ss_exc.ApiError:
     return ss_exc.ApiError(err, message)
 
 
+def _api_error_with_status(
+    code: int, status_code: int, message: str = "api error"
+) -> ss_exc.ApiError:
+    """Build a generic ``ApiError`` with BOTH ``result.code`` and
+    ``result.status_code`` set explicitly.
+
+    Mirrors the real SDK shape for an HTTP 5xx it cannot parse into a
+    meaningful result code: ``error.result.code == 0`` and
+    ``error.result.status_code`` carrying the real HTTP status (e.g. 503).
+    ``status_code`` is set explicitly to an int rather than relying on the
+    auto-Mock attribute (which would compare unequal to any real int).
+    """
+    err = mock.Mock()
+    err.result.code = code
+    err.result.status_code = status_code
+    return ss_exc.ApiError(err, message)
+
+
 def _rate_limit_error() -> ss_exc.RateLimitExceededError:
     # RateLimitExceededError(error, message) — should_retry=True in the SDK.
     return ss_exc.RateLimitExceededError(None, "rate limit exceeded")
@@ -108,6 +126,51 @@ def test_retries_typed_server_timeout_then_succeeds():
 
 def test_raises_after_exhausting_attempts_on_4000():
     func = mock.Mock(side_effect=_api_error(4000))
+    with mock.patch("pipeline.retry.time.sleep"):
+        with pytest.raises(ss_exc.ApiError):
+            smartsheet_call_with_retry(func, max_attempts=4)
+    assert func.call_count == 4  # all attempts used
+
+
+# --- GENERATE-WEEKLY-EXCEL-89: HTTP 5xx wrapped as a generic code-0 ApiError ---
+# The SDK cannot parse a 5xx body into a meaningful result code, so it wraps
+# it as ApiError with result.code == 0 and result.status_code == 5xx. Prior
+# to the fix these dropped a whole source sheet on attempt 1 with zero
+# backoff (the "Resiliency Promax Database Backup 59" 0-row billing gap).
+
+
+def test_retries_api_error_status_503_then_succeeds():
+    func = mock.Mock(side_effect=[_api_error_with_status(0, 503), "ok"])
+    with mock.patch("pipeline.retry.time.sleep") as slept:
+        result = smartsheet_call_with_retry(func, max_attempts=4)
+    assert result == "ok"
+    assert func.call_count == 2
+    assert slept.call_count == 1
+
+
+@pytest.mark.parametrize("status_code", [500, 502, 504])
+def test_retries_api_error_5xx_status_then_succeeds(status_code):
+    func = mock.Mock(side_effect=[_api_error_with_status(0, status_code), "ok"])
+    with mock.patch("pipeline.retry.time.sleep") as slept:
+        result = smartsheet_call_with_retry(func, max_attempts=4)
+    assert result == "ok"
+    assert func.call_count == 2
+    slept.assert_called_once()
+
+
+def test_permanent_code_and_4xx_status_raises_immediately():
+    # Fail-fast preserved: a permanent code (1006 not-found) with a 4xx
+    # status must still raise on attempt 1 with no backoff.
+    func = mock.Mock(side_effect=_api_error_with_status(1006, 404, "not found"))
+    with mock.patch("pipeline.retry.time.sleep") as slept:
+        with pytest.raises(ss_exc.ApiError):
+            smartsheet_call_with_retry(func, max_attempts=4)
+    func.assert_called_once()
+    slept.assert_not_called()
+
+
+def test_raises_after_exhausting_attempts_on_status_503():
+    func = mock.Mock(side_effect=_api_error_with_status(0, 503))
     with mock.patch("pipeline.retry.time.sleep"):
         with pytest.raises(ss_exc.ApiError):
             smartsheet_call_with_retry(func, max_attempts=4)


### PR DESCRIPTION
## Objective

Fix the two open production Sentry issues on the weekly billing pipeline:

- **GENERATE-WEEKLY-EXCEL-89** — an HTTP 503 from Smartsheet on `get_sheet` is wrapped by the SDK as a generic `ApiError` with `result.code == 0`, `should_retry: false`, and the real status in `result.status_code`. `smartsheet_call_with_retry()` only treated result code 4000 as transient, so the 503 raised on attempt 1 with zero backoff and source sheet "Resiliency Promax Database Backup 59" dropped with **0 rows** (missing billing) on 2026-07-06.
- **GENERATE-WEEKLY-EXCEL-6V** — the Sentry Crons monitor uses `checkin_margin: 5`, but GitHub Actions starts the scheduled runs **25–57 minutes late** (measured across the last 25 runs; 24 succeeded). Nearly every *successful* run still fired a "missed check-in" outage — 78 false events in 14 days.

Commit bodies carry `Fixes GENERATE-WEEKLY-EXCEL-89` / `Fixes GENERATE-WEEKLY-EXCEL-6V` so Sentry auto-resolves both issues on merge.

## Changes Made

- `pipeline/retry.py` — new `_RETRYABLE_HTTP_STATUS = frozenset({500, 502, 503, 504})` and `_http_status_code()` extractor (mirrors `_api_error_code`, `AttributeError → None`). The generic-`ApiError` branch now retries when **either** the result code (4000) **or** the HTTP status is transient. Design-contract docstring updated.
- `tests/test_smartsheet_retry.py` — `_api_error_with_status()` helper + 5 new tests (red-first): 503 retry-then-succeed, parametrized 500/502/504, permanent code 1006/status 404 fail-fast single-call, 5xx exhaustion re-raise. 17/17 green.
- `pipeline/observability.py` — `_build_cron_monitor_config()` `checkin_margin` 5 → 60 with evidence comment (margin absorbs observed GH Actions delay while staying under the 2 h run interval, so a true no-show still alerts).
- `tests/test_cron_monitor_config.py` — margin assertion 5 → 60. 5/5 green.
- `.planning/` + ledger docs — GSD quick-task artifacts (plan, summary, state/ledger entries).

## Production Safety Check

Existing production logic is unbroken:

- **Fail-fast preserved**: permanent `ApiError` codes (1006 not-found, 1002 auth) and 4xx statuses still raise immediately on attempt 1 with zero sleep (regression-tested).
- **Bounded-sleep contract untouched**: `max_total_sleep` / exhaustion re-raise behavior unchanged; no change to `PARALLEL_WORKERS`, grouping, hashing, filenames, or attachment logic.
- **Cron margin is config-only**: the monitor config is upserted on the next check-in; `failure_issue_threshold: 1` still alerts immediately once the 60-min margin truly lapses.
- **Validation**: `python -m py_compile generate_weekly_pdfs.py` clean; full suite 1163 passed / 1 failed — `test_startup_banner_printed_once`, reproduced identically on pristine `origin/master` in a temp worktree (Windows-host cp1252 subprocess decode of the emoji banner; unrelated, green in Ubuntu CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ng8Gn8k1WzwKqVdjRboEPY

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates Smartsheet retry behavior and Sentry cron monitoring for the weekly billing pipeline. The main changes are:

- Retries generic Smartsheet `ApiError` responses when they carry transient HTTP `500`, `502`, `503`, or `504` statuses.
- Preserves fail-fast behavior for permanent Smartsheet codes and `4xx` HTTP statuses.
- Raises the Sentry cron `checkin_margin` from 5 to 60 minutes.
- Adds targeted tests for retry, exhaustion, fail-fast, and cron monitor configuration behavior.
- Updates planning and ledger documentation for the Sentry incidents.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

The changes are surgical, additive, and covered by focused tests for the changed retry and cron-monitor paths. No runtime, data, or security issues were identified in the changed code.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The changed-file py\_compile command was executed and logged to verify the updated file compiled successfully.
- The focused retry cron pytest command was run and logged to verify the retry path tests, including its working directory, test results, and exit status.
- The Pytest run reported 22 passed in 0.41s, confirming the PR's retry handling and Sentry cron monitor config tests completed successfully.

<a href="https://app.greptile.com/trex/runs/13911446/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pipeline/retry.py | Adds retry classification for generic Smartsheet `ApiError` responses carrying transient HTTP 5xx status codes; no issues found. |
| tests/test_smartsheet_retry.py | Adds tests for 5xx status retry, 4xx fail-fast behavior, and exhaustion semantics; no issues found. |
| pipeline/observability.py | Raises the Sentry cron monitor check-in margin from 5 to 60 minutes while preserving schedule, runtime, and thresholds; no issues found. |
| tests/test_cron_monitor_config.py | Updates the cron monitor configuration assertion to expect the widened 60-minute check-in margin; no issues found. |
| .planning/quick/260709-oa7-fix-sentry-503-apierror-retry-gap-and-cr/260709-oa7-SUMMARY.md | Adds the task completion summary and validation notes for the two Sentry fixes; no issues found. |
| memory-bank/living-ledger.md | Appends operational memory for the Smartsheet 5xx retry gap and cron check-in margin incident; no issues found. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Job as Weekly billing job
participant Retry as smartsheet_call_with_retry
participant SDK as Smartsheet SDK
participant Sentry as Sentry Crons

Job->>Sentry: "start check-in with checkin_margin=60"
Job->>Retry: fetch sheet via get_sheet
Retry->>SDK: call Smartsheet API
SDK-->>Retry: "ApiError code=0, status=503"
Retry->>Retry: "classify status in {500,502,503,504}"
Retry->>Retry: sleep bounded backoff
Retry->>SDK: retry get_sheet
SDK-->>Retry: sheet rows
Retry-->>Job: return successful result
Job->>Sentry: complete check-in
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Job as Weekly billing job
participant Retry as smartsheet_call_with_retry
participant SDK as Smartsheet SDK
participant Sentry as Sentry Crons

Job->>Sentry: "start check-in with checkin_margin=60"
Job->>Retry: fetch sheet via get_sheet
Retry->>SDK: call Smartsheet API
SDK-->>Retry: "ApiError code=0, status=503"
Retry->>Retry: "classify status in {500,502,503,504}"
Retry->>Retry: sleep bounded backoff
Retry->>SDK: retry get_sheet
SDK-->>Retry: sheet rows
Retry-->>Job: return successful result
Job->>Sentry: complete check-in
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(quick-260709-oa7): plan, summary, l..."](https://github.com/jflo21/generate-weekly-pdfs-dsr-resiliency/commit/a63ff11c3df304abd78ed81a36c4c3dc31342fb9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43154806)</sub>

<!-- /greptile_comment -->