### PR TITLE
feat: smartsheet-python-sdk 4.3.0 migration (Phase 08)

### DIFF
--- a/.claude/project-state.md
+++ b/.claude/project-state.md
@@ -48,8 +48,16 @@ write-back reminder). Keep it terse; link to history rather than duplicating it.
    reads; unset the token for local gate runs). New automated row
    08-SEC-T1 covers the SKIP_UPLOAD zero-mutation invariant. Commits
    `fa80b48` (validation), `8777246` (security docs), `442cb92` (fix).
-6. **Next:** PR per D-06 (weekday daytime merge after green cron + one
-   watched canary dispatch); then `/gsd:verify-work 08` if desired. Also: Juan's `.env` line-1 token
+6. **UAT COMPLETE (2026-07-22 ~16:30 CDT): `/gsd-verify-work 08` — 6/6
+   passed, 0 issues** (commit `d78e7d5`). Full-UAT in
+   `.planning/phases/08-*/08-UAT.md`; the old 1-test `08-HUMAN-UAT.md`
+   closed (its attachment-loss check = Test 5, Juan-confirmed: WR
+   89881161 self-healed via cron, WR 89708709/90093002 intact).
+   `08-VERIFICATION.md` flipped `human_needed` → `passed` (the human
+   gate it awaited was exactly Test 5). Roadmap/STATE/PROJECT transition
+   had already run in the prior session — no re-transition.
+7. **Next:** PR per D-06 (weekday daytime merge after green cron + one
+   watched canary dispatch); then `/gsd-verify-work 09`. Also: Juan's `.env` line-1 token
    surfaced in an editor selection into chat — rotation recommended.
    Carry-forward WARNING for next phase's register: `TEST_MODE=true` with
    a real token still performs real Smartsheet reads.

--- a/.claude/project-state.md
+++ b/.claude/project-state.md
@@ -56,10 +56,17 @@ write-back reminder). Keep it terse; link to history rather than duplicating it.
    `08-VERIFICATION.md` flipped `human_needed` → `passed` (the human
    gate it awaited was exactly Test 5). Roadmap/STATE/PROJECT transition
    had already run in the prior session — no re-transition.
-7. **PR #286 OPEN** (branch pushed 2026-07-22 ~16:40 CDT). **Next per
-   D-06:** merge in a weekday daytime window right after a green
-   scheduled run, then fire ONE watched `workflow_dispatch` canary;
-   then `/gsd-verify-work 09`. Also: Juan's `.env` line-1 token
+7. **PR #286 OPEN** (branch pushed 2026-07-22 ~16:40 CDT). **Review fix
+   shipped (quick task 260722-nst, ~17:35 CDT):** the 6th mutating call
+   site — `run_claimer_remediation` in the isolated REMEDIATE_CLAIMERS
+   branch (`pipeline/orchestrate.py` ~452) — now uses
+   `dry_run=REMEDIATION_DRY_RUN or SKIP_UPLOAD` (test `458d7e5`, fix
+   `60d0473`, docs `1b6ff9a`; TestRemediationGatesOnSkipUpload pins it;
+   8/8 gating tests green; haiku-verifier PASS 4/4). SKIP_UPLOAD=true ⇒
+   zero mutations now covers ALL 6 call sites. **Next per D-06:** merge
+   in a weekday daytime window right after a green scheduled run, then
+   fire ONE watched `workflow_dispatch` canary; then
+   `/gsd-verify-work 09`. Also: Juan's `.env` line-1 token
    surfaced in an editor selection into chat — rotation recommended.
    Carry-forward WARNING for next phase's register: `TEST_MODE=true` with
    a real token still performs real Smartsheet reads.

--- a/.claude/project-state.md
+++ b/.claude/project-state.md
@@ -1,38 +1,40 @@
 # Project State — Generate-Weekly-PDFs-DSR-Resiliency
 
-_Last updated: 2026-07-21 · **overwrite-in-place each session** (this is the
+_Last updated: 2026-07-22 · **overwrite-in-place each session** (this is the
 canonical "where the project stands" landing spot for the global Stop
 write-back reminder). Keep it terse; link to history rather than duplicating it._
 
-## Latest work (2026-07-21) — Sentry fixes VERIFIED in prod · Phase 08 context LOCKED
-1. **PR #284 post-merge validation CLOSED.** Both 260709-oa7 fixes confirmed
-   working 12 days post-merge: GENERATE-WEEKLY-EXCEL-89 (503 retry) zero
-   events since merge; GENERATE-WEEKLY-EXCEL-6V missed-check-in storm (was
-   78/14d) fully stopped, `checkin_margin: 60` live in the monitor config.
-   One 2026-07-18 "timeout check-in" event = lost closing check-in on a run
-   that actually succeeded in 65 min (GH run 29620427187) — one-off, not
-   actionable unless it recurs.
-2. **Branch hygiene:** local `master` had diverged (3 wip commits vs 19
-   remote). WIP preserved on `wip/phase08-research-pdf-poc` (Phase-08
-   research doc + PDF POC pause-commits); `master` hard-reset to
-   `origin/master` @ `720b0aa`; merged `fix/sentry-503-retry-cron-margin`
-   deleted.
-3. **Phase 08 (SDK 4.x migration) UNBLOCKED + context gathered** via
-   `/gsd-discuss-phase 08` (advisor mode; subagent spawns failed on a
-   transient org billing issue → research done inline). Four decisions
-   locked in `08-CONTEXT.md` (commit `631f757` on branch
-   `feat/phase-08-sdk-430-migration`): exact pin `==4.3.0`; NO workflow
-   edits (`--no-binary` obsolete — wheel bug fixed upstream in 4.0.1 #144,
-   wheel sizes verified); proof = 6-gate harness + live read-only Smartsheet
-   probe (mocked-ApiError blind spot); rollout = branch SKIP_UPLOAD dry-run
-   → weekday merge after green cron → one watched canary dispatch.
-   Key research facts embedded in CONTEXT.md `<specifics>` (changelog
-   4.0.1→4.3.0 all additive; 08-RESEARCH.md staleness corrections in D-08).
-4. **Phase 08 planning IN PROGRESS** (`/gsd-plan-phase 08`, same session):
-   `08-VALIDATION.md` created + committed (`68ac4ae`) — pytest sampling
-   contract + manual live-probe row for SDK-05. Pattern-mapper →
-   planner (opus) → plan-checker loop running; PLAN.md files not yet
-   written. **Next: finish plan-phase 08, then `/gsd-execute-phase 08`.**
+## Latest work (2026-07-22) — Phase 08 SDK 4.3.0 migration EXECUTED (both plans)
+1. **Phase 08 executed via `/gsd-execute-phase 08`** on branch
+   `feat/phase-08-sdk-430-migration` (unpushed; no PR yet). Wave 1 (08-01,
+   merge `6334531`): SDK 4.3.0 installed (env upgrade 3.9.0→4.3.0), dead
+   27-line 3.x re-export shim removed from `generate_weekly_pdfs.py`, Gate 1
+   baseline 178→177 (`_exc_name`), six gates ALL PASSED + full suite green.
+   Wave 2 (08-02, merge `72f72ef`): `requirements.txt` pin lifted to exact
+   `smartsheet-python-sdk==4.3.0`, Living Ledger entries added, D-06/D-07
+   rollout+rollback runbooks captured in `08-02-SUMMARY.md`.
+2. **D-05 live read-only probe: APPROVED by Juan** (bounded
+   `SKIP_UPLOAD=true WR_FILTER=... MAX_GROUPS=5` run, real transport, 2,771
+   groups validated, 5 Excel generated, zero SDK error-shape drift).
+   **Finding:** `SKIP_UPLOAD=true` is NOT fully read-only — the
+   delete-old-attachment step still ran (WR 89881161 weeks 072025/081725
+   deleted; hash withheld → next weekday cron regenerates + re-uploads
+   automatically; Juan chose wait-for-cron). Logged in phase
+   `deferred-items.md` + Living Ledger; follow-up fix candidate: gate the
+   delete on SKIP_UPLOAD too.
+3. **Test hermeticity fix (`4aa19ff`):**
+   `tests/test_entrypoint_no_double_import.py` now sets
+   `SMARTSHEET_API_TOKEN=''` (was `pop()`) — the engine's `load_dotenv()`
+   re-injected the token from Juan's new repo-root `.env`, flipping the
+   banner test into a real multi-minute API fetch (180s timeout). Empty
+   string survives dotenv (no override) and stays falsy → synthetic path.
+   Post-merge gate green: 1164 passed + 130 subtests.
+4. **In flight at session close:** phase code-review agent (08-REVIEW.md)
+   + gsd-verifier (08-VERIFICATION.md) then phase-complete roadmap update;
+   security note: `/gsd:secure-phase 08` not yet run. Next after close:
+   PR per D-06 (weekday daytime merge after green cron + one watched
+   canary dispatch). Also: Juan's `.env` line-1 token surfaced in an editor
+   selection into chat — rotation recommended.
 
 ## Current milestone
 **v1.3.1 — Smartsheet API resilience & silent-failure hardening** (follow-up to

--- a/.claude/project-state.md
+++ b/.claude/project-state.md
@@ -42,9 +42,14 @@ write-back reminder). Keep it terse; link to history rather than duplicating it.
    pin → v6); full suite **1171 passed + 130 subtests**. Threat register:
    `.planning/phases/08-*/08-SECURITY.md` (6/6 closed, threats_open: 0).
    Deferred item "SKIP_UPLOAD deletes prior attachments" marked RESOLVED.
-5. **Next:** PR per D-06 (weekday daytime merge after green cron + one
-   watched canary dispatch); then `/gsd:validate-phase 08` /
-   `/gsd:verify-work 08` if desired. Also: Juan's `.env` line-1 token
+5. **Nyquist gate CLEARED (2026-07-22 PM): `/gsd:validate-phase 08` run.**
+   0 gaps; all 6 task commands re-run live and green (six gates PASSED —
+   note: gate run took ~35 min because TEST_MODE + `.env` token does real
+   reads; unset the token for local gate runs). New automated row
+   08-SEC-T1 covers the SKIP_UPLOAD zero-mutation invariant. Commits
+   `fa80b48` (validation), `8777246` (security docs), `442cb92` (fix).
+6. **Next:** PR per D-06 (weekday daytime merge after green cron + one
+   watched canary dispatch); then `/gsd:verify-work 08` if desired. Also: Juan's `.env` line-1 token
    surfaced in an editor selection into chat — rotation recommended.
    Carry-forward WARNING for next phase's register: `TEST_MODE=true` with
    a real token still performs real Smartsheet reads.

--- a/.claude/project-state.md
+++ b/.claude/project-state.md
@@ -28,7 +28,11 @@ write-back reminder). Keep it terse; link to history rather than duplicating it.
    → weekday merge after green cron → one watched canary dispatch.
    Key research facts embedded in CONTEXT.md `<specifics>` (changelog
    4.0.1→4.3.0 all additive; 08-RESEARCH.md staleness corrections in D-08).
-   **Next: `/gsd-plan-phase 08`** on the phase branch.
+4. **Phase 08 planning IN PROGRESS** (`/gsd-plan-phase 08`, same session):
+   `08-VALIDATION.md` created + committed (`68ac4ae`) — pytest sampling
+   contract + manual live-probe row for SDK-05. Pattern-mapper →
+   planner (opus) → plan-checker loop running; PLAN.md files not yet
+   written. **Next: finish plan-phase 08, then `/gsd-execute-phase 08`.**
 
 ## Current milestone
 **v1.3.1 — Smartsheet API resilience & silent-failure hardening** (follow-up to

--- a/.claude/project-state.md
+++ b/.claude/project-state.md
@@ -29,12 +29,25 @@ write-back reminder). Keep it terse; link to history rather than duplicating it.
    banner test into a real multi-minute API fetch (180s timeout). Empty
    string survives dotenv (no override) and stays falsy → synthetic path.
    Post-merge gate green: 1164 passed + 130 subtests.
-4. **In flight at session close:** phase code-review agent (08-REVIEW.md)
-   + gsd-verifier (08-VERIFICATION.md) then phase-complete roadmap update;
-   security note: `/gsd:secure-phase 08` not yet run. Next after close:
-   PR per D-06 (weekday daytime merge after green cron + one watched
-   canary dispatch). Also: Juan's `.env` line-1 token surfaced in an editor
-   selection into chat — rotation recommended.
+4. **Security gate CLEARED (2026-07-22 PM): `/gsd:secure-phase 08` run.**
+   gsd-security-auditor verified 5/6 threats closed; the 6th (T-08-03,
+   `SKIP_UPLOAD=true` still ran the attachment DELETE — materialized in
+   the D-05 probe) was **fixed same-session, Juan-approved**: `dry_run`
+   param on `delete_old_excel_attachments` /
+   `cleanup_untracked_sheet_attachments` / `purge_existing_hashed_outputs`
+   (`pipeline/cleanup.py`), wired `dry_run=SKIP_UPLOAD` at all 5 mutating
+   call sites in `pipeline/orchestrate.py`. New invariant (ledger
+   `[2026-07-22 14:37]`): SKIP_UPLOAD=true ⇒ zero Smartsheet mutations.
+   TDD'd (`tests/test_skip_upload_delete_gating.py`, 7 tests; signature
+   pin → v6); full suite **1171 passed + 130 subtests**. Threat register:
+   `.planning/phases/08-*/08-SECURITY.md` (6/6 closed, threats_open: 0).
+   Deferred item "SKIP_UPLOAD deletes prior attachments" marked RESOLVED.
+5. **Next:** PR per D-06 (weekday daytime merge after green cron + one
+   watched canary dispatch); then `/gsd:validate-phase 08` /
+   `/gsd:verify-work 08` if desired. Also: Juan's `.env` line-1 token
+   surfaced in an editor selection into chat — rotation recommended.
+   Carry-forward WARNING for next phase's register: `TEST_MODE=true` with
+   a real token still performs real Smartsheet reads.
 
 ## Current milestone
 **v1.3.1 — Smartsheet API resilience & silent-failure hardening** (follow-up to

--- a/.claude/project-state.md
+++ b/.claude/project-state.md
@@ -1,32 +1,34 @@
 # Project State — Generate-Weekly-PDFs-DSR-Resiliency
 
-_Last updated: 2026-07-06 · **overwrite-in-place each session** (this is the
+_Last updated: 2026-07-21 · **overwrite-in-place each session** (this is the
 canonical "where the project stands" landing spot for the global Stop
 write-back reminder). Keep it terse; link to history rather than duplicating it._
 
-## Latest work (2026-07-09) — Sentry fixes SHIPPED to PR
-**GSD quick task `260709-oa7` COMPLETE** on branch
-`fix/sentry-503-retry-cron-margin` (cut from `origin/master` @ `c563b90`; the
-parked `fix/hash-store-crash-consistency` branch is untouched). Two Sentry
-issues root-caused and fixed TDD-first (red proven before green):
-1. **GENERATE-WEEKLY-EXCEL-89** (`1791246`) — HTTP 503 on `get_sheet` arrives
-   as generic `ApiError` code 0 / `status_code` 503 (`shouldRetry:false` is an
-   unparseable-body artifact), which `pipeline/retry.py` classified as
-   permanent (only result code 4000 retried) → source sheet dropped with 0
-   rows. Fix: new `_RETRYABLE_HTTP_STATUS = {500, 502, 503, 504}` +
-   `_http_status_code()` extractor; permanent codes/4xx still fail fast;
-   bounded-sleep contract unchanged. 5 new tests, 17/17 in
-   `tests/test_smartsheet_retry.py`.
-2. **GENERATE-WEEKLY-EXCEL-6V** (`7469204`) — cron monitor `checkin_margin: 5`
-   vs observed GH Actions cron start delays of 25–57 min (24/25 recent runs
-   succeeded) → 78 false "missed check-in" events/14d. Fix: margin 5 → 60 in
-   `pipeline/observability.py::_build_cron_monitor_config` (+ test flip).
-Full suite on this host: 1163 passed / 1 failed —
-`test_startup_banner_printed_once`, **verified pre-existing on pristine
-`origin/master`** (Windows cp1252 subprocess decode of the emoji banner;
-green in Ubuntu CI). Commit bodies carry `Fixes GENERATE-WEEKLY-EXCEL-89/-6V`
-so Sentry auto-resolves on merge. Next: merge PR, then confirm the next
-scheduled run fetches all sheets and the missed-check-in noise stops.
+## Latest work (2026-07-21) — Sentry fixes VERIFIED in prod · Phase 08 context LOCKED
+1. **PR #284 post-merge validation CLOSED.** Both 260709-oa7 fixes confirmed
+   working 12 days post-merge: GENERATE-WEEKLY-EXCEL-89 (503 retry) zero
+   events since merge; GENERATE-WEEKLY-EXCEL-6V missed-check-in storm (was
+   78/14d) fully stopped, `checkin_margin: 60` live in the monitor config.
+   One 2026-07-18 "timeout check-in" event = lost closing check-in on a run
+   that actually succeeded in 65 min (GH run 29620427187) — one-off, not
+   actionable unless it recurs.
+2. **Branch hygiene:** local `master` had diverged (3 wip commits vs 19
+   remote). WIP preserved on `wip/phase08-research-pdf-poc` (Phase-08
+   research doc + PDF POC pause-commits); `master` hard-reset to
+   `origin/master` @ `720b0aa`; merged `fix/sentry-503-retry-cron-margin`
+   deleted.
+3. **Phase 08 (SDK 4.x migration) UNBLOCKED + context gathered** via
+   `/gsd-discuss-phase 08` (advisor mode; subagent spawns failed on a
+   transient org billing issue → research done inline). Four decisions
+   locked in `08-CONTEXT.md` (commit `631f757` on branch
+   `feat/phase-08-sdk-430-migration`): exact pin `==4.3.0`; NO workflow
+   edits (`--no-binary` obsolete — wheel bug fixed upstream in 4.0.1 #144,
+   wheel sizes verified); proof = 6-gate harness + live read-only Smartsheet
+   probe (mocked-ApiError blind spot); rollout = branch SKIP_UPLOAD dry-run
+   → weekday merge after green cron → one watched canary dispatch.
+   Key research facts embedded in CONTEXT.md `<specifics>` (changelog
+   4.0.1→4.3.0 all additive; 08-RESEARCH.md staleness corrections in D-08).
+   **Next: `/gsd-plan-phase 08`** on the phase branch.
 
 ## Current milestone
 **v1.3.1 — Smartsheet API resilience & silent-failure hardening** (follow-up to

--- a/.claude/project-state.md
+++ b/.claude/project-state.md
@@ -56,8 +56,10 @@ write-back reminder). Keep it terse; link to history rather than duplicating it.
    `08-VERIFICATION.md` flipped `human_needed` → `passed` (the human
    gate it awaited was exactly Test 5). Roadmap/STATE/PROJECT transition
    had already run in the prior session — no re-transition.
-7. **Next:** PR per D-06 (weekday daytime merge after green cron + one
-   watched canary dispatch); then `/gsd-verify-work 09`. Also: Juan's `.env` line-1 token
+7. **PR #286 OPEN** (branch pushed 2026-07-22 ~16:40 CDT). **Next per
+   D-06:** merge in a weekday daytime window right after a green
+   scheduled run, then fire ONE watched `workflow_dispatch` canary;
+   then `/gsd-verify-work 09`. Also: Juan's `.env` line-1 token
    surfaced in an editor selection into chat — rotation recommended.
    Carry-forward WARNING for next phase's register: `TEST_MODE=true` with
    a real token still performs real Smartsheet reads.

--- a/.github/instructions/copilot-setup.instructions.md
+++ b/.github/instructions/copilot-setup.instructions.md
@@ -216,7 +216,7 @@ MAX_GROUPS=50 REGEN_WEEKS=081725,082425 RESET_WR_LIST=WR123,WR456
 **Configuration & Deployment:**
 - `.github/workflows/weekly-excel-generation.yml` - Production workflow with 10-input consolidation
 - `.env.example`, `.env.template`, `.env.audit.example` - Environment variable references
-- `requirements.txt` - Dependencies (sentry-sdk>=2.35.0, smartsheet-python-sdk>=3.1.0, etc.)
+- `requirements.txt` - Dependencies (sentry-sdk>=2.54.0, smartsheet-python-sdk==4.3.0 exact-pinned, etc.)
 
 **Runtime Artifacts:**
 - `generated_docs/` - Output directory (safe to clear)

--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -98,6 +98,15 @@ migrate; it is removed. See Out of Scope.
 
 ## Current State
 
+**Phase 08 complete (2026-07-22): SDK 4.3.0 migration executed.** Both plans
+shipped on `feat/phase-08-sdk-430-migration` (unpushed, PR pending per D-06
+weekday merge window): exact pin `smartsheet-python-sdk==4.3.0`, dead 3.x
+re-export shim removed, six-gate harness + 1164-test suite green, D-05 live
+read-only probe approved by the operator (one finding: `SKIP_UPLOAD=true`
+does not gate the attachment-delete half — logged in phase deferred-items +
+Living Ledger). Verification 6/6 must-haves; `08-HUMAN-UAT.md` tracks one
+partial item.
+
 **Shipped: v1.0 Subcontractor Rate Logic (2026-05-20).** 2 phases (01 +
 inserted 01.1), 19 plans, `pytest tests/` → 682 passed / 26 skipped /
 58 subtests. The pipeline now emits two subcontractor-scoped Excel variants
@@ -453,8 +462,10 @@ This document evolves at phase transitions and milestone boundaries.
 4. Update Context with current state
 
 ---
-*Last updated: 2026-06-08 — Milestone **v1.2 smartsheet-python-sdk 4.0.0
-Compatibility Migration** started (Phase 08). Compat-only migration to SDK
+*Last updated: 2026-07-22 — Phase 08 executed: SDK migrated to the exact
+`==4.3.0` pin with behavior-neutrality proven (six gates + full suite) and
+the live probe approved. Milestone **v1.2 smartsheet-python-sdk 4.0.0
+Compatibility Migration** started 2026-06-08 (Phase 08). Compat-only migration to SDK
 4.0.0 so the temporary `<4.0.0` pin (hotfix 260608-gwm / PR #273) can be
 lifted, with zero behavior change to the billing pipeline. v1.1 Portal shipped
 (Phases 03–07); its artifacts are preserved (not archived — pending Phase 06

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -139,29 +139,29 @@ compatibility so the pin can be lifted.
 
 ### SDK 4.0.0 Migration
 
-- [ ] **SDK-01**: The billing engine resolves Smartsheet exception classes
+- [x] **SDK-01**: The billing engine resolves Smartsheet exception classes
   (`RateLimitExceededError`, `UnexpectedErrorShouldRetryError`,
   `InternalServerError`, `ServerTimeoutExceededError`) under SDK 4.0.0 — the
   `import smartsheet.exceptions` at `generate_weekly_pdfs.py:28` and the retry
   `except` blocks (~8389/8397/8603/8620-8622/9835/9843) work without
   `ModuleNotFoundError` / `AttributeError`.
-- [ ] **SDK-02**: The `smartsheet.smartsheet` retry-exception re-export
+- [x] **SDK-02**: The `smartsheet.smartsheet` retry-exception re-export
   workaround (`generate_weekly_pdfs.py:30-54`) is reconciled with 4.0.0 — kept,
   updated, or removed if 4.0.0 makes it obsolete — and the SDK's internal
   retryable-exception lookup still succeeds (no silently-swallowed retries).
-- [ ] **SDK-03**: Every in-use SDK call site is verified compatible with 4.0.0
+- [x] **SDK-03**: Every in-use SDK call site is verified compatible with 4.0.0
   signatures and return shapes: `Sheets.get_sheet(sheet_id, include=…,
   row_numbers=…)`, `Attachments.list_row_attachments / delete_attachment /
   attach_file_to_row`, and `Folders.get_folder_children(..., last_key=…)`
   token-based pagination.
-- [ ] **SDK-04**: The full `pytest tests/` suite passes against SDK 4.0.0; test
+- [x] **SDK-04**: The full `pytest tests/` suite passes against SDK 4.0.0; test
   mocks/fixtures are updated for any relocated symbols (notably
   `tests/test_billing_audit_shadow.py:64` and the `last_key` pagination tests in
   `test_subcontractor_pricing.py` / `test_vac_crew.py`).
-- [ ] **SDK-05**: The `requirements.txt` upper-bound pin is lifted to allow
+- [x] **SDK-05**: The `requirements.txt` upper-bound pin is lifted to allow
   4.0.0 (e.g. `smartsheet-python-sdk>=4.0.0`) **only after** SDK-01..04 pass,
   and the corresponding Living Ledger / CLAUDE.md pin notes are updated.
-- [ ] **SDK-06**: A non-upload validation run (`TEST_MODE=true` and/or
+- [x] **SDK-06**: A non-upload validation run (`TEST_MODE=true` and/or
   `SKIP_UPLOAD=true`) confirms the pipeline produces identical grouping and
   Excel output under 4.0.0 — proving zero behavior change.
 
@@ -244,12 +244,12 @@ Which phases cover which requirements.
 | SEC-03 | Phase 07 | Pending |
 | SEC-04 | Phase 07 | Pending |
 | SEC-05 | Phase 07 | Pending |
-| SDK-01 | Phase 08 | Pending |
-| SDK-02 | Phase 08 | Pending |
-| SDK-03 | Phase 08 | Pending |
-| SDK-04 | Phase 08 | Pending |
-| SDK-05 | Phase 08 | Pending |
-| SDK-06 | Phase 08 | Pending |
+| SDK-01 | Phase 08 | Complete |
+| SDK-02 | Phase 08 | Complete |
+| SDK-03 | Phase 08 | Complete |
+| SDK-04 | Phase 08 | Complete |
+| SDK-05 | Phase 08 | Complete |
+| SDK-06 | Phase 08 | Complete |
 
 **Coverage:**
 - v1.1 requirements: 33 total — mapped to phases: 33 (Phase 03: 5, Phase 04: 15, Phase 05: 9, Phase 06: 4, Phase 07: 5); unmapped: 0 ✓

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -106,7 +106,7 @@ Full phase details in main ROADMAP.md Phase 2 section below (archived inline).
 | 05. Artifact Table and Search | v1.1 | 4/4 | Complete    | 2026-06-02 |
 | 06. Realtime and UI Polish | v1.1 | 5/5 | Complete    | 2026-06-02 |
 | 07. Security Hardening and Express Removal | v1.1 | 4/4 | ✅ Complete | 2026-06-03 |
-| 08. smartsheet-python-sdk 4.0.0 Compatibility Migration | v1.2 | 0/2 | Planned | — |
+| 08. smartsheet-python-sdk 4.0.0 Compatibility Migration | v1.2 | 1/2 | In Progress|  |
 | 09. Engine Modularization (pipeline package split) | v1.3 | 5/7 | In Progress|  |
 
 ---
@@ -474,12 +474,12 @@ must be reconciled first).
 5. The production weekly workflow runs green on 4.0.0 (observed on the next
    scheduled cron after merge).
 
-**Plans:** 2 plans in 2 waves
+**Plans:** 1/2 plans executed
 
 Plans:
 **Wave 1**
 
-- [ ] 08-01-PLAN.md — Install SDK 4.3.0 + remove the dead 3.x re-export block + rebaseline Gate 1 (`_exc_name` 178→177) + green six-gate & full-pytest behavior-neutrality proof (SDK-01/02/03/04/06)
+- [x] 08-01-PLAN.md — Install SDK 4.3.0 + remove the dead 3.x re-export block + rebaseline Gate 1 (`_exc_name` 178→177) + green six-gate & full-pytest behavior-neutrality proof (SDK-01/02/03/04/06)
 
 **Wave 2** *(blocked on Wave 1 — pin lifted only after the automated proof is green)*
 

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -106,7 +106,7 @@ Full phase details in main ROADMAP.md Phase 2 section below (archived inline).
 | 05. Artifact Table and Search | v1.1 | 4/4 | Complete    | 2026-06-02 |
 | 06. Realtime and UI Polish | v1.1 | 5/5 | Complete    | 2026-06-02 |
 | 07. Security Hardening and Express Removal | v1.1 | 4/4 | ✅ Complete | 2026-06-03 |
-| 08. smartsheet-python-sdk 4.0.0 Compatibility Migration | v1.2 | 0/? | Planning | — |
+| 08. smartsheet-python-sdk 4.0.0 Compatibility Migration | v1.2 | 0/2 | Planned | — |
 | 09. Engine Modularization (pipeline package split) | v1.3 | 5/7 | In Progress|  |
 
 ---
@@ -474,6 +474,13 @@ must be reconciled first).
 5. The production weekly workflow runs green on 4.0.0 (observed on the next
    scheduled cron after merge).
 
-**Plans:** TBD — run `/gsd-plan-phase 08` (focused SDK research → planner →
-plan-checker). The 4.0.0 CHANGELOG is already indexed in the context-mode KB
-under source `smartsheet-sdk-changelog`.
+**Plans:** 2 plans in 2 waves
+
+Plans:
+**Wave 1**
+
+- [ ] 08-01-PLAN.md — Install SDK 4.3.0 + remove the dead 3.x re-export block + rebaseline Gate 1 (`_exc_name` 178→177) + green six-gate & full-pytest behavior-neutrality proof (SDK-01/02/03/04/06)
+
+**Wave 2** *(blocked on Wave 1 — pin lifted only after the automated proof is green)*
+
+- [ ] 08-02-PLAN.md — Lift the exact pin `smartsheet-python-sdk==4.3.0` + Living Ledger entry + [BLOCKING] live read-only Smartsheet probe (D-05) + rollout/rollback runbook (SDK-03/05/06)

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -106,7 +106,7 @@ Full phase details in main ROADMAP.md Phase 2 section below (archived inline).
 | 05. Artifact Table and Search | v1.1 | 4/4 | Complete    | 2026-06-02 |
 | 06. Realtime and UI Polish | v1.1 | 5/5 | Complete    | 2026-06-02 |
 | 07. Security Hardening and Express Removal | v1.1 | 4/4 | ✅ Complete | 2026-06-03 |
-| 08. smartsheet-python-sdk 4.0.0 Compatibility Migration | v1.2 | 2/2 | Complete   | 2026-07-22 |
+| 08. smartsheet-python-sdk 4.0.0 Compatibility Migration | v1.2 | 2/2 | Complete    | 2026-07-22 |
 | 09. Engine Modularization (pipeline package split) | v1.3 | 5/7 | In Progress|  |
 
 ---

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -77,7 +77,7 @@ Full phase details in main ROADMAP.md Phase 2 section below (archived inline).
 
 ### v1.2 smartsheet-python-sdk 4.0.0 Compatibility Migration
 
-- [ ] **Phase 08: smartsheet-python-sdk 4.0.0 Compatibility Migration** —
+- [x] **Phase 08: smartsheet-python-sdk 4.0.0 Compatibility Migration** — (completed 2026-07-22)
   reconcile exception-class imports + retry blocks + the `smartsheet.smartsheet`
   re-export workaround with 4.0.0's module layout, verify all in-use SDK call
   sites (`Sheets.get_sheet`, `Attachments.*`, `Folders.get_folder_children`),
@@ -106,7 +106,7 @@ Full phase details in main ROADMAP.md Phase 2 section below (archived inline).
 | 05. Artifact Table and Search | v1.1 | 4/4 | Complete    | 2026-06-02 |
 | 06. Realtime and UI Polish | v1.1 | 5/5 | Complete    | 2026-06-02 |
 | 07. Security Hardening and Express Removal | v1.1 | 4/4 | ✅ Complete | 2026-06-03 |
-| 08. smartsheet-python-sdk 4.0.0 Compatibility Migration | v1.2 | 1/2 | In Progress|  |
+| 08. smartsheet-python-sdk 4.0.0 Compatibility Migration | v1.2 | 2/2 | Complete   | 2026-07-22 |
 | 09. Engine Modularization (pipeline package split) | v1.3 | 5/7 | In Progress|  |
 
 ---
@@ -474,7 +474,7 @@ must be reconciled first).
 5. The production weekly workflow runs green on 4.0.0 (observed on the next
    scheduled cron after merge).
 
-**Plans:** 1/2 plans executed
+**Plans:** 2/2 plans complete
 
 Plans:
 **Wave 1**
@@ -483,4 +483,4 @@ Plans:
 
 **Wave 2** *(blocked on Wave 1 — pin lifted only after the automated proof is green)*
 
-- [ ] 08-02-PLAN.md — Lift the exact pin `smartsheet-python-sdk==4.3.0` + Living Ledger entry + [BLOCKING] live read-only Smartsheet probe (D-05) + rollout/rollback runbook (SDK-03/05/06)
+- [x] 08-02-PLAN.md — Lift the exact pin `smartsheet-python-sdk==4.3.0` + Living Ledger entry + [BLOCKING] live read-only Smartsheet probe (D-05) + rollout/rollback runbook (SDK-03/05/06)

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,13 +2,13 @@
 gsd_state_version: 1.0
 milestone: v1.2
 milestone_name: smartsheet-python-sdk 4.0.0 Compatibility Migration
-status: completed
-last_updated: "2026-07-21T23:18:14.935Z"
-last_activity: "2026-07-09 - Completed quick task 260709-oa7: Sentry 5xx ApiError retry gap + cron checkin_margin fixes"
+status: executing
+last_updated: "2026-07-22T00:33:48.680Z"
+last_activity: 2026-07-22 -- Phase 08 planning complete
 progress:
   total_phases: 8
   completed_phases: 6
-  total_plans: 28
+  total_plans: 30
   completed_plans: 28
   percent: 75
 ---
@@ -32,12 +32,12 @@ pipeline.
 
 Phase: 09 (engine-modularization-pipeline-package-split) — ✅ COMPLETE
 Plan: 7 of 7 complete
-Status: 09-06 (Wave 6: orchestrate + thin facade) complete — PHASE 09 COMPLETE.
+Status: Ready to execute
   Engine 10,476 -> 709-line thin facade; 13-module pipeline/ package; 0 behavior
   change; all 7 waves independently 6-gate-verified. Next: /gsd-verify-work 09,
   then PR / milestone close. (Phase 08 SDK 4.0.0 migration still outstanding — same
   file, so it could not run concurrently; now unblocked.)
-Last activity: 2026-07-09 - Completed quick task 260709-oa7: Sentry 5xx ApiError retry gap + cron checkin_margin fixes
+Last activity: 2026-07-22 -- Phase 08 planning complete
 
 ### Infrastructure Topology (discovered 2026-06-01 via Supabase MCP) — READ BEFORE PHASE 05
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -4,7 +4,7 @@ milestone: v1.2
 milestone_name: smartsheet-python-sdk 4.0.0 Compatibility Migration
 status: ready_to_plan
 last_updated: 2026-07-22T21:30:00.000Z
-last_activity: 2026-07-22 -- Phase 08 UAT complete (6/6 passed, 0 issues)
+last_activity: 2026-07-22 -- Quick task 260722-nst: SKIP_UPLOAD gate extended to claimer remediation (PR #286 review fix)
 progress:
   total_phases: 8
   completed_phases: 6
@@ -204,6 +204,7 @@ See PROJECT.md `<decisions>` table for the full 30+ entry log.
 
 | # | Description | Date | Commit | Directory |
 |---|-------------|------|--------|-----------|
+| 260722-nst | Gate claimer remediation on SKIP_UPLOAD (PR #286 review fix — 6th mutating call site) | 2026-07-22 | 458d7e5, 60d0473 | [260722-nst](./quick/260722-nst-gate-claimer-remediation-on-skip-upload-/) |
 | 260709-oa7 | Fix Sentry 503 ApiError retry gap (GENERATE-WEEKLY-EXCEL-89) and cron checkin_margin 5→60 (GENERATE-WEEKLY-EXCEL-6V) | 2026-07-09 | 1791246, 7469204 | [260709-oa7](./quick/260709-oa7-fix-sentry-503-apierror-retry-gap-and-cr/) |
 | 260528-lu6 | Reconcile AGENTS.md into a lean pointer mirroring CLAUDE.md | 2026-05-28 | d30be0e | [260528-lu6](./quick/260528-lu6-reconcile-agents-md-into-a-lean-pointer-/) |
 | 260528-mdc | Add warn-only ruff + mypy lint tooling and isolated CI workflow | 2026-05-28 | 7f8dbfb | [260528-mdc](./quick/260528-mdc-add-warn-only-ruff-and-mypy-lint-tooling/) |

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,15 +2,16 @@
 gsd_state_version: 1.0
 milestone: v1.2
 milestone_name: smartsheet-python-sdk 4.0.0 Compatibility Migration
-status: executing
-last_updated: "2026-07-22T00:54:15.569Z"
+status: ready_to_plan
+last_updated: 2026-07-22T17:49:27.826Z
 last_activity: 2026-07-22 -- Phase 08 execution started
 progress:
   total_phases: 8
   completed_phases: 6
   total_plans: 30
-  completed_plans: 28
+  completed_plans: 50
   percent: 75
+stopped_at: Phase 08 complete (2/2) — ready to discuss Phase 9
 ---
 
 # Project State
@@ -26,18 +27,18 @@ right generated Excel billing artifact fast, from a secure, auth-gated,
 beautiful web portal — with zero change to the production Python billing
 pipeline.
 
-**Current focus:** Phase 08 — smartsheet-python-sdk-4-0-0-compatibility-migration
+**Current focus:** Phase 9 — engine modularization (pipeline package split)
 
 ## Current Position
 
-Phase: 08 (smartsheet-python-sdk-4-0-0-compatibility-migration) — EXECUTING
-Plan: 1 of 2
-Status: Executing Phase 08
+Phase: 9
+Plan: Not started
+Status: Ready to plan
   Engine 10,476 -> 709-line thin facade; 13-module pipeline/ package; 0 behavior
   change; all 7 waves independently 6-gate-verified. Next: /gsd-verify-work 09,
   then PR / milestone close. (Phase 08 SDK 4.0.0 migration still outstanding — same
   file, so it could not run concurrently; now unblocked.)
-Last activity: 2026-07-22 -- Phase 08 execution started
+Last activity: 2026-07-22
 
 ### Infrastructure Topology (discovered 2026-06-01 via Supabase MCP) — READ BEFORE PHASE 05
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,15 +3,15 @@ gsd_state_version: 1.0
 milestone: v1.2
 milestone_name: smartsheet-python-sdk 4.0.0 Compatibility Migration
 status: ready_to_plan
-last_updated: 2026-07-22T17:49:27.826Z
-last_activity: 2026-07-22 -- Phase 08 execution started
+last_updated: 2026-07-22T21:30:00.000Z
+last_activity: 2026-07-22 -- Phase 08 UAT complete (6/6 passed, 0 issues)
 progress:
   total_phases: 8
   completed_phases: 6
   total_plans: 30
   completed_plans: 50
   percent: 75
-stopped_at: Phase 08 complete (2/2) — ready to discuss Phase 9
+stopped_at: Phase 08 UAT complete (6/6 pass) + verification human-gate resolved — next is the D-06 PR/rollout, then Phase 9 verify
 ---
 
 # Project State

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,15 +2,15 @@
 gsd_state_version: 1.0
 milestone: v1.2
 milestone_name: smartsheet-python-sdk 4.0.0 Compatibility Migration
-status: executing
-last_updated: "2026-06-27T00:10:00Z"
-last_activity: 2026-06-26
+status: completed
+last_updated: "2026-07-21T23:18:14.935Z"
+last_activity: "2026-07-09 - Completed quick task 260709-oa7: Sentry 5xx ApiError retry gap + cron checkin_margin fixes"
 progress:
   total_phases: 8
-  completed_phases: 7
-  total_plans: 35
-  completed_plans: 34
-  percent: 88
+  completed_phases: 6
+  total_plans: 28
+  completed_plans: 28
+  percent: 75
 ---
 
 # Project State

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,8 +3,8 @@ gsd_state_version: 1.0
 milestone: v1.2
 milestone_name: smartsheet-python-sdk 4.0.0 Compatibility Migration
 status: executing
-last_updated: "2026-07-22T00:33:48.680Z"
-last_activity: 2026-07-22 -- Phase 08 planning complete
+last_updated: "2026-07-22T00:54:15.569Z"
+last_activity: 2026-07-22 -- Phase 08 execution started
 progress:
   total_phases: 8
   completed_phases: 6
@@ -26,18 +26,18 @@ right generated Excel billing artifact fast, from a secure, auth-gated,
 beautiful web portal — with zero change to the production Python billing
 pipeline.
 
-**Current focus:** Phase 09 — engine-modularization-pipeline-package-split
+**Current focus:** Phase 08 — smartsheet-python-sdk-4-0-0-compatibility-migration
 
 ## Current Position
 
-Phase: 09 (engine-modularization-pipeline-package-split) — ✅ COMPLETE
-Plan: 7 of 7 complete
-Status: Ready to execute
+Phase: 08 (smartsheet-python-sdk-4-0-0-compatibility-migration) — EXECUTING
+Plan: 1 of 2
+Status: Executing Phase 08
   Engine 10,476 -> 709-line thin facade; 13-module pipeline/ package; 0 behavior
   change; all 7 waves independently 6-gate-verified. Next: /gsd-verify-work 09,
   then PR / milestone close. (Phase 08 SDK 4.0.0 migration still outstanding — same
   file, so it could not run concurrently; now unblocked.)
-Last activity: 2026-07-22 -- Phase 08 planning complete
+Last activity: 2026-07-22 -- Phase 08 execution started
 
 ### Infrastructure Topology (discovered 2026-06-01 via Supabase MCP) — READ BEFORE PHASE 05
 

--- a/.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-01-PLAN.md
+++ b/.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-01-PLAN.md
@@ -13,10 +13,11 @@ user_setup: []
 
 must_haves:
   truths:
-    - "smartsheet-python-sdk==4.3.0 imports cleanly; the four retryable exception classes and the smartsheet.smartsheet module both resolve"
-    - "generate_weekly_pdfs.py no longer contains the 3.x re-export workaround block; py_compile is clean"
-    - "All six gates in scripts/run_6_gates.sh pass under 4.3.0 (Gate 1 baseline reflects the authorized _exc_name deletion)"
+    - "D-02/D-08: smartsheet-python-sdk==4.3.0 (the changelog-reviewed additive target, not the stale >=4.0.0) imports cleanly; the four retryable exception classes and the smartsheet.smartsheet module both resolve"
+    - "D-04: generate_weekly_pdfs.py no longer contains the 3.x re-export workaround block (line-18 ss_exc import stays; pipeline/retry.py untouched); py_compile is clean"
+    - "D-05: All six gates in scripts/run_6_gates.sh pass under 4.3.0 (Gate 1 baseline reflects the authorized _exc_name deletion)"
     - "The full pytest suite is green under 4.3.0 with zero test/fixture changes"
+    - "D-03: No .github/workflows/*.yml file is modified; install uses the plain PyPI wheel with NO --no-binary flag"
   artifacts:
     - path: "generate_weekly_pdfs.py"
       provides: "SDK imports without the dead 3.x re-export workaround"

--- a/.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-01-PLAN.md
+++ b/.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-01-PLAN.md
@@ -1,0 +1,269 @@
+---
+phase: 08-smartsheet-python-sdk-4-0-0-compatibility-migration
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - generate_weekly_pdfs.py
+  - tests/golden/baseline_names.json
+autonomous: true
+requirements: [SDK-01, SDK-02, SDK-03, SDK-04, SDK-06]
+user_setup: []
+
+must_haves:
+  truths:
+    - "smartsheet-python-sdk==4.3.0 imports cleanly; the four retryable exception classes and the smartsheet.smartsheet module both resolve"
+    - "generate_weekly_pdfs.py no longer contains the 3.x re-export workaround block; py_compile is clean"
+    - "All six gates in scripts/run_6_gates.sh pass under 4.3.0 (Gate 1 baseline reflects the authorized _exc_name deletion)"
+    - "The full pytest suite is green under 4.3.0 with zero test/fixture changes"
+  artifacts:
+    - path: "generate_weekly_pdfs.py"
+      provides: "SDK imports without the dead 3.x re-export workaround"
+      contains: "import smartsheet.exceptions as ss_exc"
+    - path: "tests/golden/baseline_names.json"
+      provides: "Gate 1 frozen name-set with the authorized _exc_name removed (178 -> 177 names)"
+  key_links:
+    - from: "generate_weekly_pdfs.py"
+      to: "smartsheet.exceptions"
+      via: "import smartsheet.exceptions as ss_exc (retained line 18)"
+      pattern: "import smartsheet\\.exceptions as ss_exc"
+    - from: "scripts/check_api_equality.py"
+      to: "tests/golden/baseline_names.json"
+      via: "baseline name-set must match the post-deletion facade+pipeline union"
+      pattern: "_exc_name"
+---
+
+<objective>
+Migrate the production billing engine's SDK import surface to
+`smartsheet-python-sdk==4.3.0` and prove behavior-neutrality with the full
+six-gate harness plus the complete pytest suite — with the temporary
+`<4.0.0` pin still in place in `requirements.txt` (the pin is lifted in
+Wave 2, plan 08-02, ONLY after this plan's proof is green, per SDK-05).
+
+Purpose: SDK-01/02/03/04/06 require that 4.3.0 resolves all in-use SDK
+symbols, that the now-dead 3.x re-export workaround is removed (D-04), and
+that grouping/Excel output is provably identical to the 3.x baseline.
+
+Output: `generate_weekly_pdfs.py` with the dead block removed; the Gate 1
+frozen baseline updated for the authorized `_exc_name` deletion; a green
+six-gate run + full pytest run recorded in the SUMMARY.
+
+CRITICAL ordering note: install 4.3.0 DIRECTLY into the environment
+(`pip install "smartsheet-python-sdk==4.3.0"`). Do NOT run
+`pip install -r requirements.txt` anywhere in this plan — the pin still
+reads `>=3.1.0,<4.0.0` and would DOWNGRADE the env back to 3.x. The
+requirements.txt pin is lifted in 08-02.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-CONTEXT.md
+@.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-PATTERNS.md
+@scripts/run_6_gates.sh
+
+<interfaces>
+<!-- Key contracts the executor needs. Extracted from the codebase. No exploration required. -->
+
+Removal target — generate_weekly_pdfs.py (current live state, lines 17-47):
+  Line 17  import smartsheet
+  Line 18  import smartsheet.exceptions as ss_exc          # KEEP
+  Line 19  (blank)                                         # KEEP as separator
+  Lines 20-33  14-line comment describing the 3.x workaround  # REMOVE
+  Line 34  import smartsheet.smartsheet as _ss_smartsheet_module  # REMOVE
+  Lines 35-44  _exc_name = None + for-loop re-export patch   # REMOVE
+  Lines 45-46  del _ss_smartsheet_module / del _exc_name     # REMOVE
+  Line 47  from dotenv import load_dotenv                    # KEEP
+
+Gate 1 mechanics — scripts/check_api_equality.py:
+  - Compares the union of top-level def/class/Assign/AnnAssign names across
+    generate_weekly_pdfs.py + pipeline/*.py against tests/golden/baseline_names.json.
+  - FAILS only when a baseline name is MISSING from that union.
+  - `import ... as X` is NOT counted (ast.Import), so removing
+    `_ss_smartsheet_module` is invisible to Gate 1.
+  - `_exc_name = None` (line 35) IS a top-level ast.Assign, so `_exc_name`
+    IS one of the 178 baseline names. Removing the block drops it ->
+    Gate 1 reports `missing: ['_exc_name']` unless the baseline is updated.
+
+Gate 4 mechanics — scripts/check_mypy_delta.sh:
+  - Fails ONLY on an INCREASE in the mypy error-LINE count vs
+    tests/golden/mypy_baseline_count.txt. Deleting dead lines is neutral or
+    reduced -> passes. No mypy-baseline refresh required. Do NOT edit
+    tests/golden/mypy_baseline*.txt.
+
+Retry contract (READ-ONLY — must survive byte-for-byte, do NOT edit):
+  pipeline/retry.py:67  import smartsheet.exceptions as ss_exc
+  pipeline/retry.py  _TRANSIENT_EXC tuple + _api_error_code()/_http_status_code()
+  introspect exc.error.result.code / .status_code. Unchanged across
+  4.0.1-4.3.0 per D-02.
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Install SDK 4.3.0 into the env and smoke-verify every in-use symbol</name>
+  <files>(no file edits — environment + verification only)</files>
+  <read_first>
+    - .planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-CONTEXT.md (D-01/D-02/D-03: exact pin 4.3.0, wheel healthy since 4.0.1, NO --no-binary)
+    - generate_weekly_pdfs.py lines 1-60 (the SDK import sites)
+    - pipeline/retry.py (the retry exception contract that consumes ss_exc.*)
+  </read_first>
+  <action>
+    Install the exact target version DIRECTLY (not via requirements.txt):
+    run `python -m pip install "smartsheet-python-sdk==4.3.0"`. Use a PLAIN
+    install — do NOT pass `--no-binary` (obsolete per D-03: the 4.0.0
+    wheel-packaging bug was fixed upstream in 4.0.1; the 4.3.0 wheel is
+    healthy at ~270 KB). Confirm the resolved version with
+    `pip show smartsheet-python-sdk`. Then smoke-verify, in one interpreter
+    invocation, that every symbol this codebase uses resolves under 4.3.0:
+    the four retryable exception classes `RateLimitExceededError`,
+    `UnexpectedErrorShouldRetryError`, `InternalServerError`,
+    `ServerTimeoutExceededError` on `smartsheet.exceptions`; the
+    `smartsheet.smartsheet` submodule (still present in 4.x — the
+    test_billing_audit_shadow import depends on it); and the in-use models
+    `smartsheet.models.sheet.Sheet` and `smartsheet.models.folder.Folder`.
+    Do NOT run `pip install -r requirements.txt` (would downgrade to 3.x).
+  </action>
+  <verify>
+    <automated>pip show smartsheet-python-sdk | grep -i "^Version: 4.3.0"</automated>
+    <automated>python -c "import smartsheet.exceptions as e, smartsheet.smartsheet; from smartsheet.models.sheet import Sheet; from smartsheet.models.folder import Folder; [getattr(e,n) for n in ('RateLimitExceededError','UnexpectedErrorShouldRetryError','InternalServerError','ServerTimeoutExceededError')]; print('SDK_401_OK')"</automated>
+  </verify>
+  <acceptance_criteria>
+    - `pip show smartsheet-python-sdk` reports `Version: 4.3.0`
+    - The smoke-import command exits 0 and prints `SDK_401_OK` (all four
+      exception classes + `smartsheet.smartsheet` + both models resolve)
+    - No `ModuleNotFoundError` / `AttributeError` from any in-use SDK import
+    - `requirements.txt` is unchanged (still `>=3.1.0,<4.0.0`) at end of task
+  </acceptance_criteria>
+  <done>SDK 4.3.0 is installed and every in-use SDK symbol resolves (SDK-01, SDK-03).</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Remove the dead 3.x re-export block and update the Gate 1 baseline</name>
+  <files>generate_weekly_pdfs.py, tests/golden/baseline_names.json</files>
+  <read_first>
+    - generate_weekly_pdfs.py lines 1-60 (exact removal target: lines 20-46)
+    - .planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-PATTERNS.md (removal action + verify pattern)
+    - scripts/check_api_equality.py (why _exc_name is a baseline name and why removal trips Gate 1)
+    - tests/golden/baseline_names.json (the frozen 178-name set that must drop _exc_name)
+  </read_first>
+  <action>
+    In `generate_weekly_pdfs.py`, delete lines 20-46 inclusive: the 14-line
+    comment describing the 3.x workaround, the
+    `import smartsheet.smartsheet as _ss_smartsheet_module` line, the
+    `_exc_name = None` + `for _exc_name in (...)` re-export loop, and both
+    `del` statements. Keep line 17 (`import smartsheet`), line 18
+    (`import smartsheet.exceptions as ss_exc`), the single blank line 19 as
+    the separator, and line 47 (`from dotenv import load_dotenv`) onward
+    byte-for-byte unchanged. Do NOT touch any `except ss_exc.*` retry block
+    elsewhere in the file, and do NOT touch `pipeline/retry.py` — those
+    resolve `ss_exc.*` directly and never depended on the removed re-export
+    (SDK-02 / D-04).
+
+    Then update `tests/golden/baseline_names.json`: remove the single entry
+    `_exc_name` (a transient import-time loop temporary that was `del`'d at
+    old line 46 and is not a public API name). The name count goes 178 ->
+    177. This is the authorized Gate 1 baseline adjustment reflecting the
+    D-04 deletion — remove EXACTLY `_exc_name` and no other name. This is
+    NOT a behavior change: `_exc_name` was never re-exported, never in the
+    facade_allowlist, and never referenced by any consumer.
+  </action>
+  <verify>
+    <automated>python -m py_compile generate_weekly_pdfs.py</automated>
+    <automated>python -c "import re; t=open('generate_weekly_pdfs.py',encoding='utf-8').read(); assert '_ss_smartsheet_module' not in t; assert 'import smartsheet.exceptions as ss_exc' in t; print('BLOCK_REMOVED_OK')"</automated>
+    <automated>python -c "import json; n=json.load(open('tests/golden/baseline_names.json')); assert '_exc_name' not in n; assert len(n)==177, len(n); print('BASELINE_177_OK')"</automated>
+    <automated>python scripts/check_api_equality.py</automated>
+  </verify>
+  <acceptance_criteria>
+    - `generate_weekly_pdfs.py` does NOT contain the string `_ss_smartsheet_module`
+    - `generate_weekly_pdfs.py` STILL contains `import smartsheet.exceptions as ss_exc`
+    - `python -m py_compile generate_weekly_pdfs.py` exits 0
+    - `tests/golden/baseline_names.json` does NOT contain `_exc_name` and has exactly 177 entries
+    - `python scripts/check_api_equality.py` prints `PASS: all 177 baseline names present` and exits 0
+    - `git diff --stat` shows only `generate_weekly_pdfs.py` and `tests/golden/baseline_names.json` changed
+  </acceptance_criteria>
+  <done>The dead workaround is gone, py_compile is clean, and Gate 1 is green at 177 names (SDK-02).</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Run the full six-gate harness and complete pytest suite under 4.3.0</name>
+  <files>(no file edits — verification only)</files>
+  <read_first>
+    - scripts/run_6_gates.sh (the six-gate behavior-neutrality oracle)
+    - scripts/check_facade_completeness.py (Gate 2 — unaffected by the deletion)
+    - scripts/check_mypy_delta.sh (Gate 4 — count-based, stays green)
+    - .planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-VALIDATION.md (sampling rate + full-suite command)
+  </read_first>
+  <action>
+    With 4.3.0 installed and the block removed, run the complete
+    behavior-neutrality proof against 4.3.0. First run the six-gate harness:
+    `bash scripts/run_6_gates.sh`. Expect all six green — Gate 1 (177
+    names), Gate 2 (facade allowlist unchanged), Gate 3 (pytest -q), Gate 4
+    (mypy delta neutral or improved; skips gracefully if mypy absent), Gate
+    5 (py_compile), Gate 6 (TEST_MODE=true SKIP_UPLOAD=true synthetic run +
+    golden run_summary structural snapshot). Then run the full verbose suite
+    `pytest tests/ -v` and confirm zero failures with zero test/fixture
+    changes (SDK-04 research finding: net test changes = zero; if any test
+    fails, STOP and report — do not edit tests to make them pass). Gate 6 +
+    the synthetic TEST_MODE run together satisfy the automated half of
+    SDK-06 (identical grouping/run_summary); the live read-only half is the
+    08-02 human probe.
+  </action>
+  <verify>
+    <automated>bash scripts/run_6_gates.sh</automated>
+    <automated>pytest tests/ -v</automated>
+  </verify>
+  <acceptance_criteria>
+    - `bash scripts/run_6_gates.sh` prints `=== ALL 6 GATES PASSED ===` and exits 0
+    - Gate 6 prints its golden-run_summary PASS (21-key structural contract intact)
+    - `pytest tests/ -v` reports 0 failed / 0 errored across the full suite (~1122 tests)
+    - No files under `tests/` other than `tests/golden/baseline_names.json` (from Task 2) are modified
+  </acceptance_criteria>
+  <done>All six gates and the full pytest suite are green under 4.3.0 with zero test changes (SDK-04, SDK-06 automated half).</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| PyPI -> local/CI pip install | Third-party package bytes cross into the runtime |
+| SDK -> billing engine retry path | `ApiError.error.result` internals consumed by pipeline/retry.py |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-08-01 | Tampering | Removing the re-export block breaks the SDK's internal retryable-exception lookup (silently swallowed retries) | mitigate | 4.x `request()` uses `importlib.import_module(__package__+".exceptions")` (D-04/RESEARCH), making the block a proven no-op; `pipeline/retry.py` untouched; `tests/test_smartsheet_retry.py` (17 tests incl. PR #284 5xx cases) green in Gate 3 / full pytest |
+| T-08-02 | Tampering | Gate 1 baseline edit masks a real dropped export | mitigate | Remove EXACTLY `_exc_name` (asserted: count 178->177, name absent); every other baseline name still enforced by Gate 1; `_exc_name` was a `del`'d import-time temp, never public |
+| T-08-SC | Tampering | pip install of `smartsheet-python-sdk==4.3.0` | mitigate | First-party official SDK already in production use (not a new/[ASSUMED] package); exact pin `==4.3.0` (D-01) + PyPI-immutable artifacts; 4.0.1-4.3.0 changelog reviewed 2026-07-21 additive-only (D-02); wheel byte-sizes verified healthy + none yanked (D-03 / CONTEXT Specifics). No new dependency introduced -> no legitimacy checkpoint required |
+</threat_model>
+
+<verification>
+- Gate harness: `bash scripts/run_6_gates.sh` -> `=== ALL 6 GATES PASSED ===`
+- Full suite: `pytest tests/ -v` -> 0 failed
+- Removal proof: `_ss_smartsheet_module` absent from `generate_weekly_pdfs.py`; `import smartsheet.exceptions as ss_exc` retained
+- Baseline proof: `tests/golden/baseline_names.json` has 177 entries, `_exc_name` absent
+- Scope proof: `git diff --name-only` lists only `generate_weekly_pdfs.py` and `tests/golden/baseline_names.json`
+- `requirements.txt` intentionally UNCHANGED in this plan (pin lifted in 08-02)
+</verification>
+
+<success_criteria>
+- SDK 4.3.0 installed; all in-use SDK symbols resolve (SDK-01, SDK-03)
+- Dead 3.x re-export block removed; py_compile clean (SDK-02)
+- Six gates + full pytest green under 4.3.0, zero test changes (SDK-04)
+- Gate 6 golden run_summary + TEST_MODE synthetic run prove identical structure (SDK-06 automated half)
+</success_criteria>
+
+<output>
+Create `.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-01-SUMMARY.md` when done.
+Record: installed SDK version, exact diff of the removed block, the 178->177
+baseline delta, the six-gate result line, and the full pytest pass count.
+</output>

--- a/.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-01-SUMMARY.md
+++ b/.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-01-SUMMARY.md
@@ -1,0 +1,166 @@
+---
+phase: 08-smartsheet-python-sdk-4-0-0-compatibility-migration
+plan: 01
+subsystem: infra
+tags: [smartsheet-python-sdk, pip, dependency-migration, mypy, pytest, billing-engine]
+
+# Dependency graph
+requires:
+  - phase: 09 (engine modularization)
+    provides: pipeline/ package + 709-line facade (generate_weekly_pdfs.py) that this plan's SDK surface targets
+provides:
+  - smartsheet-python-sdk 4.3.0 installed and smoke-verified against every in-use SDK symbol
+  - Dead 3.x re-export workaround removed from generate_weekly_pdfs.py (D-04)
+  - Gate 1 baseline updated to 177 names (authorized _exc_name removal)
+  - Green six-gate harness + full pytest suite proof under 4.3.0
+affects: [08-02 (requirements.txt pin lift + live-probe + rollout)]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns: []
+
+key-files:
+  created: []
+  modified:
+    - generate_weekly_pdfs.py
+    - tests/golden/baseline_names.json
+
+key-decisions:
+  - "Installed smartsheet-python-sdk==4.3.0 directly via pip (not via requirements.txt, which still pins <4.0.0 until 08-02)"
+  - "Removed generate_weekly_pdfs.py lines 20-46 (the 3.x smartsheet.smartsheet re-export shim) per D-04; kept line 18 (import smartsheet.exceptions as ss_exc) and pipeline/retry.py untouched"
+  - "Updated tests/golden/baseline_names.json 178 -> 177 entries, removing exactly _exc_name (an import-time temp, never public API)"
+
+patterns-established: []
+
+requirements-completed: [SDK-01, SDK-02, SDK-03, SDK-04, SDK-06]
+
+# Metrics
+duration: 12min
+completed: 2026-07-22
+---
+
+# Phase 08 Plan 01: SDK 4.3.0 Install + Dead Re-export Removal Summary
+
+**smartsheet-python-sdk upgraded 3.9.0 -> 4.3.0 in the environment; dead 3.x `smartsheet.smartsheet` re-export shim deleted from the production billing engine; six-gate harness and full 1164-test pytest suite green with zero test/fixture changes.**
+
+## Performance
+
+- **Duration:** 12 min
+- **Started:** 2026-07-22T01:26:27Z
+- **Completed:** 2026-07-22T01:37:41Z (execution) — SUMMARY finalized shortly after
+- **Tasks:** 3 completed
+- **Files modified:** 2 (`generate_weekly_pdfs.py`, `tests/golden/baseline_names.json`)
+
+## Accomplishments
+
+- `smartsheet-python-sdk==4.3.0` installed directly (`pip install`, not via `requirements.txt`); resolved version confirmed `4.3.0`; smoke-verified all four retryable exception classes (`RateLimitExceededError`, `UnexpectedErrorShouldRetryError`, `InternalServerError`, `ServerTimeoutExceededError`), the `smartsheet.smartsheet` submodule, and `smartsheet.models.sheet.Sheet` / `smartsheet.models.folder.Folder` resolve cleanly under 4.3.0.
+- Removed the dead 3.x re-export workaround block (14-line comment + `import smartsheet.smartsheet as _ss_smartsheet_module` + `_exc_name` re-export loop + both `del` statements — 27 lines total) from `generate_weekly_pdfs.py`. Lines 17-18 (`import smartsheet`, `import smartsheet.exceptions as ss_exc`) and `pipeline/retry.py` are untouched.
+- Updated `tests/golden/baseline_names.json` from 178 to 177 entries, removing exactly `_exc_name` (the authorized Gate 1 adjustment per D-04/T-08-02).
+- Ran the full six-gate behavior-neutrality harness (`bash scripts/run_6_gates.sh`) under 4.3.0: **`=== ALL 6 GATES PASSED ===`**.
+- Ran the full verbose pytest suite (`pytest tests/ -v`) under 4.3.0: **1164 passed, 130 subtests passed, 0 failed** — with zero test/fixture edits (only the golden baseline count file, as authorized).
+- `requirements.txt` intentionally left unchanged (still `>=3.1.0,<4.0.0`) per the plan's ordering constraint — the pin lift is Plan 08-02.
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Install SDK 4.3.0 into the env and smoke-verify every in-use symbol** — no commit (environment-only change; no repo files modified, confirmed via `git status --short`)
+2. **Task 2: Remove the dead 3.x re-export block and update the Gate 1 baseline** - `b2e76bf` (fix)
+3. **Task 3: Run the full six-gate harness and complete pytest suite under 4.3.0** — no commit (verification-only; `git status --short` clean after)
+
+_Note: This plan has no separate plan-metadata commit — SUMMARY.md is committed as the final worktree commit per parallel-executor convention (STATE.md/ROADMAP.md excluded, owned by the orchestrator)._
+
+## Six-Gate Harness Result (full output line)
+
+```
+=== Gate 1: AST import equality ===
+PASS: all 177 baseline names present
+=== Gate 2: Facade completeness ===
+PASS: all 108 allowlist names resolve
+=== Gate 3: pytest ===
+1164 passed, 130 subtests passed in 12.85s
+=== Gate 4: mypy delta ===
+PASS: mypy delta neutral or improved (56 -> 58)
+=== Gate 5: py_compile ===
+PASS: py_compile clean
+=== Gate 6: golden run_summary ===
+PASS: run_summary.json structure matches baseline (21 keys)
+=== ALL 6 GATES PASSED ===
+```
+
+## Full Pytest Result
+
+```
+1164 passed, 130 subtests passed in 10.45s
+```
+(run with `PYTHONUTF8=1 PYTHONIOENCODING=utf-8` — same encoding posture `run_6_gates.sh` forces; see Issues Encountered below)
+
+## Removed Block (exact diff)
+
+```diff
+ import smartsheet
+ import smartsheet.exceptions as ss_exc
+ 
+-# Upstream SDK workaround: smartsheet-python-sdk 3.8.0 raises an
+-# AttributeError from smartsheet.smartsheet.Smartsheet._request_with_retry
+-# whenever the API returns a retryable error (429, 5xx). At
+-# smartsheet/smartsheet.py:303 it does
+-# ``getattr(sys.modules[__name__], native.result.name)`` to look up the
+-# exception class to raise, but that module's top-level imports only
+-# expose ApiError / HttpError / UnexpectedRequestError. The retryable
+-# exception classes (RateLimitExceededError, UnexpectedErrorShouldRetry-
+-# Error, InternalServerError, ServerTimeoutExceededError, SystemMainte-
+-# nanceError) live in smartsheet.exceptions and were never re-exported
+-# into smartsheet.smartsheet, so the getattr fails and our retry
+-# wrapper never gets the real exception. Re-export the missing names
+-# here so the SDK's internal lookup succeeds. The ``if not hasattr``
+-# guard makes this a no-op if the upstream SDK ever re-exports them.
+-import smartsheet.smartsheet as _ss_smartsheet_module
+-_exc_name = None
+-for _exc_name in (
+-    'RateLimitExceededError',
+-    'UnexpectedErrorShouldRetryError',
+-    'InternalServerError',
+-    'ServerTimeoutExceededError',
+-    'SystemMaintenanceError',
+-):
+-    if not hasattr(_ss_smartsheet_module, _exc_name) and hasattr(ss_exc, _exc_name):
+-        setattr(_ss_smartsheet_module, _exc_name, getattr(ss_exc, _exc_name))
+-del _ss_smartsheet_module
+-del _exc_name
+ from dotenv import load_dotenv
+```
+
+## Files Created/Modified
+
+- `generate_weekly_pdfs.py` - removed the dead 3.x SDK re-export shim (27 lines); import surface now just `import smartsheet` + `import smartsheet.exceptions as ss_exc`
+- `tests/golden/baseline_names.json` - dropped `_exc_name` (178 -> 177 entries), the Gate 1 frozen name-set adjustment authorized by D-04
+
+## Decisions Made
+
+- Installed 4.3.0 directly via `pip install "smartsheet-python-sdk==4.3.0"` rather than touching `requirements.txt`, exactly as the plan's critical ordering constraint requires (the `<4.0.0` pin stays until 08-02).
+- No new dependency was introduced (first-party SDK already in production use), so no package-legitimacy checkpoint was required per the plan's threat model (T-08-SC).
+
+## Deviations from Plan
+
+None - plan executed exactly as written. Both authorized deletions (the 27-line re-export block, the single `_exc_name` baseline entry) match the plan's `<interfaces>` section byte-for-byte.
+
+## Issues Encountered
+
+- **Gate 4 (`scripts/check_mypy_delta.sh`) raw count moved 56 -> 58, masked by a pre-existing CRLF bug in `tests/golden/mypy_baseline_count.txt`.** Investigated by running `mypy` directly and diffing against `tests/golden/mypy_baseline.txt` with line numbers stripped: the actual type-error set is byte-identical (22 errors in 5 files, same messages) before and after this plan's changes. The +2 raw-line delta is exclusively 2 extra "annotation-unchecked" NOTE-level lines for `pipeline/orchestrate.py` (a file this plan never touched — confirmed via `git diff --stat`) plus a "checked 21 -> 22 source files" summary artifact, most likely because SDK 4.3.0 changes what mypy's import graph pulls in. Zero new type ERRORS. The CRLF byte in the checked-in baseline count file (pre-dating this plan) causes bash's `-gt` integer comparison to silently no-op inside an `if` condition (exempt from `set -e`), so Gate 4 always prints PASS on this Windows/Git-Bash environment regardless of the true comparison. This is a pre-existing tooling bug unrelated to the SDK migration — logged to `.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/deferred-items.md` per the executor SCOPE BOUNDARY rule (not fixed; out of this plan's authorized file list).
+- **One full-suite pytest run failed transiently on `test_startup_banner_printed_once`** when run without first exporting `PYTHONUTF8=1`/`PYTHONIOENCODING=utf-8` in the shell (a `UnicodeDecodeError` in the subprocess reader thread decoding the engine's emoji startup banner under Windows cp1252). Re-running with those two env vars set — exactly the posture `scripts/run_6_gates.sh` already forces for this documented reason (see CLAUDE.md / Living Ledger note on Windows cp1252 emoji banners) — reproduced a clean `1164 passed, 130 subtests passed, 0 failed`. Not a regression from this plan; a pre-existing Windows console-encoding environment condition.
+
+## User Setup Required
+
+None - no external service configuration required.
+
+## Next Phase Readiness
+
+- SDK 4.3.0 is installed and proven behavior-neutral (six gates + full suite green); the dead 3.x facade shim is gone.
+- `requirements.txt` still pins `>=3.1.0,<4.0.0` by design — Plan 08-02 lifts the pin to `==4.3.0`, adds the live read-only probe (D-05), and executes the D-06 rollout sequence.
+- No blockers for 08-02.
+
+---
+*Phase: 08-smartsheet-python-sdk-4-0-0-compatibility-migration*
+*Completed: 2026-07-22*

--- a/.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-01-SUMMARY.md
+++ b/.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-01-SUMMARY.md
@@ -164,3 +164,12 @@ None - no external service configuration required.
 ---
 *Phase: 08-smartsheet-python-sdk-4-0-0-compatibility-migration*
 *Completed: 2026-07-22*
+
+## Self-Check: PASSED
+
+- FOUND: generate_weekly_pdfs.py
+- FOUND: tests/golden/baseline_names.json
+- FOUND: .planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-01-SUMMARY.md
+- FOUND: .planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/deferred-items.md
+- FOUND: commit b2e76bf (fix(08-01): remove dead 3.x SDK re-export workaround)
+- FOUND: commit 39d7f0e (docs(08-01): complete SDK 4.3.0 install + dead-block removal plan)

--- a/.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-02-PLAN.md
+++ b/.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-02-PLAN.md
@@ -19,9 +19,10 @@ user_setup:
 
 must_haves:
   truths:
-    - "requirements.txt pins smartsheet-python-sdk==4.3.0 exactly (no range, no <4.0.0)"
-    - "memory-bank/living-ledger.md records the migration: exact pin landed, dead block removed, commit hash, six-gate + live-probe evidence"
-    - "A live read-only SKIP_UPLOAD=true probe on 4.3.0 confirms real Sheets.get_sheet + attachment list + real error-shape with no regression, writing nothing to Smartsheet"
+    - "D-01/D-02: requirements.txt pins smartsheet-python-sdk==4.3.0 exactly (no range, no <4.0.0) — the changelog-reviewed exact-pin decision"
+    - "D-01: memory-bank/living-ledger.md records the migration: exact pin landed, dead block removed, commit hash, six-gate + live-probe evidence, and the exact-pin transport-dep rule"
+    - "D-05: A live read-only SKIP_UPLOAD=true probe on 4.3.0 confirms real Sheets.get_sheet + attachment list + real error-shape with no regression, writing nothing to Smartsheet"
+    - "D-06/D-07: The staged rollout (branch dry-run -> weekday merge after green cron -> one watched canary dispatch) and the revert-PR rollback protocol are documented as runbook steps, not executed in this phase"
   artifacts:
     - path: "requirements.txt"
       provides: "Exact SDK pin, emergency <4.0.0 ceiling lifted"

--- a/.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-02-PLAN.md
+++ b/.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-02-PLAN.md
@@ -1,0 +1,274 @@
+---
+phase: 08-smartsheet-python-sdk-4-0-0-compatibility-migration
+plan: 02
+type: execute
+wave: 2
+depends_on: ["08-01"]
+files_modified:
+  - requirements.txt
+  - memory-bank/living-ledger.md
+  - CLAUDE.md
+autonomous: false
+requirements: [SDK-03, SDK-05, SDK-06]
+user_setup:
+  - service: smartsheet
+    why: "The D-05 live read-only probe reads real production Smartsheet on SDK 4.3.0 to catch error-shape drift mocks cannot"
+    env_vars:
+      - name: SMARTSHEET_API_TOKEN
+        source: "Existing production token (.env / operator shell) — reused, not created"
+
+must_haves:
+  truths:
+    - "requirements.txt pins smartsheet-python-sdk==4.3.0 exactly (no range, no <4.0.0)"
+    - "memory-bank/living-ledger.md records the migration: exact pin landed, dead block removed, commit hash, six-gate + live-probe evidence"
+    - "A live read-only SKIP_UPLOAD=true probe on 4.3.0 confirms real Sheets.get_sheet + attachment list + real error-shape with no regression, writing nothing to Smartsheet"
+  artifacts:
+    - path: "requirements.txt"
+      provides: "Exact SDK pin, emergency <4.0.0 ceiling lifted"
+      contains: "smartsheet-python-sdk==4.3.0"
+    - path: "memory-bank/living-ledger.md"
+      provides: "Dated post-implementation migration entry"
+      contains: "smartsheet-python-sdk==4.3.0"
+  key_links:
+    - from: "requirements.txt"
+      to: "the resolved install environment"
+      via: "pip resolves exactly 4.3.0 (no other version satisfies ==4.3.0)"
+      pattern: "smartsheet-python-sdk==4\\.3\\.0"
+    - from: "D-05 live probe"
+      to: "pipeline/retry.py ApiError introspection"
+      via: "real SDK error shape validated against exc.error.result.code/.status_code"
+      pattern: "SKIP_UPLOAD"
+---
+
+<objective>
+Lift the temporary `>=3.1.0,<4.0.0` emergency pin to the exact
+`smartsheet-python-sdk==4.3.0` (SDK-05), record the migration in the Living
+Ledger, and close the phase with the D-05 live read-only Smartsheet probe on
+4.3.0 (SDK-06 live half) plus the D-06 rollout / D-07 rollback runbook.
+
+Purpose: SDK-05 requires the pin lifted ONLY AFTER SDK-01..04 pass — which
+08-01 proved with a green six-gate + full pytest run. SDK-06 requires a
+real-transport confirmation that mocks cannot give, because
+`tests/test_smartsheet_retry.py` builds `ApiError.error.result` with
+`mock.Mock()` and TEST_MODE never touches the wire.
+
+Output: `requirements.txt` with the exact pin; a dated Living Ledger entry;
+a signed-off live read-only probe result; the merge-window + canary +
+rollback runbook captured for the operator.
+
+Depends on 08-01 (Wave 1): the migrated engine + green automated proof must
+exist before the pin is lifted and before the live probe runs.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-CONTEXT.md
+@.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-PATTERNS.md
+
+<interfaces>
+<!-- Concrete edit targets. No exploration required. -->
+
+requirements.txt (current lines 4-8 — the ONLY dependency change this phase):
+  Line 4  # Core Dependencies
+  Line 5  # 3.1.0+ required for Folders.get_folder_children ...
+  Line 6  # Upper bound excludes the breaking 4.0.0 (2026-06-08) major release ...
+  Line 7  # smartsheet.exceptions + Folders.get_folder/list_folders + Templates ...
+  Line 8  smartsheet-python-sdk>=3.1.0,<4.0.0        <-- becomes  ==4.3.0
+
+Living Ledger append convention (memory-bank/living-ledger.md tail):
+  ## [YYYY-MM-DD HH:MM] <short imperative title>
+  <1-2 sentence context: phase/branch/commit>
+  - **<Rule name>:** <durable, generalizable rule>
+  Most recent entries: [2026-07-21 18:20] (exact-pin rule, --no-binary retired)
+  and [2026-07-21 19:10] (planning start). This plan APPENDS the
+  post-implementation entry — cross-reference the 18:20 --no-binary retirement,
+  do not restate it.
+
+Live probe target — the real transport surface (read-only):
+  SKIP_UPLOAD=true python generate_weekly_pdfs.py
+  Exercises real client.Sheets.get_sheet(...), client.Attachments.list_row_attachments(...),
+  and real ApiError shapes through pipeline/retry.py — writes NOTHING back to
+  Smartsheet (no attachment upload, no delete). Bound the run with WR_FILTER
+  and/or MAX_GROUPS to keep it fast while still hitting the live API.
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Lift the emergency pin to the exact ==4.3.0</name>
+  <files>requirements.txt</files>
+  <read_first>
+    - requirements.txt (current lines 1-29; the pin is line 8)
+    - .planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-CONTEXT.md (D-01/D-02: exact pin rationale; D-08: target is ==4.3.0 NOT >=4.0.0, and NO --no-binary comment)
+    - .planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-PATTERNS.md (requirements.txt comment convention: short 2-4 line comment, ledger holds the narrative)
+  </read_first>
+  <action>
+    Replace `smartsheet-python-sdk>=3.1.0,<4.0.0` (line 8) with the exact pin
+    `smartsheet-python-sdk==4.3.0`. Replace the existing 3-line comment
+    (lines 5-7, which describes the now-lifted `<4.0.0` ceiling) with a
+    concise 3-4 line comment that records: (1) this is an EXACT pin, not a
+    range — it extends the 260608-gwm "upper-bound transport-critical deps"
+    Living Ledger rule to its strongest form per D-01, so an unreviewed
+    release can never auto-enter production; (2) 4.0.1->4.3.0 changelog
+    reviewed 2026-07-21, additive-only; (3) a pointer to
+    `memory-bank/living-ledger.md` for the full rationale. Do NOT mention
+    `--no-binary` (obsolete per D-03) and do NOT use a range operator. Keep
+    the `# Core Dependencies` header. Leave every other line of
+    requirements.txt unchanged.
+  </action>
+  <verify>
+    <automated>python -c "import re,sys; t=open('requirements.txt').read(); m=re.search(r'^smartsheet-python-sdk(.*)$', t, re.M); spec=(m.group(1).strip() if m else ''); print('SPEC:',spec); sys.exit(0 if spec=='==4.3.0' else 1)"</automated>
+    <automated>python -c "t=open('requirements.txt').read(); assert '<4.0.0' not in t and '--no-binary' not in t, 'stale pin/flag present'; print('CLEAN')"</automated>
+  </verify>
+  <acceptance_criteria>
+    - `requirements.txt` contains the line `smartsheet-python-sdk==4.3.0` (exact, no range)
+    - `requirements.txt` does NOT contain `<4.0.0`, `>=4.0.0`, or `--no-binary`
+    - The pin's comment mentions the exact-pin rule and points to `memory-bank/living-ledger.md`
+    - `git diff --name-only` shows only `requirements.txt` changed by this task
+  </acceptance_criteria>
+  <done>The emergency ceiling is replaced by the exact ==4.3.0 pin with a coherent comment (SDK-05 config half).</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Append the Living Ledger migration entry and refresh CLAUDE.md if stale</name>
+  <files>memory-bank/living-ledger.md, CLAUDE.md</files>
+  <read_first>
+    - memory-bank/living-ledger.md (tail ~60 lines: the [2026-07-21 18:20] and [2026-07-21 19:10] entries — mirror their header/bullet shape)
+    - .planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-PATTERNS.md (post-implementation ledger entry checklist)
+    - CLAUDE.md "Build, Test, and Run Commands -> Python core engine" section (discretionary refresh target)
+  </read_first>
+  <action>
+    Append a new dated `## [YYYY-MM-DD HH:MM]` entry to the BOTTOM of
+    `memory-bank/living-ledger.md` (use the actual current date/time)
+    recording: (1) the exact pin `smartsheet-python-sdk==4.3.0` landed,
+    replacing the `<4.0.0` emergency range; (2) the dead 3.x re-export block
+    removed from `generate_weekly_pdfs.py` and the authorized Gate 1 baseline
+    delta (`_exc_name`, 178->177); (3) the commit hash(es) of the 08-01 code
+    change; (4) verification evidence — six-gate harness result + live
+    read-only probe result (fill the probe result after Task 3); (5) an
+    explicit cross-reference that `--no-binary` is retired (already recorded
+    in the 18:20 entry — reference it, do not duplicate). Follow the ledger's
+    bolded-rule-name bullet convention.
+
+    CLAUDE.md is DISCRETIONARY (D-08): `grep -rn "smartsheet-python-sdk"
+    CLAUDE.md` currently returns zero matches, so there is likely nothing
+    stale to fix. Only touch CLAUDE.md if you find a stale SDK version or
+    `--no-binary` reference; if so, add a one-line note inside the existing
+    `pip install -r requirements.txt` fenced block that local dev needs
+    `pip install "smartsheet-python-sdk==4.3.0"`. Do NOT add a new heading
+    and do NOT restate the ledger narrative. If grep is clean, leave CLAUDE.md
+    untouched and note "no CLAUDE.md change needed" in the SUMMARY.
+  </action>
+  <verify>
+    <automated>python -c "t=open('memory-bank/living-ledger.md',encoding='utf-8').read(); assert 'smartsheet-python-sdk==4.3.0' in t, 'ledger missing pin'; print('LEDGER_OK')"</automated>
+    <automated>grep -rn "smartsheet-python-sdk" CLAUDE.md || echo "CLAUDE_MD_CLEAN (no SDK ref — no change required)"</automated>
+  </verify>
+  <acceptance_criteria>
+    - `memory-bank/living-ledger.md` ends with a new dated entry containing `smartsheet-python-sdk==4.3.0`
+    - The entry records the block removal, the 178->177 baseline delta, and the six-gate + live-probe evidence
+    - CLAUDE.md is either unchanged (grep clean) OR has a single one-line install note added inside the existing pip-install block — never a new heading
+  </acceptance_criteria>
+  <done>The migration is durably recorded in the Living Ledger; CLAUDE.md is refreshed only if it was stale (SDK-05 docs half).</done>
+</task>
+
+<task type="checkpoint:human-verify" gate="blocking-human">
+  <name>Task 3: Live read-only Smartsheet probe on 4.3.0 + rollout/rollback runbook</name>
+  <files>(no repo file edits — production-touch verification; results captured in the SUMMARY)</files>
+  <read_first>
+    - .planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-CONTEXT.md (D-05 live probe, D-06 rollout, D-07 rollback)
+    - pipeline/retry.py (the ApiError introspection the probe validates against a real response)
+    - .planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-VALIDATION.md (Manual-Only Verifications row)
+  </read_first>
+  <what-built>
+    SDK 4.3.0 is installed, the dead re-export block is removed, Gate 1 is
+    rebaselined (177 names), all six gates + full pytest are green (08-01),
+    and the exact pin + Living Ledger entry are in place (Tasks 1-2). What
+    remains is the one thing automation cannot prove: that 4.3.0's REAL
+    Smartsheet responses (success shapes AND error shapes) match what
+    pipeline/retry.py expects — mocks in tests/test_smartsheet_retry.py use
+    mock.Mock() and TEST_MODE never hits the wire.
+  </what-built>
+  <action>
+    Production-touch verification — the operator (Juan) runs it; Claude
+    prepares the exact command and expected observations, then pauses. Run
+    against real Smartsheet on the branch, READ-ONLY (writes nothing):
+    (1) Confirm `pip show smartsheet-python-sdk` reports Version 4.3.0 and
+    SMARTSHEET_API_TOKEN is set. (2) Run a bounded read-only dry-run — bash:
+    `SKIP_UPLOAD=true WR_FILTER=<one or two known WRs> MAX_GROUPS=5 python
+    generate_weekly_pdfs.py`; PowerShell: set `$env:SKIP_UPLOAD="true"`,
+    `$env:WR_FILTER="<WRs>"`, `$env:MAX_GROUPS="5"`, then run the script.
+    This performs real `Sheets.get_sheet` + `Attachments.list_row_attachments`
+    calls and writes Excel LOCALLY under `generated_docs/`, with NO attachment
+    upload/delete on Smartsheet (SKIP_UPLOAD=true is the write-suppression
+    guard). (3) Confirm the run completes with no ModuleNotFoundError /
+    AttributeError / unexpected retry-path exception, real rows are fetched,
+    and Excel files are produced. If the run raises any SDK error-shape
+    exception (e.g. AttributeError on `exc.error.result`), STOP — that is the
+    real drift the probe exists to catch; capture it as a gap. (4) Record the
+    D-06 rollout runbook for the operator (do NOT execute now): merge in a
+    weekday DAYTIME window immediately after a green scheduled run — never in
+    the Sunday-night window before the Monday 05:00 UTC weekly deep run — then
+    fire ONE manual workflow_dispatch canary (a normal idempotent production
+    run) and watch it go green. (5) Record the D-07 rollback runbook: revert
+    the PR (restores the `<4.0.0` pin; the pip cache auto-busts on the
+    requirements.txt hash), then optionally one confirm dispatch.
+  </action>
+  <verify>
+    <human-check>Operator runs the bounded `SKIP_UPLOAD=true` dry-run against real Smartsheet on 4.3.0; confirms exit 0, real rows fetched, Excel generated under generated_docs/, ZERO writes to Smartsheet, and no SDK error-shape exception.</human-check>
+    <automated>pip show smartsheet-python-sdk | grep -i "^Version: 4.3.0"</automated>
+  </verify>
+  <acceptance_criteria>
+    - The bounded `SKIP_UPLOAD=true` run completes with exit 0 against real Smartsheet on 4.3.0
+    - Real rows are fetched and Excel files are generated under `generated_docs/`; ZERO uploads/deletes hit Smartsheet
+    - No `ModuleNotFoundError` / `AttributeError` / unexpected retry-path exception surfaces (real error shape matches pipeline/retry.py)
+    - The D-06 rollout and D-07 rollback steps are recorded in the SUMMARY for the operator
+  </acceptance_criteria>
+  <done>Live read-only probe green on real 4.3.0 transport (SDK-03 real path, SDK-06 live half); rollout/rollback runbook captured.</done>
+  <resume-signal>Type "approved" (probe green) or paste the exception/observed drift to open a gap.</resume-signal>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| requirements.txt -> CI/local install resolution | The pin governs which SDK bytes reach production |
+| billing engine -> real Smartsheet API | The live probe crosses into production data (read path) |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-08-03 | Tampering / Integrity | Live probe accidentally WRITES to production Smartsheet (attachment upload/delete) during validation | mitigate | Probe is `SKIP_UPLOAD=true` (reads prod, writes nothing) and human-gated (operator-run); bounded via WR_FILTER/MAX_GROUPS; canary (D-06) is a normal idempotent production run |
+| T-08-04 | Tampering | A future unreviewed SDK release auto-enters production | mitigate | Exact pin `==4.3.0` (D-01) makes any bump a deliberate reviewed PR; ledger records the exact-pin rule for all transport-critical deps |
+| T-08-05 | Repudiation / DoS | Real 4.3.0 error-shape drift silently breaks retry/backoff (mocks blind to it) | mitigate | D-05 live probe exercises the REAL `ApiError.error.result` path through pipeline/retry.py; any drift raises and is captured as a gap before merge |
+| T-08-SC | Tampering | pip resolves the pinned `smartsheet-python-sdk==4.3.0` | accept | First-party official SDK, exact-pinned to an immutable PyPI artifact already verified in 08-01 (wheel healthy, changelog additive, not yanked — D-02/D-03); no new package introduced |
+</threat_model>
+
+<verification>
+- Pin: `smartsheet-python-sdk==4.3.0` present; `<4.0.0` / `>=4.0.0` / `--no-binary` absent
+- Ledger: new dated entry contains `smartsheet-python-sdk==4.3.0` + block-removal + evidence
+- Live probe: bounded `SKIP_UPLOAD=true` run green against real Smartsheet, zero writes
+- Scope: `git diff --name-only` lists only `requirements.txt`, `memory-bank/living-ledger.md` (and CLAUDE.md only if it was stale)
+</verification>
+
+<success_criteria>
+- Exact pin `==4.3.0` in requirements.txt, emergency ceiling lifted (SDK-05)
+- Living Ledger records the migration with evidence (SDK-05)
+- Live read-only probe proves real 4.3.0 transport + error shapes match (SDK-03 real path, SDK-06 live half)
+- Rollout (D-06) + rollback (D-07) runbook captured for the operator
+</success_criteria>
+
+<output>
+Create `.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-02-SUMMARY.md` when done.
+Record: the requirements.txt diff, the ledger entry text, the live-probe
+command + result (rows fetched, Excel generated, zero writes), and the
+D-06/D-07 runbook steps for the operator.
+</output>

--- a/.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-02-SUMMARY.md
+++ b/.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-02-SUMMARY.md
@@ -1,0 +1,155 @@
+---
+phase: 08-smartsheet-python-sdk-4-0-0-compatibility-migration
+plan: 02
+subsystem: infra
+tags: [smartsheet-python-sdk, pip, dependency-migration, living-ledger, live-probe]
+
+# Dependency graph
+requires:
+  - phase: 08-01
+    provides: smartsheet-python-sdk 4.3.0 installed, dead 3.x re-export shim removed, green six-gate + full pytest proof
+provides:
+  - Exact pin smartsheet-python-sdk==4.3.0 in requirements.txt (emergency <4.0.0 ceiling lifted)
+  - Living Ledger entries recording the migration and the D-05 live-probe sign-off
+  - Operator-run live read-only probe proving real 4.3.0 transport + error shapes
+  - D-06 rollout runbook and D-07 rollback runbook captured for the operator
+  - Deferred-item record of a pre-existing (non-SDK) SKIP_UPLOAD delete-before-skip defect
+affects: []
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns: []
+
+key-files:
+  created:
+    - .planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-02-SUMMARY.md
+  modified:
+    - requirements.txt
+    - memory-bank/living-ledger.md
+    - .planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/deferred-items.md
+
+key-decisions:
+  - "Exact pin smartsheet-python-sdk==4.3.0 (no range), per D-01, lifting the >=3.1.0,<4.0.0 emergency ceiling"
+  - "CLAUDE.md left unchanged — grep confirmed zero stale smartsheet-python-sdk references (D-08 discretion, no-op)"
+  - "SKIP_UPLOAD delete-before-skip defect deferred, not fixed inline — pre-existing on 3.x, out of this plan's compat-only file list; self-healing withheld-hash behavior means no data loss"
+  - "Operator approved the live probe with the finding recorded, not treated as SDK regression"
+
+patterns-established: []
+
+requirements-completed: [SDK-03, SDK-05, SDK-06]
+
+# Metrics
+duration: ~20min active (across two sessions, separated by an operator-run checkpoint pause)
+completed: 2026-07-22
+---
+
+# Phase 08 Plan 02: SDK Pin Lift + Living Ledger + Live Probe Summary
+
+**Emergency `<4.0.0` pin lifted to the exact `smartsheet-python-sdk==4.3.0`; migration recorded in the Living Ledger; operator-run live read-only probe confirms real 4.3.0 transport is green against production Smartsheet, with one pre-existing (non-SDK) SKIP_UPLOAD finding captured and deferred.**
+
+## Performance
+
+- **Duration:** ~20 min of active executor work, split across two sessions separated by the Task 3 `checkpoint:human-verify` pause (operator ran the live probe independently)
+- **Started:** 2026-07-21T21:31:11-05:00 (first commit, Task 1)
+- **Completed:** 2026-07-22T10:26:39-05:00 (last commit, ledger sign-off)
+- **Tasks:** 3 completed (2 auto + 1 checkpoint:human-verify)
+- **Files modified:** 3 (`requirements.txt`, `memory-bank/living-ledger.md`, `deferred-items.md`)
+
+## Accomplishments
+
+- Replaced `smartsheet-python-sdk>=3.1.0,<4.0.0` with the exact `smartsheet-python-sdk==4.3.0` in `requirements.txt`, with a comment recording the exact-pin rule, the changelog review date, and a pointer to the Living Ledger.
+- Appended a dated Living Ledger entry recording the migration: exact pin landed, dead re-export block removed (08-01), Gate 1 baseline delta (178→177), and the six-gate/pytest evidence.
+- Confirmed `CLAUDE.md` needed no change (`grep -rn "smartsheet-python-sdk" CLAUDE.md` returned zero matches both before and after) — correctly left untouched per D-08 discretion.
+- Operator (Juan) ran the D-05 bounded read-only live probe against real production Smartsheet on 4.3.0 and it came back **green** for every SDK-facing criterion.
+- Captured a pre-existing (not SDK-caused) `SKIP_UPLOAD` defect discovered by the probe in `deferred-items.md`, and recorded a second Living Ledger entry signing off the probe result plus the finding.
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Lift the emergency pin to the exact ==4.3.0** — `76e2471` (fix)
+2. **Task 2: Append the Living Ledger migration entry (CLAUDE.md checked, no change needed)** — `038816c` (docs)
+3. **Task 3: Live read-only Smartsheet probe on 4.3.0 + rollout/rollback runbook** — operator-run probe (no repo edits per plan's `<files>` spec for this task); follow-up documentation commits: `a31121d` (deferred-items.md finding) and `aa55b6b` (Living Ledger sign-off)
+
+**Plan metadata:** this SUMMARY commit (parallel-executor convention — STATE.md/ROADMAP.md excluded, owned by the orchestrator)
+
+## Files Created/Modified
+
+- `requirements.txt` — exact pin `smartsheet-python-sdk==4.3.0` replaces the `>=3.1.0,<4.0.0` emergency ceiling; comment records the exact-pin rule + changelog review date + ledger pointer
+- `memory-bank/living-ledger.md` — two new dated entries: `[2026-07-22 02:31]` (migration landed) and `[2026-07-22 10:20]` (D-05 live-probe sign-off + SKIP_UPLOAD finding)
+- `.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/deferred-items.md` — new section documenting the pre-existing SKIP_UPLOAD delete-before-skip defect, self-healing behavior, and suggested future fix
+
+## D-05 Live Probe Result (operator-run 2026-07-22 ~10:07 CDT)
+
+**Command:** `SKIP_UPLOAD=true WR_FILTER=84157414,89881161 MAX_GROUPS=5 python generate_weekly_pdfs.py` (SDK version confirmed `4.3.0` via `python -m pip show smartsheet-python-sdk`)
+
+**Result: PASSED** for all SDK-facing criteria:
+- Real transport green end-to-end: all source sheets fetched, "Grouping validation passed: 2771 groups", target-sheet map 676 WRs (sheet `5723337641643908`), PPP map 545 WRs (sheet `8162920222379908`).
+- 676 target-row + 545 PPP attachment-list calls completed via the retry wrapper in 12.8s/9.5s (8 workers), 0 cancelled.
+- 5 Excel files generated locally under `generated_docs/` (WR 84157414 ×3 weeks, WR 89881161 ×2 weeks); totals validation printed; "Session complete!".
+- Zero `ModuleNotFoundError` / `AttributeError` / retry-path exceptions. No SDK error-shape drift observed — `pipeline/retry.py`'s `ApiError.error.result` introspection matches the real 4.3.0 response shape.
+
+**Approved-with-finding (recorded, not treated as SDK drift):**
+- `SKIP_UPLOAD=true` gates only the UPLOAD half of the delete-then-upload sequence, not the DELETE half. The run deleted 2 prior primary attachments on the production target sheet (WR 89881161, weeks 072025 and 081725) and then correctly skipped the re-upload. This is pre-existing engine behavior, identical on 3.x — unrelated to the 4.3.0 migration.
+- Self-healing confirmed in the log: the hash-history write was withheld for all 5 groups ("upload did not complete — they will regenerate next run"), so the next scheduled weekday cron run will regenerate and re-upload both files. Operator decision: wait for cron, no manual restore performed.
+- Full detail and suggested fix logged in `deferred-items.md` (see "08-02: SKIP_UPLOAD deletes prior attachments before skipping upload").
+
+## D-06 Rollout Runbook (recorded for the operator, not executed this plan)
+
+1. This plan's `SKIP_UPLOAD=true` dry-run (above) already serves as rollout step 1 (reads prod, writes nothing) — complete.
+2. Merge in a weekday **daytime** window immediately after a green scheduled run. Do **not** merge in the Sunday-night window before the Monday 05:00 UTC weekly deep run.
+3. Fire **one** manual `workflow_dispatch` canary and watch it go green before walking away. The canary is a normal idempotent production run — no special flags needed.
+
+## D-07 Rollback Runbook (recorded for the operator, not executed this plan)
+
+1. Revert the PR. This restores the `>=3.1.0,<4.0.0` pin; the pip cache auto-busts on the `requirements.txt` hash, so no manual cache-clear is needed.
+2. Optionally fire one confirm `workflow_dispatch` dispatch to verify the reverted state is green.
+3. No other rollback machinery is required — this migration made zero workflow-file or retry-logic changes (D-03/D-04).
+
+## Decisions Made
+
+- **Exact pin, not a range** (D-01): `smartsheet-python-sdk==4.3.0` makes any future SDK bump a deliberate, changelog-reviewed PR — extends the 260608-gwm "upper-bound transport-critical deps" rule to its strongest form.
+- **CLAUDE.md untouched**: grep confirmed no stale SDK reference existed before or after this plan; the D-08 discretionary refresh was correctly a no-op.
+- **SKIP_UPLOAD finding deferred, not fixed inline**: fixing the delete/upload gate coupling is a real behavior change to `pipeline/upload.py`, outside this plan's compat-only, zero-behavior-change scope, and it's a pre-existing defect (identical on 3.x) rather than something this migration introduced. The self-healing withheld-hash mechanism means no attachment is permanently lost — the next cron run regenerates and re-uploads.
+- **Operator approved with finding**: the checkpoint was resolved "approved" with the finding explicitly recorded (not silently ignored, not treated as an SDK regression).
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+None — no Rule 1/2/3 auto-fixes were needed. The one unplanned discovery (the SKIP_UPLOAD delete-before-skip behavior) was surfaced by the operator during the plan's own designed verification step (D-05 live probe) and was explicitly out-of-scope to fix per the plan's compat-only, zero-behavior-change mandate and the executor SCOPE BOUNDARY rule (pre-existing behavior unrelated to this plan's authorized changes) — it was documented in `deferred-items.md` and the Living Ledger instead, exactly as the coordinator instructed.
+
+---
+
+**Total deviations:** 0 auto-fixed. One pre-existing defect discovered and deferred per plan design (the D-05 probe's entire purpose is to surface exactly this class of finding).
+**Impact on plan:** None on scope. The SDK migration itself is fully proven behavior-neutral (six gates + full pytest + real-transport live probe, all green). The deferred SKIP_UPLOAD finding is a separate, pre-existing issue for a future plan.
+
+## Issues Encountered
+
+None beyond the documented deferred item above. The checkpoint pause between Task 2 and Task 3 (operator running the live probe independently) was expected, designed behavior — not an issue.
+
+## User Setup Required
+
+None further. The `SMARTSHEET_API_TOKEN` env var referenced in this plan's `user_setup` frontmatter was the operator's existing production token, reused (not created) for the live probe, which the operator has already run successfully.
+
+## Next Phase Readiness
+
+- Phase 08 (smartsheet-python-sdk 4.0.0 Compatibility Migration) is functionally complete: SDK 4.3.0 installed, dead 3.x shim removed, exact pin lifted, six-gate + full pytest green, real-transport live probe green, Living Ledger fully records the migration.
+- **Operator action still pending (D-06, not part of this plan's scope):** merge this branch in a weekday daytime window after a green scheduled run, then fire one watched `workflow_dispatch` canary. This is the actual production rollout — deliberately not executed as part of plan 08-02.
+- **Tracked for a future plan (not blocking):** the SKIP_UPLOAD delete-before-skip defect in `pipeline/upload.py` (see `deferred-items.md`). Low/medium priority — self-healing prevents data loss, but the flag's name currently overpromises "read-only."
+- No blockers for closing Phase 08.
+
+---
+*Phase: 08-smartsheet-python-sdk-4-0-0-compatibility-migration*
+*Completed: 2026-07-22*
+
+## Self-Check: PASSED
+
+- FOUND: requirements.txt (contains `smartsheet-python-sdk==4.3.0`)
+- FOUND: memory-bank/living-ledger.md (contains both new dated entries)
+- FOUND: .planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/deferred-items.md (SKIP_UPLOAD section present)
+- FOUND: commit 76e2471 (fix(08-02): lift emergency SDK pin to exact ==4.3.0)
+- FOUND: commit 038816c (docs(08-02): record SDK 4.3.0 migration in Living Ledger)
+- FOUND: commit a31121d (docs(08-02): log SKIP_UPLOAD delete-before-skip defect)
+- FOUND: commit aa55b6b (docs(08-02): record D-05 live-probe sign-off in Living Ledger)

--- a/.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-CHECK-RESULT.md
+++ b/.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-CHECK-RESULT.md
@@ -1,0 +1,67 @@
+## VERIFICATION PASSED
+
+**Phase:** 08-smartsheet-python-sdk-4-0-0-compatibility-migration
+**Plans verified:** 2 (08-01-PLAN.md, 08-02-PLAN.md)
+**Status:** All checks passed (2 non-blocking warnings noted)
+
+### Coverage Summary
+
+| Requirement | Plans | Covering Task(s) | Status |
+|---|---|---|---|
+| SDK-01 (exception classes resolve under target SDK) | 08-01 | Task 1 (smoke-verify 4 exception classes) | Covered |
+| SDK-02 (re-export workaround reconciled) | 08-01 | Task 2 (remove dead block, keep `ss_exc` import) | Covered |
+| SDK-03 (call sites verified compatible) | 08-01, 08-02 | 08-01 T1/T3 (automated) + 08-02 T3 (live probe, real `Sheets.get_sheet`/`Attachments.*`) | Covered |
+| SDK-04 (full pytest passes) | 08-01 | Task 3 (`pytest tests/ -v`, zero test changes) | Covered |
+| SDK-05 (pin lifted only after SDK-01..04 pass) | 08-02 | Task 1 (exact `==4.3.0`), sequenced via `depends_on: ["08-01"]` | Covered |
+| SDK-06 (identical output proof) | 08-01, 08-02 | 08-01 T3 (Gate 6 + TEST_MODE synthetic, automated half) + 08-02 T3 (live read-only probe, live half) | Covered |
+
+All 6 roadmap requirement IDs (SDK-01..06) appear in plan frontmatter `requirements:` fields and have concrete, verifiable covering tasks — not just tag references.
+
+### Plan Summary
+
+| Plan | Tasks | Files Modified | Wave | Status |
+|---|---|---|---|---|
+| 08-01 | 3 (all `auto`) | 2 (generate_weekly_pdfs.py, tests/golden/baseline_names.json) | 1 | Valid |
+| 08-02 | 3 (2 `auto` + 1 `checkpoint:human-verify`) | 3 (requirements.txt, memory-bank/living-ledger.md, CLAUDE.md-conditional) | 2 | Valid |
+
+### Fact-Checks Performed Against Live Repository (all confirmed accurate)
+
+- `generate_weekly_pdfs.py` lines 1-55 read directly: removal target (lines 20-46) and keep-lines (17-19, 47+) match the plan's `<interfaces>` block byte-for-byte.
+- `requirements.txt` lines 4-8 read directly: current pin `>=3.1.0,<4.0.0` and comment match the plan's stated "current state."
+- `tests/golden/baseline_names.json` currently has exactly 178 entries including `_exc_name` — confirms the planned 178→177 delta is accurate.
+- `scripts/check_api_equality.py` read directly: confirms "FAILS only on MISSING baseline name" mechanics claimed in the plan's Gate 1 interface notes.
+- `scripts/check_facade_completeness.py` read directly: confirms `_exc_name` is not part of the facade allowlist (Gate 2 unaffected by its removal).
+- `scripts/run_6_gates.sh` read directly: confirms the exact 6-gate sequence (AST equality → facade completeness → pytest → mypy delta → py_compile → golden run_summary) matches the plan's description.
+- `pipeline/retry.py` read directly: confirms `_TRANSIENT_EXC`, `_api_error_code`, `_http_status_code`, `smartsheet_call_with_retry`, and the `import smartsheet.exceptions as ss_exc` contract cited in both plans' interfaces/threat models.
+- `tests/test_smartsheet_retry.py` and `tests/test_billing_audit_shadow.py` read directly: confirm the `mock.Mock()` blind-spot claim (D-05 live-probe rationale) and the `smartsheet.smartsheet` / `smartsheet.exceptions` import dependencies cited.
+- `CLAUDE.md` grep confirmed zero matches for `smartsheet-python-sdk` — matches the plan's "likely no-op" discretionary handling for Task 2 of 08-02.
+- `git rev-list --left-right --count master...origin/master` → `0 0` — confirms RESEARCH.md's "master diverged 10/10" open question is now moot (stale, not a live blocker).
+
+### Context Compliance (08-CONTEXT.md D-01..D-08) — all honored
+
+- D-01/D-02 (exact `==4.3.0` pin, changelog-reviewed rationale): 08-02 Task 1 implements exactly this; no range operator used.
+- D-03 (no workflow-file changes, `--no-binary` obsolete): neither plan's `files_modified` touches any `.github/workflows/*.yml`; 08-01 Task 1 action explicitly says "do NOT pass `--no-binary`."
+- D-04 (remove dead re-export block; line 18 `ss_exc` import stays; `pipeline/retry.py` untouched): 08-01 Task 2 implements exactly this scope, with an explicit "do NOT touch" callout for `pipeline/retry.py` and the `except ss_exc.*` blocks.
+- D-05 (six-gate proof + live read-only probe): split correctly across 08-01 Task 3 (automated) and 08-02 Task 3 (live probe) — this is a correct decomposition of a single decision across two sequenced plans, not a scope reduction.
+- D-06/D-07 (rollout/rollback runbook): captured as documented (not executed) runbook steps in 08-02 Task 3, consistent with "record, do NOT execute now."
+- D-08 (research staleness corrections): plans correctly use `==4.3.0` (not `>=4.0.0`), correctly omit `--no-binary`, and correctly reference the post-Phase-09 `pipeline/retry.py` location rather than stale monolith line numbers.
+- Deferred idea (CI import-smoke line) is correctly absent from both plans — no scope creep.
+- No scope-reduction language found (grepped both plans for "v1", "future enhancement", "stub", "not wired to", "placeholder", etc. — zero matches).
+
+### Warnings (non-blocking, should fix for hygiene)
+
+**1. [research_resolution] 08-RESEARCH.md's "## Open Questions" section is not marked resolved**
+- File: `08-RESEARCH.md` (lines 378-395)
+- The section lacks the `(RESOLVED)` heading suffix and neither of its two questions has an inline `RESOLVED` marker.
+- Mitigating factor: Question 1 (upstream wheel-packaging fix status) is functionally answered by CONTEXT.md D-01/D-02/D-03's 2026-07-21 live re-research (4.0.1 fixed the wheel; target is now `==4.3.0`; no `--no-binary` needed). Question 2 (master/origin divergence) is confirmed moot — `git rev-list --left-right --count master...origin/master` returns `0 0` today. Both plans correctly build on the fresh CONTEXT.md answers rather than the stale RESEARCH.md text, so execution is not at risk — this is a paper-trail gap, not a planning defect.
+- Fix hint: Add `(RESOLVED)` to the RESEARCH.md heading and one-line inline resolutions cross-referencing CONTEXT.md D-01/D-02/D-03 (Q1) and the confirmed 0/0 branch state (Q2), for audit-trail completeness. Does not block execution.
+
+**2. [nyquist_compliance / check 8b] Full-suite automated verify commands exceed the generic 30s feedback-latency guidance**
+- Plans: 08-01 (Task 3), 08-02 (indirectly via wave-level sampling in 08-VALIDATION.md)
+- `bash scripts/run_6_gates.sh` (~150s) and `pytest tests/ -v` (~120s, ~1122 tests) both exceed the dimension's generic 30-second warning threshold.
+- Mitigating factor: 08-VALIDATION.md already deliberately sets `Max feedback latency: 180 seconds` for this phase and orders the six gates cheapest-first (AST equality, facade completeness before the full pytest run), which is a considered, documented tradeoff for a full-regression-critical dependency migration — not an oversight.
+- Fix hint: No action required; noting for completeness per the Nyquist dimension's literal rule. If tightening further is desired, a `pytest -x -q` fast-fail subset could run before the full `-v` pass (already partially achieved via the "after every task commit" quick-run command in 08-VALIDATION.md).
+
+### Recommendation
+
+No blockers. Plans are ready for execution as-is. The two warnings above are optional documentation-hygiene follow-ups and do not gate `/gsd:execute-phase 08`.

--- a/.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-CONTEXT.md
+++ b/.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-CONTEXT.md
@@ -1,0 +1,168 @@
+# Phase 08: smartsheet-python-sdk 4.x Compatibility Migration - Context
+
+**Gathered:** 2026-07-21
+**Status:** Ready for planning
+
+<domain>
+## Phase Boundary
+
+Compat-only migration of the production billing engine off the temporary
+`smartsheet-python-sdk>=3.1.0,<4.0.0` emergency pin (hotfix 260608-gwm /
+PR #273) onto SDK **4.3.0**, with **zero behavior change** to the
+Smartsheet → Excel → Smartsheet pipeline. Explicitly NOT a redesign,
+optimization, or retry-logic change. Target change surface is deliberately
+tiny: `requirements.txt`, removal of one dead facade block, ledger/docs
+notes. **No GitHub Actions workflow edits** (locked decision D-03).
+
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### Target version & pin shape (discussed 2026-07-21)
+- **D-01:** Pin **exact**: `smartsheet-python-sdk==4.3.0`. Not a range.
+  Rationale: the June 2026 crash happened because an unreviewed release
+  auto-entered production; exact pin makes that structurally impossible.
+  This EXTENDS the Living Ledger 260608-gwm rule (upper-bound
+  transport-critical deps) to its strongest form: exact-pin + deliberate
+  reviewed bumps.
+- **D-02:** 4.3.0 chosen over 4.0.2 because the 4.0.1→4.3.0 changelog was
+  reviewed live on 2026-07-21 and every change is additive; only 4.3.0
+  grazes in-use models (new `proof` field on `Row`, new template case in
+  `PaginatedChildrenResult.append_data`) — additive, low risk. Zero
+  changes to `smartsheet.exceptions`, `ApiError`/`error.result` internals,
+  or any in-use call signature across 4.0.1–4.3.0.
+
+### CI install posture (discussed 2026-07-21)
+- **D-03:** **No workflow-file changes.** The 08-RESEARCH.md `--no-binary`
+  prescription is OBSOLETE: the 4.0.0 wheel packaging bug was fixed in
+  4.0.1 (upstream issue #144; wheel sizes verified 2026-07-21: 4.0.0 =
+  7,842 B broken; 4.0.1–4.3.0 = 259–271 KB healthy). PyPI artifacts are
+  immutable, so the exact-pinned 4.3.0 wheel cannot regress. An
+  import-smoke CI step was considered and REJECTED as redundant with the
+  exact pin (revisit only when a future bump PR shows packaging anomalies).
+
+### Code change scope
+- **D-04:** Remove the dead 3.x re-export workaround block in
+  `generate_weekly_pdfs.py` (the `import smartsheet.smartsheet as
+  _ss_smartsheet_module` block, currently ~lines 30–45; research verdict
+  "remove", still valid post-Phase-09). Line 18
+  `import smartsheet.exceptions as ss_exc` STAYS. Zero changes to
+  `pipeline/retry.py` classification logic or any `except ss_exc.*` path.
+  `tests/test_billing_audit_shadow.py:65` imports `smartsheet.smartsheet`
+  directly — module still exists in 4.x, no test change expected (SDK-04
+  research finding stands).
+
+### Behavior-neutrality proof (discussed 2026-07-21)
+- **D-05:** Pre-merge proof = **full `scripts/run_6_gates.sh` on 4.3.0**
+  (AST equality, facade completeness, pytest, mypy delta, py_compile,
+  golden run_summary) **PLUS a live read-only probe** against real
+  Smartsheet on 4.3.0 (real `Sheets.get_sheet`, attachment list, and an
+  error-shape sanity check). The live probe exists because
+  `tests/test_smartsheet_retry.py` builds `ApiError.error.result` with
+  `mock.Mock()` — mocked tests cannot catch real SDK error-shape drift,
+  and TEST_MODE synthetic runs never touch the transport at all.
+
+### Rollout & rollback (discussed 2026-07-21)
+- **D-06:** Rollout sequence: (1) SKIP_UPLOAD real-data dry-run on the
+  branch (reads prod, writes nothing); (2) merge in a weekday daytime
+  window immediately after a green scheduled run (do NOT merge in the
+  Sunday-night window before the Monday 05:00 UTC weekly deep run);
+  (3) fire ONE manual workflow_dispatch canary and watch it green before
+  walking away. Canary is a normal idempotent production run.
+- **D-07:** Rollback protocol: revert PR (restores the `<4.0.0` pin; pip
+  cache auto-busts on the requirements.txt hash), then optionally one
+  confirm dispatch. No other rollback machinery needed.
+
+### Research refresh obligations for the planner
+- **D-08:** Treat `08-RESEARCH.md` (2026-06-08, self-expired 2026-07-08)
+  as authoritative on the 4.0.0 root cause and in-use surface audit, but
+  STALE on: (a) `--no-binary` — obsolete per D-03; (b) target version —
+  now 4.3.0 per D-01/D-02; (c) all `generate_weekly_pdfs.py` line
+  references — pre-Phase-09 monolith numbering; the retry `except` blocks
+  it references were consolidated into `pipeline/retry.py` (v1.3.1) and
+  extended by PR #284 (`_RETRYABLE_HTTP_STATUS` + `_http_status_code()`
+  ApiError introspection); (d) SDK-05 requirement text — pin target is
+  `==4.3.0` with NO workflow comment about `--no-binary`.
+
+### Claude's Discretion
+- Exact `requirements.txt` comment wording (must record review date +
+  exact-pin rationale pointer to the ledger).
+- Live-probe implementation shape: throwaway script vs committed
+  `scripts/` utility — planner decides; keep it read-only either way.
+- Living Ledger entry wording; whether CLAUDE.md's local-dev install note
+  needs the (now plain) `pip install` guidance refreshed.
+- Whether SDK-06's "identical output" evidence is satisfied by Gate 6 +
+  the SKIP_UPLOAD dry-run in D-06 step 1 (recommended) or needs a formal
+  A/B compare — planner's call within the D-05/D-06 envelope.
+
+</decisions>
+
+<canonical_refs>
+## Canonical References
+
+**Downstream agents MUST read these before planning or implementing.**
+
+### Phase definition & research
+- `.planning/ROADMAP.md` § Phase 08 — goal, SDK-01..06 requirements, success criteria
+- `.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-RESEARCH.md` — 4.0.0 surface audit (read WITH the D-08 staleness corrections)
+
+### Code that must survive unchanged
+- `pipeline/retry.py` — the transient-retry exception contract (typed `ss_exc.*` set, `_RETRYABLE_API_CODES`, `_RETRYABLE_HTTP_STATUS`, `_api_result_code()`, `_http_status_code()`); depends on `ApiError.error.result` internals
+- `tests/test_smartsheet_retry.py` — 17 tests incl. PR #284's 5xx cases; documents the mocked `error.result` shape
+- `generate_weekly_pdfs.py` lines 17–18 (SDK imports, keep) and ~30–45 (re-export block, REMOVE per D-04)
+
+### Proof harness
+- `scripts/run_6_gates.sh` — the six-gate behavior-neutrality oracle (Gates: AST equality, facade completeness, pytest, mypy delta, py_compile, golden run_summary)
+
+### Files to change
+- `requirements.txt` lines 7–8 — pin + comment (only dependency change)
+- `memory-bank/living-ledger.md` — 260608-gwm entry to extend; append the new dated migration entry here
+
+### Explicitly out of scope (do not edit)
+- `.github/workflows/weekly-excel-generation.yml`, `.github/workflows/system-health-check.yml` — D-03: no install-step changes
+
+</canonical_refs>
+
+<code_context>
+## Existing Code Insights
+
+### Reusable Assets
+- `scripts/run_6_gates.sh`: calibrated Phase 09 harness; re-runnable as-is (forces PYTHONUTF8=1 for Windows)
+- `pipeline/retry.py::smartsheet_call_with_retry`: centralized retry — the ONLY place ApiError internals are introspected; a live probe exercising it covers the whole pipeline's error-handling dependency
+- TEST_MODE (synthetic, no token) and SKIP_UPLOAD (real reads, no writes) run modes for staged validation
+
+### Established Patterns
+- Additive/surgical changes only; `pytest tests/ -v` gates push (Claude Code pre-push hook)
+- Conventional Commits; PR body needs Objective / Changes Made / Production Safety Check
+- Living Ledger append (dated `[YYYY-MM-DD HH:MM]`) in the same PR as the code change
+
+### Integration Points
+- SDK import sites post-Phase-09: `generate_weekly_pdfs.py:17-18,34`, `pipeline/retry.py:67`, `pipeline/orchestrate.py:40`; `pipeline/fetch.py` / `pipeline/discovery.py` consume the SDK only via `smartsheet_call_with_retry`
+- `tests/test_billing_audit_shadow.py:65` imports `smartsheet.smartsheet` (exists in 4.x — no change)
+
+</code_context>
+
+<specifics>
+## Specific Ideas
+
+Verified facts from the 2026-07-21 live re-research (planner need not refetch):
+- Release timeline: 4.0.0 (06-08, broken wheel) → 4.0.1 (06-09, packaging fix #144) → 4.0.2 (06-10) → 4.1.0 (06-26) → 4.2.0 (07-09) → 4.3.0 (07-20)
+- Wheel sizes (PyPI JSON): 4.0.0 = 7,842 B; 4.0.1 = 259,410 B; 4.0.2 = 259,431 B; 4.1.0 = 266,410 B; 4.2.0 = 268,439 B; 4.3.0 = 270,661 B; none yanked
+- 4.0.1→4.3.0 changelog: entirely additive to surfaces this codebase does not use, EXCEPT 4.3.0's additive `Row.proof` field and `PaginatedChildrenResult.append_data` template case (both in-use models, additive only)
+
+</specifics>
+
+<deferred>
+## Deferred Ideas
+
+- CI post-install import-smoke verification line — rejected for this phase
+  (redundant with exact pin); reconsider as part of any FUTURE SDK bump PR
+  checklist if packaging anomalies reappear.
+
+</deferred>
+
+---
+
+*Phase: 08-smartsheet-python-sdk-4-0-0-compatibility-migration*
+*Context gathered: 2026-07-21*

--- a/.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-DISCUSSION-LOG.md
+++ b/.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-DISCUSSION-LOG.md
@@ -1,0 +1,90 @@
+# Phase 08: smartsheet-python-sdk 4.x Compatibility Migration - Discussion Log
+
+> **Audit trail only.** Do not use as input to planning, research, or execution agents.
+> Decisions are captured in CONTEXT.md — this log preserves the alternatives considered.
+
+**Date:** 2026-07-21
+**Phase:** 08-smartsheet-python-sdk-4-0-0-compatibility-migration
+**Areas discussed:** Target version & pin shape, Wheel-bug posture in CI, Behavior-neutrality proof depth, Rollout & rollback strategy
+
+**Mode note:** Advisor mode (research-backed comparison tables). The four
+gsd-advisor-researcher subagents failed to spawn (transient org
+billing/access issue, resolved later in session); research was performed
+inline by the main session instead — PyPI JSON wheel-size verification,
+upstream CHANGELOG.md review for 4.0.1→4.3.0, and repo inspection of
+`scripts/run_6_gates.sh`, `pipeline/retry.py`, `tests/test_smartsheet_retry.py`,
+and the workflow install steps.
+
+---
+
+## Target version & pin shape
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| ==4.3.0 exact | Deterministic; all deltas reviewed 2026-07-21; future bumps are deliberate PRs | ✓ |
+| ==4.0.2 exact | Closest to June research; starts 3 minors behind with no risk benefit | |
+| >=4.3,<5 range | Auto-takes future 4.x — re-opens the unreviewed-release path that caused the June crash | |
+| >=4.0.2,<5 range | Widest compat; same unreviewed-drift risk, worse | |
+
+**User's choice:** ==4.3.0 exact (recommended option)
+**Notes:** Extends the Living Ledger 260608-gwm transport-dep rule from
+"upper-bound" to "exact-pin + deliberate reviewed bumps".
+
+---
+
+## Wheel-bug posture in CI
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| No workflow change | Wheel bug fixed in 4.0.1 (#144); exact pin freezes a verified-good immutable artifact | ✓ |
+| Add import-smoke line | One-line post-install verification in both workflows | |
+| Keep --no-binary | Carry the sdist workaround despite the root cause being fixed | |
+
+**User's choice:** No workflow change (recommended option)
+**Notes:** Evidence: PyPI wheel sizes — 4.0.0 = 7,842 B (broken) vs
+4.0.1–4.3.0 = 259–271 KB (healthy). Import-smoke idea preserved as a
+deferred checklist item for future bump PRs.
+
+---
+
+## Behavior-neutrality proof depth
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| 6 gates + live probe | Full Phase 09 harness + read-only real-Smartsheet probe on 4.3.0 (covers mocked-ApiError blind spot), ~15 min | ✓ |
+| 6 gates + SKIP_UPLOAD A/B | Also full read-only pipeline runs on 3.x vs 4.3.0 with output compare, ~40 min | |
+| pytest + TEST_MODE only | Lightest; accepts live-transport blind spot | |
+| Max: everything | All oracles, ~1 hour | |
+
+**User's choice:** 6 gates + live probe (recommended option)
+**Notes:** Grounding: TEST_MODE synthetic path never touches the real SDK;
+retry tests build `error.result` with `mock.Mock()` — neither catches live
+SDK drift, hence the live probe.
+
+---
+
+## Rollout & rollback strategy
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Dry-run + timed merge + canary | SKIP_UPLOAD branch run → weekday merge after green cron → one watched manual dispatch | ✓ |
+| Canary dispatch only | Merge anytime, dispatch one manual run and watch | |
+| Passive watch | Merge; next scheduled cron + Sentry import-crash alert as tripwire | |
+
+**User's choice:** Dry-run + timed merge + canary (recommended option)
+**Notes:** Avoid merging in the Sunday-night window before the Monday
+05:00 UTC weekly deep run. Rollback = revert PR (restores <4.0.0 pin; pip
+cache auto-busts on requirements.txt hash).
+
+---
+
+## Claude's Discretion
+
+- requirements.txt comment wording (record review date + ledger pointer)
+- Live-probe shape: throwaway vs committed `scripts/` utility (read-only either way)
+- Living Ledger entry wording; CLAUDE.md local-install note refresh
+- Whether Gate 6 + the D-06 SKIP_UPLOAD dry-run satisfies SDK-06 or a formal A/B compare is warranted
+
+## Deferred Ideas
+
+- CI post-install import-smoke verification — rejected this phase (redundant with exact pin); revisit on future SDK bump PRs if packaging anomalies reappear.

--- a/.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-HUMAN-UAT.md
+++ b/.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-HUMAN-UAT.md
@@ -1,14 +1,14 @@
 ---
-status: partial
+status: complete
 phase: 08-smartsheet-python-sdk-4-0-0-compatibility-migration
 source: [08-VERIFICATION.md]
 started: 2026-07-22T17:30:00Z
-updated: 2026-07-22T17:30:00Z
+updated: 2026-07-22T21:24:22Z
 ---
 
 ## Current Test
 
-[awaiting human confirmation]
+[testing complete — resolved as Test 5 of 08-UAT.md (full-UAT session, pass)]
 
 ## Tests
 
@@ -31,14 +31,17 @@ deletes. The only real-delete exposure remains NON-test-mode
 SKIP_UPLOAD runs — already logged in deferred-items.md (WR 89881161,
 self-restoring via cron).
 
-result: [pending]
+result: pass
+resolved: 2026-07-22 via 08-UAT.md Test 5 — Juan confirmed no lingering
+attachment loss on target sheet 5723337641643908 (WR 89881161 self-healed
+via cron regeneration; WR 89708709 / WR 90093002 intact).
 
 ## Summary
 
 total: 1
-passed: 0
+passed: 1
 issues: 0
-pending: 1
+pending: 0
 skipped: 0
 blocked: 0
 

--- a/.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-HUMAN-UAT.md
+++ b/.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-HUMAN-UAT.md
@@ -1,0 +1,45 @@
+---
+status: partial
+phase: 08-smartsheet-python-sdk-4-0-0-compatibility-migration
+source: [08-VERIFICATION.md]
+started: 2026-07-22T17:30:00Z
+updated: 2026-07-22T17:30:00Z
+---
+
+## Current Test
+
+[awaiting human confirmation]
+
+## Tests
+
+### 1. No lingering production-attachment loss from Gate-6 / TEST_MODE runs (WR 89708709, WR 90093002 on target sheet 5723337641643908)
+
+expected: Either the two fixture WRs have no matching attachments on the
+target sheet (no-op), or any prior loss already self-healed via the
+withheld-hash → next-cron regeneration path (as with the WR 89881161
+D-05 probe finding). No manual restore needed.
+
+orchestrator analysis (2026-07-22): deletion from TEST_MODE runs is
+structurally impossible — `delete_old_excel_attachments` is only invoked
+from an upload task carrying a `target_row` (pipeline/orchestrate.py:2140),
+upload tasks only exist for WRs found in `target_map`, and `target_map` is
+built only `if not TEST_MODE` (pipeline/orchestrate.py:595). In TEST_MODE
+the map is empty, so no delete path can execute regardless of token
+presence. The D-05 probe log corroborates the gate: WR 84157414 (not in
+target sheet) produced "not found in target sheet" warnings and zero
+deletes. The only real-delete exposure remains NON-test-mode
+SKIP_UPLOAD runs — already logged in deferred-items.md (WR 89881161,
+self-restoring via cron).
+
+result: [pending]
+
+## Summary
+
+total: 1
+passed: 0
+issues: 0
+pending: 1
+skipped: 0
+blocked: 0
+
+## Gaps

--- a/.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-PATTERNS.md
+++ b/.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-PATTERNS.md
@@ -1,0 +1,311 @@
+# Phase 08: smartsheet-python-sdk 4.3.0 Compatibility Migration - Pattern Map
+
+**Mapped:** 2026-07-21
+**Files analyzed:** 3 confirmed modify targets + 1 discretionary (CLAUDE.md) + 0 new files
+**Analogs found:** 4 / 4
+
+> **Scope note:** Per 08-CONTEXT.md (D-01–D-08), this is a compat-only pin
+> bump. There are NO new files, NO new components/services/controllers, and
+> NO GitHub Actions workflow edits (D-03 — `--no-binary` is obsolete, upstream
+> fixed the wheel in 4.0.1). The "closest analog" for every touched file is
+> unusually strong: this repo already ran the *mirror-image* change (adding
+> the `<4.0.0` pin) as quick-task `260608-gwm`, whose PLAN/SUMMARY are read
+> directly below as the primary analog. The live read-only probe (D-05) is
+> **not a new file** — 08-VALIDATION.md already specifies it as a manual
+> `SKIP_UPLOAD=true` dry-run step, not a committed script.
+
+## File Classification
+
+| New/Modified File | Role | Data Flow | Closest Analog | Match Quality |
+|-------------------|------|-----------|-----------------|---------------|
+| `requirements.txt` (lines 4-8) | config (dependency manifest) | batch (one-time resolution at install) | `.planning/quick/260608-gwm-.../260608-gwm-PLAN.md` Task 1 (the pin's own predecessor edit, same file, same lines) | exact — same file, same lines, mirror-image change |
+| `generate_weekly_pdfs.py` (lines 20-46, dead re-export block) | script / SDK import site | request-response (client init at module load) | Same file, lines 1-60 (current live state) + `260608-gwm-PLAN.md` `<interfaces>` block (documents the block being removed, as it looked when added) | exact — literal removal target, already read in full |
+| `memory-bank/living-ledger.md` (append) | docs / append-only ledger | event-driven (dated entry per change) | `260608-gwm-SUMMARY.md` Task 2 (Living Ledger append action) + existing 2026-07-21 18:20 / 19:10 entries already in the ledger | exact — same file, same append convention, same phase's own prior entries |
+| `CLAUDE.md` (discretionary — local-dev install note) | docs / config | N/A | CLAUDE.md "Build, Test, and Run Commands → Python core engine" section | role-match — only touch if a stale `--no-binary` or version note exists (grep confirms it does NOT — see Metadata) |
+
+**No files are created in this phase.** `pipeline/retry.py` and
+`tests/test_smartsheet_retry.py` are read-only reference contracts (must
+survive byte-for-byte unchanged per D-04/canonical_refs) — included below
+under Shared Patterns for context, not as edit targets.
+
+---
+
+## Pattern Assignments
+
+### `requirements.txt` (config, batch)
+
+**Analog:** the file's own prior edit in `260608-gwm-PLAN.md` Task 1 (2026-06-08, added the `<4.0.0` ceiling this phase now replaces).
+
+**Current state** (read 2026-07-21, lines 4-8):
+```
+# Core Dependencies
+# 3.1.0+ required for Folders.get_folder_children (replacement for deprecated get_folder)
+# Upper bound excludes the breaking 4.0.0 (2026-06-08) major release, which removed
+# smartsheet.exceptions + Folders.get_folder/list_folders + Templates and changed pagination.
+smartsheet-python-sdk>=3.1.0,<4.0.0
+```
+
+**Prior-edit pattern to mirror** (from `260608-gwm-PLAN.md` Task 1 — this is
+literally how the last SDK-pin edit to this exact file was specified and
+verified):
+```
+Change line N of requirements.txt from:
+    smartsheet-python-sdk>=3.1.0
+to:
+    smartsheet-python-sdk>=3.1.0,<4.0.0
+
+Keep the existing explanatory comment coherent and extend it so a future
+operator understands BOTH bounds.
+```
+
+**Apply for Phase 08** (per D-01/D-02, exact pin — comment wording is
+Claude's Discretion per D-08 but must record review date + ledger pointer):
+```
+smartsheet-python-sdk==4.3.0
+```
+Comment must state: (1) this is an EXACT pin, not a range — extends the
+260608-gwm "upper-bound transport-critical deps" rule to its strongest form
+per D-01; (2) 4.0.1-4.3.0 changelog reviewed 2026-07-21, additive only; (3)
+pointer to `memory-bank/living-ledger.md` for full rationale (do not restate
+the whole ledger entry inline — this file's own convention, established by
+260608-gwm, is a short 2-4 line comment + the ledger holds the narrative).
+
+**Verify pattern to mirror** (from `260608-gwm-PLAN.md` Task 1 `<verify>`,
+adapted to exact-pin matching instead of range matching):
+```python
+python -c "import re,sys; t=open('requirements.txt').read(); m=re.search(r'^smartsheet-python-sdk(.*)$', t, re.M); spec=m.group(1) if m else ''; ok=(spec.strip()=='==4.3.0'); print('SPEC:', spec.strip()); sys.exit(0 if ok else 1)"
+```
+
+---
+
+### `generate_weekly_pdfs.py` lines 20-46 (script, SDK import site — removal only)
+
+**Analog:** the block's own addition, documented verbatim in
+`260608-gwm-PLAN.md`'s `<interfaces>` section — this phase performs the
+exact inverse operation.
+
+**Current live content** (Read directly, lines 17-47 — this IS the removal
+target, already fully captured, do not re-read):
+```python
+17  import smartsheet
+18  import smartsheet.exceptions as ss_exc
+19
+20  # Upstream SDK workaround: smartsheet-python-sdk 3.8.0 raises an
+21  # AttributeError from smartsheet.smartsheet.Smartsheet._request_with_retry
+22  # whenever the API returns a retryable error (429, 5xx). At
+23  # smartsheet/smartsheet.py:303 it does
+24  # ``getattr(sys.modules[__name__], native.result.name)`` to look up the
+25  # exception class to raise, but that module's top-level imports only
+26  # expose ApiError / HttpError / UnexpectedRequestError. The retryable
+27  # exception classes (RateLimitExceededError, UnexpectedErrorShouldRetry-
+28  # Error, InternalServerError, ServerTimeoutExceededError, SystemMainte-
+29  # nanceError) live in smartsheet.exceptions and were never re-exported
+30  # into smartsheet.smartsheet, so the getattr fails and our retry
+31  # wrapper never gets the real exception. Re-export the missing names
+32  # here so the SDK's internal lookup succeeds. The ``if not hasattr``
+33  # guard makes this a no-op if the upstream SDK ever re-exports them.
+34  import smartsheet.smartsheet as _ss_smartsheet_module
+35  _exc_name = None
+36  for _exc_name in (
+37      'RateLimitExceededError',
+38      'UnexpectedErrorShouldRetryError',
+39      'InternalServerError',
+40      'ServerTimeoutExceededError',
+41      'SystemMaintenanceError',
+42  ):
+43      if not hasattr(_ss_smartsheet_module, _exc_name) and hasattr(ss_exc, _exc_name):
+44          setattr(_ss_smartsheet_module, _exc_name, getattr(ss_exc, _exc_name))
+45  del _ss_smartsheet_module
+46  del _exc_name
+47  from dotenv import load_dotenv
+```
+
+**Removal action (D-04):** Delete lines 20-46 in full (the comment block +
+the `import smartsheet.smartsheet as _ss_smartsheet_module` line + the
+re-export loop + both `del` statements). Lines 17-18 (`import smartsheet`,
+`import smartsheet.exceptions as ss_exc`) and line 47 onward stay byte-for-
+byte unchanged. Confirmed by 08-RESEARCH.md SDK-02: SDK 4.x's `request()`
+uses `importlib.import_module(__package__ + ".exceptions")`, making this
+workaround a permanent no-op — safe to delete, not just leave inert.
+
+**Do NOT touch (explicitly out of scope, D-04):**
+- The six `except ss_exc.*` retry blocks elsewhere in the file — zero
+  changes, they resolve `ss_exc.*` directly and never depended on the
+  removed re-export.
+- `pipeline/retry.py` — the centralized retry contract (see Shared Patterns
+  below) — not part of this migration's edit surface at all.
+
+**Verify pattern:**
+```bash
+python -m py_compile generate_weekly_pdfs.py
+pytest tests/ -v -k test_billing_audit_shadow
+```
+
+---
+
+### `memory-bank/living-ledger.md` (docs, append-only)
+
+**Analog:** `260608-gwm-PLAN.md` Task 2 action text (the append convention
+for this exact ledger, same subsystem) + the two entries this same phase
+already added on 2026-07-21 (context-gathering + planning-start), which are
+the most recent and most relevant style reference.
+
+**Existing entries from this same phase (read directly, tail of file —
+extract the header/timestamp convention, do not restate the full history):**
+```
+## [2026-07-21 18:20] Phase 08 SDK 4.x migration — decisions locked; exact-pin rule for transport-critical deps
+
+Phase 08 (lift the `<4.0.0` smartsheet-python-sdk pin) unblocked and context
+gathered (`/gsd-discuss-phase 08`, branch `feat/phase-08-sdk-430-migration`,
+commit `631f757`). Durable rules and facts:
+
+- **Exact-pin rule (extends 260608-gwm):** transport-critical deps get an
+  EXACT pin (`smartsheet-python-sdk==4.3.0`), not just an upper bound. ...
+
+## [2026-07-21 19:10] Phase 08 planning started — validation strategy committed
+...
+```
+
+**Append convention to mirror (header shape, verified across both prior
+entries in this ledger):**
+```
+## [YYYY-MM-DD HH:MM] <short imperative title — what happened>
+
+<1-2 sentence context: which phase/branch/commit>. <Durable rules and facts,
+as bullet points, each bolded with a short rule name:>
+
+- **<Rule name>:** <what changed, why, and the generalizable rule other
+  future changes should follow>.
+```
+
+**Apply for Phase 08 (post-implementation entry — append AFTER the code
+change lands, per the same pattern the 260608-gwm predecessor used of
+appending post-hoc with commit hashes):** record (1) the exact pin
+`==4.3.0` landed, replacing the `<4.0.0` range; (2) the dead re-export block
+removed from `generate_weekly_pdfs.py`; (3) commit hash(es); (4) verification
+evidence (6-gate harness result + live probe result per D-05); (5) explicit
+statement that `--no-binary` is retired (already recorded in the 18:20
+entry — do not duplicate, cross-reference it instead).
+
+**Verify pattern (mirrors 260608-gwm-PLAN.md Task 2 `<verify>`):**
+```python
+python -c "import sys; t=open('memory-bank/living-ledger.md',encoding='utf-8').read(); ok=('smartsheet-python-sdk==4.3.0' in t); print('LEDGER_OK:', ok); sys.exit(0 if ok else 1)"
+```
+
+---
+
+### `CLAUDE.md` (discretionary, docs) — likely NO-OP
+
+**Analog:** "Build, Test, and Run Commands → Python core engine" section
+(already present, shows the current install command).
+
+**Finding:** `grep -rn "smartsheet-python-sdk" CLAUDE.md` returns zero
+matches — CLAUDE.md has never referenced a specific SDK version or
+`--no-binary`, so there is nothing stale to refresh here. Per D-08's
+discretion note, only touch this file if the planner independently decides
+a version pointer adds operator value; the existing pattern for such a
+pointer would be a one-line addition inside the existing `pip install -r
+requirements.txt` fenced block, not a new section — do not add a new
+top-level heading for a one-line fact.
+
+---
+
+## Shared Patterns
+
+### The retry exception contract — READ-ONLY reference, must survive unchanged
+
+**Source:** `pipeline/retry.py` (lines 67, 81-117, 130-155, 158-248)
+**Applies to:** Nothing in this phase modifies this file. Included here
+only so the planner/implementer can confirm the D-05 live probe and D-04
+removal cannot regress it.
+
+```python
+# pipeline/retry.py:67
+import smartsheet.exceptions as ss_exc
+
+# pipeline/retry.py:81-87 — typed exceptions given exponential backoff
+_TRANSIENT_EXC: tuple[type[BaseException], ...] = (
+    ss_exc.UnexpectedErrorShouldRetryError,  # API 4004
+    ss_exc.ServerTimeoutExceededError,       # API 4002
+    ss_exc.SystemMaintenanceError,           # API 4001
+    ss_exc.UnexpectedRequestError,           # SDK wrapper: requests.RequestException
+    ss_exc.HttpError,                        # SDK wrapper: SSLError; base of 500
+)
+
+# pipeline/retry.py:130-155 — ApiError introspection helpers (the exact
+# surface D-05's live probe exists to validate against a REAL response,
+# since tests/test_smartsheet_retry.py mocks exc.error.result with
+# mock.Mock() and cannot catch real SDK error-shape drift)
+def _api_error_code(exc: BaseException) -> int | None:
+    try:
+        return exc.error.result.code  # type: ignore[attr-defined]
+    except AttributeError:
+        return None
+
+def _http_status_code(exc: BaseException) -> int | None:
+    try:
+        return exc.error.result.status_code  # type: ignore[attr-defined]
+    except AttributeError:
+        return None
+```
+
+Per D-02, the 4.0.1-4.3.0 changelog review confirmed zero changes to
+`smartsheet.exceptions`, `ApiError.error.result` internals, or any of the
+above call signatures — this contract is expected to need no code change,
+only the D-05 live-probe confirmation (a `SKIP_UPLOAD=true` dry-run per
+08-VALIDATION.md, not a new script).
+
+### Mocked-shape blind spot — why a live probe exists (reference only)
+
+**Source:** `tests/test_smartsheet_retry.py` (lines 46-66, 152)
+**Applies to:** Explains D-05's rationale; no test file changes required
+(SDK-04 finding: net test changes = zero).
+
+```python
+# tests/test_smartsheet_retry.py:46-49 — mirrors the real SDK shape but
+# is a Mock(), not the live SDK — cannot catch real error-shape drift
+err = mock.Mock()
+err.error.result.code = 4000
+...
+# lines 61-66 — same for the 5xx/status_code path
+err.error.result.status_code = 503
+```
+
+### Living Ledger dated-entry convention
+
+**Source:** `memory-bank/living-ledger.md` (tail, 2026-07-09 and 2026-07-21 entries)
+**Applies to:** The one ledger append this phase makes.
+
+```
+## [YYYY-MM-DD HH:MM] <imperative title>
+
+<narrative context paragraph>
+
+- **<Bolded rule name>:** <durable rule, generalizable beyond this one change>.
+```
+
+---
+
+## No Analog Found
+
+None. Every file in this phase's edit surface (`requirements.txt`,
+`generate_weekly_pdfs.py`, `memory-bank/living-ledger.md`) has a direct,
+same-file, same-lineage predecessor edit (`260608-gwm`) already in the
+repo's history, plus the current live content was read directly for exact
+line numbers. `CLAUDE.md` has no analog because it needs no change (see
+above).
+
+## Metadata
+
+**Analog search scope:** `generate_weekly_pdfs.py` (lines 1-60),
+`requirements.txt` (full, 29 lines), `pipeline/retry.py` (full, 249 lines),
+`tests/test_smartsheet_retry.py` (targeted grep, lines 46-66/152),
+`memory-bank/living-ledger.md` (tail ~60 lines + grep for `260608-gwm`),
+`.planning/quick/260608-gwm-.../260608-gwm-PLAN.md` and `-SUMMARY.md` (full),
+`scripts/check_facade_completeness.py` (full, as a style reference for the
+gate-script family invoked by `scripts/run_6_gates.sh` — confirmed no new
+script is needed per 08-VALIDATION.md's manual-only probe row), CLAUDE.md
+(grep only, zero matches for `smartsheet-python-sdk`).
+**Files scanned:** 9 read/grepped directly; 08-VALIDATION.md confirmed the
+live probe is a manual dry-run, not a new committed file.
+**Pattern extraction date:** 2026-07-21

--- a/.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-REVIEW.md
+++ b/.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-REVIEW.md
@@ -1,0 +1,173 @@
+---
+phase: 08-smartsheet-python-sdk-4-0-0-compatibility-migration
+reviewed: 2026-07-22T16:05:00Z
+depth: standard
+files_reviewed: 5
+files_reviewed_list:
+  - generate_weekly_pdfs.py
+  - memory-bank/living-ledger.md
+  - requirements.txt
+  - tests/golden/baseline_names.json
+  - tests/test_entrypoint_no_double_import.py
+findings:
+  critical: 0
+  warning: 1
+  info: 3
+  total: 4
+status: issues_found
+---
+
+# Phase 08: Code Review Report
+
+**Reviewed:** 2026-07-22T16:05:00Z
+**Depth:** standard
+**Files Reviewed:** 5
+**Status:** issues_found
+
+## Summary
+
+Reviewed the Phase 08 SDK 4.3.0 migration diff (`c48955f..HEAD`): the 27-line
+3.x re-export shim deletion in `generate_weekly_pdfs.py`, the exact pin
+`smartsheet-python-sdk==4.3.0` in `requirements.txt`, the `_exc_name` removal
+from `tests/golden/baseline_names.json`, the env-sanitation change in
+`tests/test_entrypoint_no_double_import.py`, and the appended Living Ledger
+entries.
+
+**Core migration is sound — verified empirically this session:**
+
+- Installed SDK is 4.3.0; `smartsheet.exceptions` exists on 4.3.0 and exposes
+  all 8 exception classes `pipeline/retry.py` depends on (`RateLimitExceededError`,
+  `UnexpectedErrorShouldRetryError`, `InternalServerError`,
+  `ServerTimeoutExceededError`, `SystemMaintenanceError`,
+  `UnexpectedRequestError`, `HttpError`, `ApiError`) — the deleted shim is
+  genuinely dead on 4.x, and the retained `import smartsheet.exceptions as
+  ss_exc` does not crash.
+- No active code uses APIs removed in 4.0 (`Folders.get_folder(`,
+  `list_folders`, `.Templates`) — only `archive/` backup references remain.
+- `scripts/check_api_equality.py` (Gate 1): `PASS: all 177 baseline names
+  present`; `baseline_names.json` has exactly 177 entries, no duplicates,
+  `_exc_name` absent. The removal was mandatory, not optional — Gate 1 fails
+  on `missing = baseline - combined`, so a stale `_exc_name` entry would have
+  broken the gate (the shim's `_exc_name = None` assignment was the only AST
+  top-level source of that name).
+- `python -m py_compile generate_weekly_pdfs.py` clean.
+- `tests/test_smartsheet_retry.py`: 17 passed on 4.3.0.
+- Empty-string env var propagation to a subprocess verified working on
+  Windows (`'ZZ_EMPTY_TEST' in os.environ` → present, `''`), and
+  `pipeline/orchestrate.py:438-442` uses a falsy check (`if not API_TOKEN`)
+  with an explicit `return` after the synthetic branch — the test's
+  empty-string strategy is logically correct. `load_dotenv()` is called with
+  defaults (`override=False`) at `generate_weekly_pdfs.py:24`, so the comment's
+  "load_dotenv never overrides an existing var" claim holds.
+- Living Ledger cross-references verified: commits `b2e76bf` (touches exactly
+  `generate_weekly_pdfs.py` −27 / `baseline_names.json` −1) and `76e2471`
+  (touches exactly `requirements.txt`) exist and match their claims; the
+  178→177 and "facade completeness 108 names" figures match the actual files
+  (`facade_allowlist.json` = 108 entries); `scripts/run_6_gates.sh` and the
+  referenced `deferred-items.md` exist. The D-05 probe entry honestly records
+  the pre-existing `SKIP_UPLOAD` delete-before-skip defect instead of burying
+  it. Note: the diff range contains **two** appended ledger entries
+  ([2026-07-22 02:31] and [2026-07-22 10:20]); the third entry the phase
+  references ([2026-07-21 18:20]) predates the diff base.
+
+**One real defect found:** the changed entrypoint test fails on vanilla
+Windows — reproduced this session — because the parent decodes the child's
+forced-UTF-8 output with cp1252. See WR-01.
+
+## Warnings
+
+### WR-01: Entrypoint test crashes with masked `TypeError` on vanilla Windows — hermeticity fix is incomplete
+
+**File:** `tests/test_entrypoint_no_double_import.py:35-40`
+**Issue:** The phase's stated goal for this file was hermeticity (commit
+`4aa19ff` "make entrypoint banner test hermetic against developer .env"), and
+the token side is fixed — but the test is still environment-sensitive on the
+exact platform its own comment calls out ("emoji banners on Windows cp1252").
+The test forces the **child** to UTF-8 (`PYTHONUTF8=1`,
+`PYTHONIOENCODING=utf-8`) but the **parent's** `subprocess.run(...,
+capture_output=True, text=True)` decodes the pipes with the parent's locale
+codec (cp1252 on vanilla Windows). The child's emoji banner bytes (e.g.
+`0x8f`) are undecodable in cp1252, both `_readerthread`s die with
+`UnicodeDecodeError`, `result.stdout`/`result.stderr` come back `None`, and
+line 40 raises:
+
+```
+TypeError: unsupported operand type(s) for +: 'NoneType' and 'NoneType'
+```
+
+— which masks the real cause AND the test's own diagnostic tail-of-output
+message. Reproduced this session: `python -m pytest
+tests/test_entrypoint_no_double_import.py` → **FAILED** (plain Windows shell);
+`PYTHONUTF8=1 python -m pytest ...` → passed in 1.19s. Consequences: (a) the
+ledger's "1164 passed, 0 failed" verification evidence only reproduces in
+UTF-8 parent environments (Linux CI, or shells with `PYTHONUTF8` set) — a
+vanilla Windows developer gets a confusing failure; (b) the
+`.github/hooks/pre-push-tests.json` Claude Code hook will deny `git push` in
+such sessions on a test that has nothing wrong with the code under test.
+**Fix:** Pin the parent-side decode explicitly:
+
+```python
+result = subprocess.run(
+    [sys.executable, 'generate_weekly_pdfs.py'],
+    cwd=repo_root, env=env,
+    capture_output=True, text=True,
+    encoding='utf-8', errors='replace',
+    timeout=180,
+)
+```
+
+(`errors='replace'` additionally guarantees the reader threads can never die
+mid-stream, so the assertion's diagnostic message always prints.)
+
+## Info
+
+### IN-01: `import smartsheet` / `import smartsheet.exceptions as ss_exc` are now unused in the facade
+
+**File:** `generate_weekly_pdfs.py:17-18`
+**Issue:** The deleted shim was the only in-file consumer of `ss_exc` (and of
+`smartsheet.smartsheet`). After the deletion, neither `smartsheet` nor
+`ss_exc` is referenced anywhere else in the facade (line 87's
+`logging.getLogger('smartsheet.smartsheet')` is a string literal), no test or
+pipeline module accesses `generate_weekly_pdfs.smartsheet` /
+`generate_weekly_pdfs.ss_exc`, and neither name appears in
+`tests/golden/facade_allowlist.json` (Gate 2) or `baseline_names.json`
+(Gate 1 ignores imports). Retention was a deliberate, documented D-04 plan
+decision ("line-18 ss_exc import stays"), so this is informational — but the
+imports now read as load-bearing when they are not, and any F401-style linter
+(e.g. the aspirational `ruff check .`) will flag them.
+**Fix:** In a future cleanup, either remove both imports or annotate the
+retention: `import smartsheet.exceptions as ss_exc  # noqa: F401 — kept per
+D-04; retry contract lives in pipeline/retry.py`.
+
+### IN-02: Exact-pin rationale contradicted by unbounded `sentry-sdk>=2.54.0` one line above
+
+**File:** `requirements.txt:2` (vs. the new comment at lines 5-9)
+**Issue:** The new pin comment states the rule as "an unreviewed SDK release
+can never auto-enter production" — but `sentry-sdk>=2.54.0` directly above
+has no upper bound at all. `sentry_sdk.init` wraps engine startup, so a
+future breaking sentry-sdk major would auto-install on the next CI run and
+could crash the production pipeline at import — the exact failure mode the
+260608-gwm hotfix (smartsheet 4.0.0) was recovering from. Out of this
+phase's change scope, but the phase's own comment now documents a policy the
+adjacent line violates.
+**Fix:** Follow-up: apply at least an upper bound (`sentry-sdk>=2.54.0,<3`)
+under the same 260608-gwm "upper-bound transport-critical deps" ledger rule.
+
+### IN-03: `.github/instructions/copilot-setup.instructions.md` still documents the old `>=3.1.0` pin
+
+**File:** `.github/instructions/copilot-setup.instructions.md:219`
+**Issue:** The line `requirements.txt - Dependencies (sentry-sdk>=2.35.0,
+smartsheet-python-sdk>=3.1.0, etc.)` now contradicts the shipped
+`smartsheet-python-sdk==4.3.0` (and the sentry-sdk floor is also stale —
+actual is `>=2.54.0`). CLAUDE.md requires keeping the `.github` Copilot docs
+in sync with reality; an agent reading this doc would conclude 3.x is still
+acceptable.
+**Fix:** Update the line to `smartsheet-python-sdk==4.3.0` and
+`sentry-sdk>=2.54.0` (or drop the version specifics and point at
+`requirements.txt` as the single source of truth).
+
+---
+
+_Reviewed: 2026-07-22T16:05:00Z_
+_Reviewer: Claude (gsd-code-reviewer)_
+_Depth: standard_

--- a/.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-SECURITY.md
+++ b/.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-SECURITY.md
@@ -1,0 +1,78 @@
+---
+phase: 08
+slug: smartsheet-python-sdk-4-0-0-compatibility-migration
+status: verified
+threats_open: 0
+asvs_level: 1
+created: 2026-07-22
+---
+
+# Phase 08 — Security
+
+> Per-phase security contract: threat register, accepted risks, and audit trail.
+> Register authored at plan time (08-01-PLAN.md + 08-02-PLAN.md `<threat_model>` blocks).
+
+---
+
+## Trust Boundaries
+
+| Boundary | Description | Data Crossing |
+|----------|-------------|---------------|
+| PyPI → local/CI pip install | Third-party package bytes cross into the runtime | SDK wheel (`smartsheet-python-sdk==4.3.0`) |
+| requirements.txt → CI/local install resolution | The pin governs which SDK bytes reach production | Dependency resolution |
+| SDK → billing engine retry path | `ApiError.error.result` internals consumed by `pipeline/retry.py` | API error shapes |
+| Billing engine → real Smartsheet API | The D-05 live probe crosses into production data (read path) | Production billing rows / attachments |
+
+---
+
+## Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation | Status |
+|-----------|----------|-----------|-------------|------------|--------|
+| T-08-01 | Tampering | Re-export shim removal vs SDK internal retryable-exception lookup | mitigate | SDK 4.3.0 `smartsheet/smartsheet.py:301-302` resolves retryables via `importlib.import_module(__package__ + ".exceptions")` — the removed 3.x shim was a proven no-op. `pipeline/retry.py:67` unchanged (`import smartsheet.exceptions as ss_exc`). `generate_weekly_pdfs.py:17-24` clean. `pytest tests/test_smartsheet_retry.py` re-run live during audit: 17 passed. | closed |
+| T-08-02 | Tampering | Gate 1 baseline edit masks a real dropped export | mitigate | `tests/golden/baseline_names.json` verified: 177 entries, `_exc_name` absent. `python scripts/check_api_equality.py` re-run live: `PASS: all 177 baseline names present`. | closed |
+| T-08-SC | Tampering (supply chain) | pip install of `smartsheet-python-sdk==4.3.0` | mitigate (08-01) / accept (08-02) | `requirements.txt:9` exact pin `==4.3.0` (no range operators, `--no-binary` absent). Ledger `[2026-07-21 18:20]` records the additive-only 4.0.1→4.3.0 changelog review, wheel byte-size/yank verification, and the exact-pin rule. First-party SDK already in production; no new dependency. Accept half logged below. | closed |
+| T-08-03 | Tampering / Integrity | Live probe writes to production Smartsheet under `SKIP_UPLOAD=true` | mitigate | **FIXED 2026-07-22 (this audit's follow-up, Juan-approved).** The declared mitigation ("probe writes nothing") was contradicted by code — `delete_old_excel_attachments()` ran unconditionally in `_upload_one` while `SKIP_UPLOAD` gated only the upload; materialized in the D-05 probe (2 attachments deleted on WR 89881161, self-healed by next cron). Fix: `dry_run: bool = False` parameter on `delete_old_excel_attachments`, `cleanup_untracked_sheet_attachments`, and `purge_existing_hashed_outputs` (`pipeline/cleanup.py`), wired `dry_run=SKIP_UPLOAD` at all five mutating call sites in `pipeline/orchestrate.py`. Invariant now absolute: `SKIP_UPLOAD=true` ⇒ zero Smartsheet mutations, while read-only skip decisions (legacy hash short-circuit) are preserved. TDD'd: `tests/test_skip_upload_delete_gating.py` (7 tests, RED→GREEN) + signature-pin update in `tests/test_security_audit_followup.py`. Full suite: 1171 passed + 130 subtests. | closed |
+| T-08-04 | Tampering | Future unreviewed SDK release auto-enters production | mitigate | `requirements.txt:9` exact pin `==4.3.0` makes any bump a deliberate reviewed PR. Ledger `[2026-07-21 18:20]` documents the exact-pin rule for transport-critical dependencies. | closed |
+| T-08-05 | Repudiation / DoS | Real 4.3.0 error-shape drift silently breaks retry/backoff | mitigate | 08-02-SUMMARY.md "D-05 Live Probe Result": operator-executed live run on 4.3.0 (2026-07-22 ~10:07 CDT) — 676 target-row + 545 PPP attachment-list calls through `pipeline/retry.py`, zero retry-path exceptions, real `ApiError.error.result` shape matched. Corroborated by ledger `[2026-07-22 10:20]` sign-off. | closed |
+
+*Status: open · closed*
+*Disposition: mitigate (implementation required) · accept (documented risk) · transfer (third-party)*
+
+---
+
+## Accepted Risks Log
+
+| Risk ID | Threat Ref | Rationale | Accepted By | Date |
+|---------|------------|-----------|-------------|------|
+| AR-08-01 | T-08-SC (accept half, 08-02) | `pip install smartsheet-python-sdk==4.3.0` pulls a third-party (Smartsheet, Inc.) artifact from PyPI. Compensating controls: first-party official SDK already in production (not newly introduced); exact pin prevents unreviewed auto-upgrade; PyPI artifacts immutable; 4.0.1→4.3.0 changelog reviewed additive-only; wheel byte-sizes healthy (259–271 KB), none yanked. | Juan (via 08-02-PLAN threat model) | 2026-07-22 |
+
+*Accepted risks do not resurface in future audit runs.*
+
+---
+
+## Unregistered Flags (informational — future phase register candidates)
+
+| Flag | Source | Note |
+|------|--------|------|
+| `TEST_MODE=true` with a real API token still performs real Smartsheet **reads** | `deferred-items.md` (found 2026-07-22 during Phase 08 goal verification) | `pipeline/orchestrate.py` takes the synthetic path only `if not API_TOKEN`; a repo-root `.env` token flips TEST_MODE into real discovery/fetch reads. Write-safety preserved (`if not TEST_MODE` gates target map / delete path; `dry_run` gates now add SKIP_UPLOAD coverage). WARNING, not a blocker — carry into the next phase's threat register. |
+
+---
+
+## Security Audit Trail
+
+| Audit Date | Threats Total | Closed | Open | Run By |
+|------------|---------------|--------|------|--------|
+| 2026-07-22 | 6 | 5 | 1 (T-08-03) | gsd-security-auditor (sonnet) |
+| 2026-07-22 | 6 | 6 | 0 | main session — T-08-03 fix implemented (Juan-approved), TDD'd, full suite green |
+
+---
+
+## Sign-Off
+
+- [x] All threats have a disposition (mitigate / accept / transfer)
+- [x] Accepted risks documented in Accepted Risks Log
+- [x] `threats_open: 0` confirmed
+- [x] `status: verified` set in frontmatter
+
+**Approval:** verified 2026-07-22

--- a/.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-UAT.md
+++ b/.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-UAT.md
@@ -1,0 +1,50 @@
+---
+status: complete
+phase: 08-smartsheet-python-sdk-4-0-0-compatibility-migration
+source: [08-01-SUMMARY.md, 08-02-SUMMARY.md, 08-HUMAN-UAT.md (carried-over test)]
+started: 2026-07-22T20:57:58Z
+updated: 2026-07-22T21:24:22Z
+---
+
+## Current Test
+
+[testing complete]
+
+## Tests
+
+### 1. SDK 4.3.0 installed and exact-pinned
+expected: `python -m pip show smartsheet-python-sdk` reports Version: 4.3.0, and `requirements.txt` contains the exact pin `smartsheet-python-sdk==4.3.0` (no `<4.0.0` ceiling remains).
+result: pass
+
+### 2. Engine imports cleanly without the 3.x re-export shim
+expected: `python -m py_compile generate_weekly_pdfs.py` exits clean, and importing the engine raises no ModuleNotFoundError/AttributeError. The 27-line `smartsheet.smartsheet` re-export block is gone from the top of generate_weekly_pdfs.py (only `import smartsheet` + `import smartsheet.exceptions as ss_exc` remain).
+result: pass
+
+### 3. Full test suite green under 4.3.0
+expected: With `PYTHONUTF8=1 PYTHONIOENCODING=utf-8` set and SMARTSHEET_API_TOKEN unset (to avoid real reads), `pytest tests/ -v` passes — 1171 passed + 130 subtests, 0 failures.
+result: pass
+
+### 4. SKIP_UPLOAD zero-mutation gating in effect
+expected: `pytest tests/test_skip_upload_delete_gating.py -v` passes all 7 tests — SKIP_UPLOAD=true now gates the DELETE half too (dry_run wired at all 5 mutating call sites in pipeline/orchestrate.py), so a SKIP_UPLOAD run performs zero Smartsheet mutations.
+result: pass
+
+### 5. No lingering production-attachment loss (WR 89881161 self-heal; WR 89708709 / WR 90093002 intact)
+expected: On target sheet 5723337641643908 — WR 89881161 weeks 072025 and 081725 (deleted by the D-05 probe) have been regenerated and re-uploaded by a subsequent weekday cron run; WR 89708709 and WR 90093002 either have no matching attachments (no-op) or show no unexplained loss. No manual restore needed.
+result: pass
+
+### 6. Migration recorded for operators (Living Ledger + rollout/rollback runbooks)
+expected: memory-bank/living-ledger.md contains the dated migration entry ([2026-07-22 02:31]) and the D-05 live-probe sign-off ([2026-07-22 10:20]); 08-02-SUMMARY.md captures the D-06 rollout runbook (weekday daytime merge + one watched canary dispatch) and the D-07 rollback runbook (revert PR, pip cache auto-busts).
+result: pass
+
+## Summary
+
+total: 6
+passed: 6
+issues: 0
+pending: 0
+skipped: 0
+blocked: 0
+
+## Gaps
+
+[none yet]

--- a/.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-VALIDATION.md
+++ b/.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-VALIDATION.md
@@ -1,10 +1,11 @@
 ---
 phase: 08
 slug: smartsheet-python-sdk-4-0-0-compatibility-migration
-status: planned
+status: validated
 nyquist_compliant: true
 wave_0_complete: true
 created: 2026-07-21
+validated: 2026-07-22
 ---
 
 # Phase 08 — Validation Strategy
@@ -39,12 +40,13 @@ created: 2026-07-21
 
 | Task ID | Plan | Wave | Requirement | Threat Ref | Secure Behavior | Test Type | Automated Command | File Exists | Status |
 |---------|------|------|-------------|------------|-----------------|-----------|-------------------|-------------|--------|
-| 08-01-T1 | 08-01 | 1 | SDK-01, SDK-03 | T-08-SC | Trusted first-party exact-pin install; every in-use SDK symbol resolves | smoke import | `python -c "import smartsheet.exceptions as e, smartsheet.smartsheet; from smartsheet.models.sheet import Sheet; from smartsheet.models.folder import Folder; [getattr(e,n) for n in ('RateLimitExceededError','UnexpectedErrorShouldRetryError','InternalServerError','ServerTimeoutExceededError')]; print('SDK_401_OK')"` | ✅ generate_weekly_pdfs.py | ⬜ pending |
-| 08-01-T2 | 08-01 | 1 | SDK-02 | T-08-01, T-08-02 | Remove dead re-export without breaking retry lookup; baseline reflects ONLY the authorized `_exc_name` deletion | AST / unit | `python -m py_compile generate_weekly_pdfs.py && python scripts/check_api_equality.py` | ✅ tests/golden/baseline_names.json | ⬜ pending |
-| 08-01-T3 | 08-01 | 1 | SDK-04, SDK-06 | T-08-01 | Full behavior-neutrality: six gates + full pytest green, zero test changes | full suite + gates | `bash scripts/run_6_gates.sh && pytest tests/ -v` | ✅ scripts/run_6_gates.sh | ⬜ pending |
-| 08-02-T1 | 08-02 | 2 | SDK-05 | T-08-04 | Exact pin blocks unreviewed auto-bump into production | config assertion | `python -c "import re,sys; t=open('requirements.txt').read(); m=re.search(r'^smartsheet-python-sdk(.*)$',t,re.M); sys.exit(0 if (m and m.group(1).strip()=='==4.3.0') else 1)"` | ✅ requirements.txt | ⬜ pending |
-| 08-02-T2 | 08-02 | 2 | SDK-05 | T-08-04 | Durable ledger record of the migration + exact-pin rule | docs assertion | `python -c "assert 'smartsheet-python-sdk==4.3.0' in open('memory-bank/living-ledger.md',encoding='utf-8').read(); print('LEDGER_OK')"` | ✅ memory-bank/living-ledger.md | ⬜ pending |
-| 08-02-T3 | 08-02 | 2 | SDK-03, SDK-06 | T-08-03, T-08-05 | Live read-only probe validates real 4.3.0 transport + error shape; ZERO writes to Smartsheet | manual live probe | `SKIP_UPLOAD=true WR_FILTER=<WRs> MAX_GROUPS=5 python generate_weekly_pdfs.py` (operator-run) + `pip show smartsheet-python-sdk` | ✅ generate_weekly_pdfs.py | ⬜ pending |
+| 08-01-T1 | 08-01 | 1 | SDK-01, SDK-03 | T-08-SC | Trusted first-party exact-pin install; every in-use SDK symbol resolves | smoke import | `python -c "import smartsheet.exceptions as e, smartsheet.smartsheet; from smartsheet.models.sheet import Sheet; from smartsheet.models.folder import Folder; [getattr(e,n) for n in ('RateLimitExceededError','UnexpectedErrorShouldRetryError','InternalServerError','ServerTimeoutExceededError')]; print('SDK_401_OK')"` | ✅ generate_weekly_pdfs.py | ✅ green |
+| 08-01-T2 | 08-01 | 1 | SDK-02 | T-08-01, T-08-02 | Remove dead re-export without breaking retry lookup; baseline reflects ONLY the authorized `_exc_name` deletion | AST / unit | `python -m py_compile generate_weekly_pdfs.py && python scripts/check_api_equality.py` | ✅ tests/golden/baseline_names.json | ✅ green |
+| 08-01-T3 | 08-01 | 1 | SDK-04, SDK-06 | T-08-01 | Full behavior-neutrality: six gates + full pytest green, zero test changes | full suite + gates | `bash scripts/run_6_gates.sh && pytest tests/ -v` | ✅ scripts/run_6_gates.sh | ✅ green |
+| 08-02-T1 | 08-02 | 2 | SDK-05 | T-08-04 | Exact pin blocks unreviewed auto-bump into production | config assertion | `python -c "import re,sys; t=open('requirements.txt').read(); m=re.search(r'^smartsheet-python-sdk(.*)$',t,re.M); sys.exit(0 if (m and m.group(1).strip()=='==4.3.0') else 1)"` | ✅ requirements.txt | ✅ green |
+| 08-02-T2 | 08-02 | 2 | SDK-05 | T-08-04 | Durable ledger record of the migration + exact-pin rule | docs assertion | `python -c "assert 'smartsheet-python-sdk==4.3.0' in open('memory-bank/living-ledger.md',encoding='utf-8').read(); print('LEDGER_OK')"` | ✅ memory-bank/living-ledger.md | ✅ green |
+| 08-02-T3 | 08-02 | 2 | SDK-03, SDK-06 | T-08-03, T-08-05 | Live read-only probe validates real 4.3.0 transport + error shape; ZERO writes to Smartsheet | manual live probe | `SKIP_UPLOAD=true WR_FILTER=<WRs> MAX_GROUPS=5 python generate_weekly_pdfs.py` (operator-run) + `pip show smartsheet-python-sdk` | ✅ generate_weekly_pdfs.py | ✅ green (see audit note) |
+| 08-SEC-T1 | secure-08 | post | SDK-06 (dry-run write-safety) | T-08-03 | `SKIP_UPLOAD=true` performs ZERO Smartsheet mutations (deletes included), read-only skip decisions preserved | unit + source-wiring pins | `pytest tests/test_skip_upload_delete_gating.py -v` | ✅ tests/test_skip_upload_delete_gating.py | ✅ green |
 
 *Status: ⬜ pending · ✅ green · ❌ red · ⚠️ flaky*
 
@@ -82,3 +84,38 @@ gap: `tests/golden/baseline_names.json` drops the transient `_exc_name`
 - [x] `nyquist_compliant: true` set in frontmatter
 
 **Approval:** approved (planner) — ready for `/gsd:execute-phase 08`
+
+---
+
+## Validation Audit 2026-07-22
+
+| Metric | Count |
+|--------|-------|
+| Gaps found | 0 |
+| Resolved | 0 |
+| Escalated | 0 |
+
+All 6 planned tasks re-verified live this audit (commands re-run, not
+inherited): smoke import `SDK_401_OK`; `check_api_equality.py`
+`PASS: all 177 baseline names present`; pin + ledger assertions OK;
+`bash scripts/run_6_gates.sh` → `=== ALL 6 GATES PASSED ===` (exit 0);
+full suite `1171 passed + 130 subtests` (2026-07-22, includes the 7 new
+security tests). Phase is Nyquist-compliant with zero open gaps.
+
+**08-02-T3 audit note (manual probe):** executed by operator 2026-07-22
+(~10:07 CDT). The "ZERO writes" secure behavior was VIOLATED as planned
+— the probe deleted 2 prior attachments (WR 89881161) because
+`SKIP_UPLOAD` gated only the upload half (T-08-03, `08-SECURITY.md`).
+Fixed same day (commit `442cb92`): `dry_run=SKIP_UPLOAD` now gates all
+mutating cleanup paths, and the formerly manual-only "zero writes"
+property is now AUTOMATED (row 08-SEC-T1,
+`tests/test_skip_upload_delete_gating.py`). The manual probe remains
+manual for the transport/error-shape half (T-08-05) only.
+
+**Infrastructure note:** the six-gate harness's estimated runtime
+(~150s) assumed a synthetic TEST_MODE run. With a repo-root `.env`
+token present, TEST_MODE performs real Smartsheet reads (deferred item
+"TEST_MODE with a real token") — the audit run took **~35 minutes**.
+Either unset the token (`SMARTSHEET_API_TOKEN=''`) when running gates
+locally, or budget accordingly, until the TEST_MODE synthetic-path gate
+is fixed in a future phase.

--- a/.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-VALIDATION.md
+++ b/.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-VALIDATION.md
@@ -1,0 +1,74 @@
+---
+phase: 08
+slug: smartsheet-python-sdk-4-0-0-compatibility-migration
+status: draft
+nyquist_compliant: false
+wave_0_complete: false
+created: 2026-07-21
+---
+
+# Phase 08 — Validation Strategy
+
+> Per-phase validation contract for feedback sampling during execution.
+
+---
+
+## Test Infrastructure
+
+| Property | Value |
+|----------|-------|
+| **Framework** | pytest (existing suite, ~1122 tests) |
+| **Config file** | none — repo-root `tests/` discovered by pytest defaults |
+| **Quick run command** | `python -m py_compile generate_weekly_pdfs.py && pytest tests/ -x -q` |
+| **Full suite command** | `pytest tests/ -v` |
+| **Estimated runtime** | ~120 seconds |
+
+---
+
+## Sampling Rate
+
+- **After every task commit:** Run `python -m py_compile generate_weekly_pdfs.py && pytest tests/ -x -q`
+- **After every plan wave:** Run `pytest tests/ -v`
+- **Before `/gsd:verify-work`:** Full suite must be green
+- **Max feedback latency:** 180 seconds
+
+---
+
+## Per-Task Verification Map
+
+| Task ID | Plan | Wave | Requirement | Threat Ref | Secure Behavior | Test Type | Automated Command | File Exists | Status |
+|---------|------|------|-------------|------------|-----------------|-----------|-------------------|-------------|--------|
+| _filled by planner_ | | | | | | | | | ⬜ pending |
+
+*Status: ⬜ pending · ✅ green · ❌ red · ⚠️ flaky*
+
+---
+
+## Wave 0 Requirements
+
+- [ ] _filled by planner — existing pytest suite likely covers phase requirements; confirm during planning_
+
+*If none: "Existing infrastructure covers all phase requirements."*
+
+---
+
+## Manual-Only Verifications
+
+| Behavior | Requirement | Why Manual | Test Instructions |
+|----------|-------------|------------|-------------------|
+| Live read-only Smartsheet probe on SDK 4.3.0 | SDK-05 | Mocked ApiError blind spot — mocks cannot prove real SDK exception shapes | Run branch `SKIP_UPLOAD=true` dry-run against live Smartsheet per 08-CONTEXT.md rollout decision |
+
+*If none: "All phase behaviors have automated verification."*
+
+---
+
+## Validation Sign-Off
+
+- [ ] All tasks have `<automated>` verify or Wave 0 dependencies
+- [ ] Sampling continuity: no 3 consecutive tasks without automated verify
+- [ ] Wave 0 covers all MISSING references
+- [ ] No watch-mode flags
+- [ ] Feedback latency < 180s
+- [ ] `nyquist_compliant: true` set in frontmatter
+
+**Approval:** pending

--- a/.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-VALIDATION.md
+++ b/.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-VALIDATION.md
@@ -1,9 +1,9 @@
 ---
 phase: 08
 slug: smartsheet-python-sdk-4-0-0-compatibility-migration
-status: draft
-nyquist_compliant: false
-wave_0_complete: false
+status: planned
+nyquist_compliant: true
+wave_0_complete: true
 created: 2026-07-21
 ---
 
@@ -17,19 +17,20 @@ created: 2026-07-21
 
 | Property | Value |
 |----------|-------|
-| **Framework** | pytest (existing suite, ~1122 tests) |
+| **Framework** | pytest (existing suite, ~1122 tests) + `scripts/run_6_gates.sh` behavior-neutrality oracle |
 | **Config file** | none — repo-root `tests/` discovered by pytest defaults |
 | **Quick run command** | `python -m py_compile generate_weekly_pdfs.py && pytest tests/ -x -q` |
 | **Full suite command** | `pytest tests/ -v` |
-| **Estimated runtime** | ~120 seconds |
+| **Gate harness** | `bash scripts/run_6_gates.sh` |
+| **Estimated runtime** | ~120 seconds (suite); ~150 seconds (six gates incl. TEST_MODE synthetic run) |
 
 ---
 
 ## Sampling Rate
 
 - **After every task commit:** Run `python -m py_compile generate_weekly_pdfs.py && pytest tests/ -x -q`
-- **After every plan wave:** Run `pytest tests/ -v`
-- **Before `/gsd:verify-work`:** Full suite must be green
+- **After every plan wave:** Run `bash scripts/run_6_gates.sh` (six gates) then `pytest tests/ -v`
+- **Before `/gsd:verify-work`:** Full six-gate + full suite must be green under SDK 4.3.0
 - **Max feedback latency:** 180 seconds
 
 ---
@@ -38,7 +39,12 @@ created: 2026-07-21
 
 | Task ID | Plan | Wave | Requirement | Threat Ref | Secure Behavior | Test Type | Automated Command | File Exists | Status |
 |---------|------|------|-------------|------------|-----------------|-----------|-------------------|-------------|--------|
-| _filled by planner_ | | | | | | | | | ⬜ pending |
+| 08-01-T1 | 08-01 | 1 | SDK-01, SDK-03 | T-08-SC | Trusted first-party exact-pin install; every in-use SDK symbol resolves | smoke import | `python -c "import smartsheet.exceptions as e, smartsheet.smartsheet; from smartsheet.models.sheet import Sheet; from smartsheet.models.folder import Folder; [getattr(e,n) for n in ('RateLimitExceededError','UnexpectedErrorShouldRetryError','InternalServerError','ServerTimeoutExceededError')]; print('SDK_401_OK')"` | ✅ generate_weekly_pdfs.py | ⬜ pending |
+| 08-01-T2 | 08-01 | 1 | SDK-02 | T-08-01, T-08-02 | Remove dead re-export without breaking retry lookup; baseline reflects ONLY the authorized `_exc_name` deletion | AST / unit | `python -m py_compile generate_weekly_pdfs.py && python scripts/check_api_equality.py` | ✅ tests/golden/baseline_names.json | ⬜ pending |
+| 08-01-T3 | 08-01 | 1 | SDK-04, SDK-06 | T-08-01 | Full behavior-neutrality: six gates + full pytest green, zero test changes | full suite + gates | `bash scripts/run_6_gates.sh && pytest tests/ -v` | ✅ scripts/run_6_gates.sh | ⬜ pending |
+| 08-02-T1 | 08-02 | 2 | SDK-05 | T-08-04 | Exact pin blocks unreviewed auto-bump into production | config assertion | `python -c "import re,sys; t=open('requirements.txt').read(); m=re.search(r'^smartsheet-python-sdk(.*)$',t,re.M); sys.exit(0 if (m and m.group(1).strip()=='==4.3.0') else 1)"` | ✅ requirements.txt | ⬜ pending |
+| 08-02-T2 | 08-02 | 2 | SDK-05 | T-08-04 | Durable ledger record of the migration + exact-pin rule | docs assertion | `python -c "assert 'smartsheet-python-sdk==4.3.0' in open('memory-bank/living-ledger.md',encoding='utf-8').read(); print('LEDGER_OK')"` | ✅ memory-bank/living-ledger.md | ⬜ pending |
+| 08-02-T3 | 08-02 | 2 | SDK-03, SDK-06 | T-08-03, T-08-05 | Live read-only probe validates real 4.3.0 transport + error shape; ZERO writes to Smartsheet | manual live probe | `SKIP_UPLOAD=true WR_FILTER=<WRs> MAX_GROUPS=5 python generate_weekly_pdfs.py` (operator-run) + `pip show smartsheet-python-sdk` | ✅ generate_weekly_pdfs.py | ⬜ pending |
 
 *Status: ⬜ pending · ✅ green · ❌ red · ⚠️ flaky*
 
@@ -46,9 +52,15 @@ created: 2026-07-21
 
 ## Wave 0 Requirements
 
-- [ ] _filled by planner — existing pytest suite likely covers phase requirements; confirm during planning_
+Existing infrastructure covers all automated phase requirements — the
+existing pytest suite (~1122 tests, including `tests/test_smartsheet_retry.py`
+17 retry-path tests and the shadow-import tests) plus the calibrated
+`scripts/run_6_gates.sh` behavior-neutrality oracle. **No new test files or
+fixtures are required** (SDK-04 research finding: net test changes = zero).
 
-*If none: "Existing infrastructure covers all phase requirements."*
+One authorized golden-baseline edit is part of implementation, not a Wave 0
+gap: `tests/golden/baseline_names.json` drops the transient `_exc_name`
+(178 -> 177) to reflect the D-04 block deletion (task 08-01-T2).
 
 ---
 
@@ -56,19 +68,17 @@ created: 2026-07-21
 
 | Behavior | Requirement | Why Manual | Test Instructions |
 |----------|-------------|------------|-------------------|
-| Live read-only Smartsheet probe on SDK 4.3.0 | SDK-05 | Mocked ApiError blind spot — mocks cannot prove real SDK exception shapes | Run branch `SKIP_UPLOAD=true` dry-run against live Smartsheet per 08-CONTEXT.md rollout decision |
-
-*If none: "All phase behaviors have automated verification."*
+| Live read-only Smartsheet probe on SDK 4.3.0 | SDK-03 (real path), SDK-06 | Mocked `ApiError.error.result` blind spot — `tests/test_smartsheet_retry.py` uses `mock.Mock()` and TEST_MODE never touches the wire; production-touch action is operator-gated | On branch `feat/phase-08-sdk-430-migration` with 4.3.0 installed, run `SKIP_UPLOAD=true WR_FILTER=<known WRs> MAX_GROUPS=5 python generate_weekly_pdfs.py`. Confirm exit 0, real rows fetched, Excel generated under `generated_docs/`, ZERO uploads/deletes, no SDK error-shape exception (08-02 task 3 / D-05) |
 
 ---
 
 ## Validation Sign-Off
 
-- [ ] All tasks have `<automated>` verify or Wave 0 dependencies
-- [ ] Sampling continuity: no 3 consecutive tasks without automated verify
-- [ ] Wave 0 covers all MISSING references
-- [ ] No watch-mode flags
-- [ ] Feedback latency < 180s
-- [ ] `nyquist_compliant: true` set in frontmatter
+- [x] All tasks have `<automated>` verify or Wave 0 dependencies (08-02-T3 pairs a `<human-check>` with a supporting automated `pip show` assertion)
+- [x] Sampling continuity: no 3 consecutive tasks without automated verify
+- [x] Wave 0 covers all MISSING references (none — existing infra + one authorized baseline edit)
+- [x] No watch-mode flags
+- [x] Feedback latency < 180s
+- [x] `nyquist_compliant: true` set in frontmatter
 
-**Approval:** pending
+**Approval:** approved (planner) — ready for `/gsd:execute-phase 08`

--- a/.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-VERIFICATION.md
+++ b/.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-VERIFICATION.md
@@ -1,0 +1,97 @@
+---
+phase: 08-smartsheet-python-sdk-4-0-0-compatibility-migration
+verified: 2026-07-22T17:20:00Z
+status: human_needed
+score: 6/6 must-haves verified
+overrides_applied: 0
+human_verification:
+  - test: "Confirm no lingering production-attachment loss from repeated Gate-6 / TEST_MODE runs against WR 89708709 and WR 90093002 on TARGET_SHEET_ID (5723337641643908)"
+    expected: "Either the two WRs have no matching real attachments on the target sheet (no-op), or — if they do — the hash-history withholding already self-healed them on the next scheduled cron exactly as it did for the WR 89881161 finding in deferred-items.md. No manual restore should be needed, but the operator should positively confirm this rather than assume it."
+    why_human: "During this verification session, `bash scripts/run_6_gates.sh` (Gate 6) and a direct `TEST_MODE=true SKIP_UPLOAD=true python generate_weekly_pdfs.py` invocation were both found to hit REAL production Smartsheet reads (real sheet IDs from pipeline/discovery.py, e.g. 'Intake Promax 3' / 2920263713771396), not synthetic data — because `pipeline/orchestrate.py`'s `if not API_TOKEN: ... _run_synthetic_test_mode(...)` only takes the pure in-memory synthetic path when SMARTSHEET_API_TOKEN is ABSENT; with a real token present (as in this repo's `.env`), TEST_MODE=true still initializes a real Smartsheet client and does real discovery/fetch before generating output for two hardcoded fixture WRs (89708709, 90093002). Per the already-documented SKIP_UPLOAD delete-before-skip defect (deferred-items.md), the delete-then-upload sequence's DELETE half is not gated by SKIP_UPLOAD — only the D-05 probe's specific WR_FILTER-bounded scope was checked by the operator for this. This external-service side effect cannot be confirmed or ruled out from static code/log inspection alone."
+---
+
+# Phase 08: smartsheet-python-sdk 4.x Compatibility Migration Verification Report
+
+**Phase Goal:** Migrate the production billing engine to smartsheet-python-sdk 4.x — exact pin ==4.3.0, dead 3.x re-export workaround removed, behavior-neutrality proven (six-gate harness + full pytest), pin lifted only after proof, live read-only Smartsheet probe on real transport, rollout/rollback runbook captured.
+**Verified:** 2026-07-22T17:20:00Z
+**Status:** human_needed
+**Re-verification:** No — initial verification
+
+## Goal Achievement
+
+### Observable Truths
+
+| # | Truth | Status | Evidence |
+|---|-------|--------|----------|
+| 1 | `requirements.txt` pins `smartsheet-python-sdk==4.3.0` exactly (no range, `<4.0.0`/`--no-binary` absent) | VERIFIED | Read `requirements.txt` line 9: `smartsheet-python-sdk==4.3.0`; grep confirms no `<4.0.0`, `>=4.0.0`, or `--no-binary` anywhere in the file |
+| 2 | Dead 3.x `smartsheet.smartsheet` re-export workaround removed from `generate_weekly_pdfs.py`; line 18 `import smartsheet.exceptions as ss_exc` retained; `pipeline/retry.py` untouched | VERIFIED | `grep -n "_ss_smartsheet_module\|_exc_name" generate_weekly_pdfs.py` → no matches; `import smartsheet.exceptions as ss_exc` present at line 18; `python -m py_compile generate_weekly_pdfs.py` exits 0 |
+| 3 | Behavior-neutrality proven: full six-gate harness + complete pytest suite green under 4.3.0 | VERIFIED | Independently re-ran (not trusting SUMMARY): Gate 1 `PASS: all 177 baseline names present`; Gate 2 `PASS: all 108 allowlist names resolve`; Gate 3 (`pytest tests/ -q`) → `1164 passed, 130 subtests passed` (0 failed); Gate 4 (`check_mypy_delta.sh`) reproduces the already-documented CRLF-masked-PASS (pre-existing, not a regression — see Anti-Patterns); Gate 5 `python -m py_compile` clean; Gate 6 structural check (`check_run_summary_structure.py`) → `PASS: run_summary.json structure matches baseline (21 keys)`. Installed SDK confirmed `Version: 4.3.0` via `python -m pip show` in the repo's active interpreter. |
+| 4 | `requirements.txt` pin lifted ONLY AFTER the SDK-01..04 proof landed | VERIFIED | Commit order: `b2e76bf`/`39d7f0e` (08-01: dead-block removal + green 6-gate/pytest proof) precede `76e2471` (08-02: pin lift `>=3.1.0,<4.0.0` → `==4.3.0`) — all 10 referenced commit hashes (`b2e76bf, 39d7f0e, 76e2471, 038816c, a31121d, aa55b6b, 4aa19ff, 552923f, c48955f, cb2cc10`) confirmed to exist in the repo via `git cat-file -e` |
+| 5 | Live read-only Smartsheet probe on real 4.3.0 transport (D-05) executed and approved | VERIFIED | `08-02-SUMMARY.md` + `memory-bank/living-ledger.md` `[2026-07-22 10:20]` entry document the operator-run probe (`SKIP_UPLOAD=true WR_FILTER=84157414,89881161 MAX_GROUPS=5`): real sheet fetches, "Grouping validation passed: 2771 groups", 5 Excel files generated, zero uploads, zero SDK error-shape exceptions, one pre-existing (non-SDK) finding recorded in `deferred-items.md` and explicitly approved-with-finding by the operator |
+| 6 | Rollout (D-06) and rollback (D-07) runbook captured for the operator, not executed | VERIFIED | `08-02-SUMMARY.md` "D-06 Rollout Runbook" / "D-07 Rollback Runbook" sections present with concrete steps (merge-window guard, canary dispatch, revert-PR rollback) |
+
+**Score:** 6/6 truths verified
+
+### Required Artifacts
+
+| Artifact | Expected | Status | Details |
+|----------|----------|--------|---------|
+| `requirements.txt` | Exact pin `==4.3.0`, comment records exact-pin rule + ledger pointer | VERIFIED | Line 9 exact pin confirmed; comment (lines 5-8) references D-01 exact-pin rule and points to `memory-bank/living-ledger.md` |
+| `generate_weekly_pdfs.py` | Dead 3.x re-export block removed; `ss_exc` import retained | VERIFIED | 27-line block absent; `import smartsheet` / `import smartsheet.exceptions as ss_exc` retained at lines 17-18; `py_compile` clean |
+| `tests/golden/baseline_names.json` | 177 entries, `_exc_name` absent (178→177 authorized delta) | VERIFIED | `python -c "json.load(...)"` confirms `count: 177`, `_exc_name present: False` |
+| `memory-bank/living-ledger.md` | Dated migration entry with pin, commit hashes, evidence | VERIFIED | Two new entries `[2026-07-22 02:31]` and `[2026-07-22 10:20]` present, contain `smartsheet-python-sdk==4.3.0`, commit hashes, gate/pytest/probe evidence |
+| `.planning/phases/08.../deferred-items.md` | Pre-existing (non-SDK) defects logged, not fixed inline | VERIFIED | Gate 4 CRLF bug + SKIP_UPLOAD delete-before-skip defect both documented with root cause, self-healing confirmation, suggested fix |
+| `.planning/phases/08.../08-REVIEW.md` | Code review pass with 0 critical findings | VERIFIED | `0 critical, 1 warning (fixed in 552923f), 3 info (1 fixed in 552923f, 2 intentionally deferred)` |
+
+### Key Link Verification
+
+| From | To | Via | Status | Details |
+|------|-----|-----|--------|---------|
+| `generate_weekly_pdfs.py` | `smartsheet.exceptions` | `import smartsheet.exceptions as ss_exc` (line 18) | WIRED | Retained byte-for-byte; `pipeline/retry.py` consumes `ss_exc.*` directly and is untouched (confirmed via `git diff --stat` scope check) |
+| `requirements.txt` | resolved install environment | `smartsheet-python-sdk==4.3.0` exact resolution | WIRED | Active repo interpreter (`C:\...\hermes-agent\venv\...\python.exe`) independently confirmed `Version: 4.3.0` via `python -m pip show` |
+| `scripts/check_api_equality.py` | `tests/golden/baseline_names.json` | AST union vs. frozen baseline | WIRED | Gate 1 independently re-run: `PASS: all 177 baseline names present` |
+| D-05 live probe | `pipeline/retry.py` `ApiError` introspection | real Smartsheet error-shape validation | WIRED | Operator-run probe confirms zero `AttributeError`/retry-path exceptions against real 4.3.0 responses (recorded in `08-02-SUMMARY.md` and Living Ledger) |
+
+### Requirements Coverage
+
+| Requirement | Source Plan | Description | Status | Evidence |
+|-------------|-------------|-------------|--------|----------|
+| SDK-01 | 08-01 | Billing engine resolves Smartsheet exception classes under 4.x | SATISFIED | `ss_exc` import retained + `py_compile` clean; `tests/test_smartsheet_retry.py` (17 tests) + `tests/test_billing_audit_shadow.py` independently re-run: 223 passed / 61 subtests, 0 failed |
+| SDK-02 | 08-01 | 3.x re-export workaround reconciled (removed, not broken) | SATISFIED | Dead block removed (commit `b2e76bf`); Gate 1 rebaselined and green; `08-REVIEW.md` independently confirmed the deleted shim is genuinely dead on 4.3.0 (all 8 exception classes resolve without it) |
+| SDK-03 | 08-01, 08-02 | In-use SDK call sites (`Sheets.get_sheet`, `Attachments.*`, `Folders.get_folder_children`) verified compatible | SATISFIED | 08-01 smoke-import (models + exceptions) + 08-02 live probe exercised real `Sheets.get_sheet` and `Attachments.list_row_attachments` against production with zero drift |
+| SDK-04 | 08-01 | Full `pytest tests/` suite passes against 4.x | SATISFIED | Independently re-run: `1164 passed, 130 subtests passed` (0 failed); only test-file change is the post-review `test_entrypoint_no_double_import.py` encoding fix (commit `552923f`, a legitimate defect fix disclosed in `08-REVIEW.md` WR-01, not a hidden SDK-04 violation) |
+| SDK-05 | 08-02 | `requirements.txt` upper-bound lifted only after SDK-01..04 pass | SATISFIED | Pin lifted to exact `==4.3.0` in commit `76e2471`, strictly after 08-01's green gate/pytest proof; Living Ledger records the rule |
+| SDK-06 | 08-01, 08-02 | Non-upload validation run confirms identical grouping/Excel output | SATISFIED | Gate 6 structural check (21-key `run_summary.json` match, independently re-verified) covers the automated half; D-05 live read-only probe covers the real-transport half |
+
+**Orphan check:** REQUIREMENTS.md maps exactly `SDK-01` through `SDK-06` to Phase 08; both plans' combined `requirements:` frontmatter cover all six. No orphaned requirement IDs.
+
+**Note (informational, not a gap):** REQUIREMENTS.md's checkbox list still shows all six `SDK-0N` items as `[ ]` unchecked and the coverage table still reads "Pending" for each. This appears to be a pre-existing repo convention gap, not specific to Phase 08 — other already-shipped requirement groups in the same file (e.g. `SEC-01..05`) show the same unchecked pattern. No plan in this phase claimed `REQUIREMENTS.md` as a file it would modify, so this is flagged for hygiene, not scored as a failure.
+
+### Anti-Patterns Found
+
+| File | Line | Pattern | Severity | Impact |
+|------|------|---------|----------|--------|
+| `scripts/check_mypy_delta.sh` | ~45 | CRLF in `tests/golden/mypy_baseline_count.txt` breaks the `-gt` integer comparison inside an `if`, causing Gate 4 to always print PASS regardless of the true delta | Info (pre-existing, documented) | Independently reproduced this session (`[: 56: integer expression expected`, falls through to PASS). Verified NOT a regression — `deferred-items.md` documents the actual mypy error set is byte-identical (22 errors) before/after this phase. Logged, not fixed, per SCOPE BOUNDARY (file outside this phase's authorized change list) |
+| `pipeline/upload.py` (`_upload_one`) | n/a | `SKIP_UPLOAD=true` gates only the UPLOAD half of delete-then-upload; DELETE runs unconditionally | Warning (pre-existing, documented) | Already logged in `deferred-items.md` with self-healing confirmation (withheld hash-history write triggers automatic regeneration next cron run). Not caused by this migration — identical on 3.x |
+| `pipeline/orchestrate.py` (`main()`, `if not API_TOKEN:`) | ~438-442 | `TEST_MODE=true` only takes the pure in-memory synthetic path when `SMARTSHEET_API_TOKEN` is ABSENT; with a real token present, `TEST_MODE=true` still opens a real Smartsheet client and performs real discovery/fetch before falling back to a hardcoded fixture-WR (89708709, 90093002) output | **New finding this session — Warning** | Empirically reproduced twice this session (six-gate harness's own Gate 6, and a direct manual invocation): both showed real production sheet IDs and row data being fetched (e.g. "Intake Promax 3" / 2920263713771396) despite `TEST_MODE=true`. This contradicts the phase's own documented design assumption in `08-CONTEXT.md`/`08-01-PLAN.md` ("TEST_MODE synthetic runs never touch the transport at all") — that assumption is only true when no token is configured. Combined with the already-known SKIP_UPLOAD delete-bug, this means **every local `bash scripts/run_6_gates.sh` run in a real-token dev environment silently reads production and can trigger an unbounded, un-gated delete** against WR 89708709 / 90093002 — broader exposure than the bounded, explicitly-approved D-05 probe. See Human Verification Required below. |
+
+### Human Verification Required
+
+#### 1. Confirm no lingering production-attachment side effect from repeated Gate 6 / TEST_MODE runs
+
+**Test:** Check the production `TARGET_SHEET_ID` sheet (`5723337641643908`) for WR 89708709 and WR 90093002 attachments. If any were deleted by a recent Gate-6-triggered run (including the one executed during this verification pass and any prior runs during phase execution/code review), confirm the hash-history withholding mechanism already regenerated and re-uploaded them on the next scheduled cron — the same self-healing behavior already confirmed for the WR 89881161 finding in `deferred-items.md`.
+**Expected:** No permanent data loss (self-healing regenerates on next cron), but this should be positively confirmed rather than assumed, since this exposure was not explicitly scoped or bounded the way the D-05 probe was (no `WR_FILTER`/`MAX_GROUPS`, no explicit human sign-off before each Gate 6 invocation).
+**Why human:** Requires reading real production Smartsheet state (attachment list + upload history), which cannot be verified from static code or local log inspection alone.
+
+**Recommended follow-up (not a phase blocker):** Harden `scripts/run_6_gates.sh`'s Gate 6 invocation to either force the pure synthetic path (`SMARTSHEET_API_TOKEN=''` alongside `TEST_MODE=true`, mirroring the pattern already used in `tests/test_entrypoint_no_double_import.py`) or bound it with `WR_FILTER`/`MAX_GROUPS` the same way the D-05 probe was bounded — so the "automated, six-gate" proof is genuinely non-production-touching regardless of the local `.env` token, and the phase's documented rationale for needing a *separate* live probe ("TEST_MODE never touches the wire") is actually true.
+
+### Gaps Summary
+
+No must-have truth failed. The core Phase 08 goal — exact pin `==4.3.0`, dead re-export removal, six-gate + full pytest behavior-neutrality proof, ordered pin lift, live read-only probe, and rollout/rollback runbook — is verified directly against the codebase, independently re-run rather than trusted from SUMMARY claims. All 6 gates were independently re-executed this session (not merely re-read from SUMMARY.md) and matched the documented results exactly.
+
+The phase is held at `human_needed` rather than `passed` because this verification session independently discovered a previously-uncaptured operational side effect: `TEST_MODE=true` does not prevent real Smartsheet transport when a real API token is configured (as it is in this repo's `.env`), which means the "automated" six-gate harness itself — not just the explicitly human-gated D-05 probe — has been silently reading (and, per the already-known SKIP_UPLOAD defect, potentially deleting-then-regenerating) real production data every time it has been run locally during this phase, including during this verification pass. This is pre-existing engine behavior unrelated to the SDK 4.3.0 migration itself (identical on 3.x), and the self-healing mechanism that already covers the documented D-05 finding should also cover this — but it was not scoped, bounded, or disclosed anywhere in the phase's artifacts, so it is surfaced here for explicit operator confirmation rather than silently assumed safe.
+
+---
+
+*Verified: 2026-07-22T17:20:00Z*
+*Verifier: Claude (gsd-verifier)*

--- a/.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-VERIFICATION.md
+++ b/.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/08-VERIFICATION.md
@@ -1,7 +1,8 @@
 ---
 phase: 08-smartsheet-python-sdk-4-0-0-compatibility-migration
 verified: 2026-07-22T17:20:00Z
-status: human_needed
+status: passed
+human_confirmed: 2026-07-22T21:24:22Z (08-UAT.md Test 5 — operator confirmed no lingering attachment loss; WR 89881161 self-healed via cron, WR 89708709 / WR 90093002 intact)
 score: 6/6 must-haves verified
 overrides_applied: 0
 human_verification:
@@ -14,7 +15,7 @@ human_verification:
 
 **Phase Goal:** Migrate the production billing engine to smartsheet-python-sdk 4.x — exact pin ==4.3.0, dead 3.x re-export workaround removed, behavior-neutrality proven (six-gate harness + full pytest), pin lifted only after proof, live read-only Smartsheet probe on real transport, rollout/rollback runbook captured.
 **Verified:** 2026-07-22T17:20:00Z
-**Status:** human_needed
+**Status:** passed (human confirmation received 2026-07-22 via 08-UAT.md Test 5)
 **Re-verification:** No — initial verification
 
 ## Goal Achievement

--- a/.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/deferred-items.md
+++ b/.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/deferred-items.md
@@ -85,6 +85,16 @@ read-only. Low/medium priority — the self-healing withheld-hash behavior
 means no data is silently lost, but the flag's name currently overpromises
 what it does; worth a small dedicated fix + test in a future plan.
 
+**✅ RESOLVED 2026-07-22 (`/gsd:secure-phase 08`, T-08-03, Juan-approved):**
+`dry_run: bool = False` added to `delete_old_excel_attachments`,
+`cleanup_untracked_sheet_attachments`, and `purge_existing_hashed_outputs`
+in `pipeline/cleanup.py`; all five mutating call sites in
+`pipeline/orchestrate.py` now pass `dry_run=SKIP_UPLOAD`. `SKIP_UPLOAD=true`
+is now fully read-only against Smartsheet (read-only skip decisions
+preserved). TDD'd in `tests/test_skip_upload_delete_gating.py` (7 tests);
+signature pin updated in `tests/test_security_audit_followup.py`; full
+suite 1171 passed + 130 subtests. See `08-SECURITY.md`.
+
 ## 08 (verification): TEST_MODE with a real token still performs real Smartsheet reads
 
 **Found during:** Phase 08 goal verification (2026-07-22)

--- a/.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/deferred-items.md
+++ b/.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/deferred-items.md
@@ -41,3 +41,46 @@ logged here, not fixed inline.
 normalize `tests/golden/mypy_baseline_count.txt` to LF-only. Low priority —
 warn-only posture per the script's own docstring; revisit alongside any
 future mypy-baseline refresh.
+
+## 08-02: SKIP_UPLOAD deletes prior attachments before skipping upload
+
+**Found during:** Task 3 (D-05 operator-run live read-only probe on 4.3.0,
+2026-07-22, `SKIP_UPLOAD=true WR_FILTER=84157414,89881161 MAX_GROUPS=5`)
+
+**Issue:** `SKIP_UPLOAD=true` is documented and intended as a read-only dry
+run flag, but it is NOT fully read-only. The delete-old-then-upload sequence
+in the upload worker gates only the UPLOAD half on `SKIP_UPLOAD` — the
+DELETE half runs unconditionally. During the probe, the run deleted 2 prior
+primary attachments on the production `TARGET_SHEET_ID` sheet
+(`5723337641643908`) for WR 89881161 (weeks 072025 and 081725 —
+`WR_89881161_WeekEnding_072025_User_Chad_Wheat.xlsx` and the 081725
+equivalent), then correctly skipped the re-upload per `SKIP_UPLOAD=true`.
+
+**Verified NOT a regression from SDK 4.3.0:** the delete-then-upload
+ordering and its gating are pre-existing engine behavior, byte-identical
+under 3.x — this is a pre-existing defect discovered by the D-05 probe, not
+a migration-caused change. `pipeline/upload.py`'s `_upload_one` worker
+(delete before attach, MOD-04 ordering) is out of this plan's authorized
+file list (`requirements.txt`, `memory-bank/living-ledger.md`, `CLAUDE.md`).
+
+**Self-healing confirmed (no data loss):** the run's hash-history write was
+withheld for all 5 affected groups ("upload did not complete — they will
+regenerate next run"), so the change-detection hash never recorded the
+deleted-then-skipped state as "done." The next scheduled weekday cron run
+will regenerate both files from source data and re-upload them normally.
+Operator decision (2026-07-22): let the next cron run self-heal — no manual
+attachment restore performed.
+
+**Why deferred, not fixed:** Fixing the gate (making DELETE conditional on
+`SKIP_UPLOAD` same as UPLOAD) is a real behavior change to
+`pipeline/upload.py`, outside this plan's compat-only, zero-behavior-change
+scope and outside its authorized file list. Also out of scope per the
+executor SCOPE BOUNDARY rule — this is a pre-existing issue the probe
+happened to surface, not one introduced by this plan's changes.
+
+**Suggested future fix:** in `pipeline/upload.py`'s `_upload_one` worker,
+gate the attachment DELETE on `SKIP_UPLOAD` the same way the UPLOAD is
+gated (skip both, or neither) so a "read-only" dry-run flag is actually
+read-only. Low/medium priority — the self-healing withheld-hash behavior
+means no data is silently lost, but the flag's name currently overpromises
+what it does; worth a small dedicated fix + test in a future plan.

--- a/.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/deferred-items.md
+++ b/.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/deferred-items.md
@@ -1,0 +1,43 @@
+# Deferred Items — Phase 08
+
+Out-of-scope discoveries logged during plan execution. Not fixed per the
+SCOPE BOUNDARY rule (pre-existing issues unrelated to the current task's
+changes are deferred, not fixed inline).
+
+## 08-01: Gate 4 (`scripts/check_mypy_delta.sh`) CRLF comparison bug
+
+**Found during:** Task 3 (six-gate harness run)
+
+**Issue:** `tests/golden/mypy_baseline_count.txt` is checked into git with
+CRLF line endings (`56\r\n`). The gate script's
+`tr -d ' \n' < "$BASELINE_COUNT_FILE"` only strips spaces and `\n`, leaving
+a trailing `\r` in `$baseline_count`. This makes the numeric comparison
+`[ "$new_count" -gt "$baseline_count" ]` throw a bash "integer expression
+expected" error instead of comparing correctly. Because that error occurs
+inside an `if` condition, `set -e` does not abort the script, and execution
+falls through to the unconditional `echo "PASS: ..."` line — so Gate 4
+always reports PASS on this Windows/Git-Bash environment regardless of the
+true comparison result.
+
+**Verified NOT a regression from this plan:** ran `mypy` directly and
+diffed byte-for-byte against `tests/golden/mypy_baseline.txt` with line
+numbers stripped. The actual error set is identical (22 errors in 5 files,
+same messages) before and after the SDK 4.3.0 install + dead-block removal.
+The raw `wc -l` delta (56 -> 58) is entirely 2 extra "annotation-unchecked"
+NOTE-level lines for `pipeline/orchestrate.py` (a file untouched by this
+plan — confirmed via `git diff --stat`) plus a "checked 21 -> 22 source
+files" summary-line artifact. Zero new type ERRORS were introduced.
+
+**Why deferred, not fixed:** `scripts/check_mypy_delta.sh` was not touched
+by this plan's authorized file list (`generate_weekly_pdfs.py`,
+`tests/golden/baseline_names.json`) and the CRLF condition in
+`mypy_baseline_count.txt` predates this plan (confirmed via `git diff`
+showing zero changes to that file across this plan's commits). Per the
+executor SCOPE BOUNDARY rule, pre-existing bugs in unrelated files are
+logged here, not fixed inline.
+
+**Suggested future fix:** change `tr -d ' \n'` to `tr -d ' \r\n'` (or
+`tr -d '[:space:]'`) in `scripts/check_mypy_delta.sh` line 45, and/or
+normalize `tests/golden/mypy_baseline_count.txt` to LF-only. Low priority —
+warn-only posture per the script's own docstring; revisit alongside any
+future mypy-baseline refresh.

--- a/.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/deferred-items.md
+++ b/.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/deferred-items.md
@@ -84,3 +84,25 @@ gated (skip both, or neither) so a "read-only" dry-run flag is actually
 read-only. Low/medium priority — the self-healing withheld-hash behavior
 means no data is silently lost, but the flag's name currently overpromises
 what it does; worth a small dedicated fix + test in a future plan.
+
+## 08 (verification): TEST_MODE with a real token still performs real Smartsheet reads
+
+**Found during:** Phase 08 goal verification (2026-07-22)
+
+**Issue:** `pipeline/orchestrate.py` takes the pure in-memory synthetic path
+only when `SMARTSHEET_API_TOKEN` is ABSENT (`if not API_TOKEN`). With a
+token present (e.g. injected from a repo-root `.env` via `load_dotenv()`),
+`TEST_MODE=true` still initializes a real Smartsheet client and performs
+real discovery/fetch reads before generating fixture output. Gate 6 of
+`scripts/run_6_gates.sh` and direct `TEST_MODE=true` invocations therefore
+hit production reads on developer machines that carry a `.env`.
+
+**Write-safety:** deletes/uploads remain impossible in TEST_MODE — the
+target map is built only `if not TEST_MODE` (orchestrate.py:595), and
+`delete_old_excel_attachments` requires a target-row hit (orchestrate.py:2140).
+Read-only exposure only.
+
+**Suggested future fix:** make TEST_MODE authoritative — take the synthetic
+path whenever `TEST_MODE=true` regardless of token presence (or explicitly
+blank the token when TEST_MODE is set). Related: the entrypoint test now
+empty-strings the token for the same load_dotenv reason (commit 4aa19ff).

--- a/.planning/quick/260722-nst-gate-claimer-remediation-on-skip-upload-/260722-nst-PLAN.md
+++ b/.planning/quick/260722-nst-gate-claimer-remediation-on-skip-upload-/260722-nst-PLAN.md
@@ -1,0 +1,189 @@
+---
+phase: quick-260722-nst
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - tests/test_skip_upload_delete_gating.py
+  - pipeline/orchestrate.py
+autonomous: true
+requirements: [PR286-REVIEW]
+
+must_haves:
+  truths:
+    - "With SKIP_UPLOAD=true, the isolated REMEDIATE_CLAIMERS sweep never calls delete_attachment against production, even when REMEDIATION_DRY_RUN=0."
+    - "run_claimer_remediation receives an effective dry_run of True whenever SKIP_UPLOAD is set."
+    - "The REMEDIATE_CLAIMERS log line reports the effective dry_run (post-SKIP_UPLOAD), not the raw REMEDIATION_DRY_RUN flag."
+    - "Existing 5 pinned SKIP_UPLOAD-gated cleanup call sites remain unchanged; this adds the 6th mutating call site."
+  artifacts:
+    - path: "pipeline/orchestrate.py"
+      provides: "SKIP_UPLOAD-gated dry_run at the run_claimer_remediation call site"
+      contains: "REMEDIATION_DRY_RUN or SKIP_UPLOAD"
+    - path: "tests/test_skip_upload_delete_gating.py"
+      provides: "Source-pin test for the 6th (claimer-remediation) mutating call site"
+      contains: "or SKIP_UPLOAD"
+  key_links:
+    - from: "pipeline/orchestrate.py REMEDIATE_CLAIMERS branch"
+      to: "pipeline.attribution.run_claimer_remediation"
+      via: "dry_run=REMEDIATION_DRY_RUN or SKIP_UPLOAD"
+      pattern: "dry_run=REMEDIATION_DRY_RUN or SKIP_UPLOAD"
+---
+
+<objective>
+Extend the SKIP_UPLOAD "zero Smartsheet mutations" invariant (Living Ledger
+[2026-07-22 14:37]) to the isolated claimer-remediation call site flagged in PR #286
+review.
+
+Confirmed defect: `pipeline/orchestrate.py:457-462` calls
+`run_claimer_remediation(client, dry_run=REMEDIATION_DRY_RUN, ...)`. When
+`SKIP_UPLOAD=true`, `REMEDIATE_CLAIMERS=1`, and `REMEDIATION_DRY_RUN=0`, the sweep can
+call `delete_attachment` against production — violating the invariant. Both
+`SKIP_UPLOAD` (config.py:48) and `REMEDIATION_DRY_RUN` (config.py:421-423) are already
+bools, so the fix is a boolean OR at the call site plus an honest log line.
+
+Purpose: Close the last unguarded mutating call site so SKIP_UPLOAD is a hard,
+uniform read-only switch. This is the 6th mutating call site; the other 5 are already
+pinned in tests/test_skip_upload_delete_gating.py.
+Output: One-line surgical fix + adjacent log-line correction + a source-pin test.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+</execution_context>
+
+<context>
+@.planning/STATE.md
+@CLAUDE.md
+
+<interfaces>
+From pipeline/attribution.py — the function being gated (DO NOT modify it):
+```python
+def run_claimer_remediation(
+    client,
+    dry_run: bool,
+    window_weeks: int,
+    valid_wr_weeks: 'set | None' = None,
+) -> None:
+    # dry_run=True => report counts only, no attachment deleted.
+```
+
+From pipeline/config.py (both already bools — a boolean OR is valid):
+```python
+SKIP_UPLOAD = os.getenv('SKIP_UPLOAD', 'false').lower() == 'true'          # line 48
+REMEDIATION_DRY_RUN = os.getenv('REMEDIATION_DRY_RUN', '1').strip().lower() \
+    in ('1', 'true', 'yes', 'on')                                          # line 421-423
+```
+
+Current defect site — pipeline/orchestrate.py:451-463 (SKIP_UPLOAD is already imported at line 112):
+```python
+if REMEDIATE_CLAIMERS:
+    logging.info(
+        f"🧹 REMEDIATE_CLAIMERS=True — running isolated claimer "
+        f"remediation sweep (dry_run={REMEDIATION_DRY_RUN}, "
+        f"window_weeks={REMEDIATION_WINDOW_WEEKS})"
+    )
+    run_claimer_remediation(
+        client,
+        dry_run=REMEDIATION_DRY_RUN,
+        window_weeks=REMEDIATION_WINDOW_WEEKS,
+        valid_wr_weeks=None,  # isolated path: no live-identity set
+    )
+    return
+```
+
+Existing pinning convention (tests/test_skip_upload_delete_gating.py) uses
+`inspect.getsource(orch)` + substring assertions. `test_orchestrate_gates_untracked_cleanup_and_purge`
+asserts `src.count("dry_run=SKIP_UPLOAD") >= 5`. NOTE: the new call uses
+`dry_run=REMEDIATION_DRY_RUN or SKIP_UPLOAD`, which does NOT contain the exact
+substring `dry_run=SKIP_UPLOAD` — so that `>= 5` count stays valid and must NOT be
+bumped. The 6th site gets its own dedicated pin asserting `or SKIP_UPLOAD` inside the
+REMEDIATE_CLAIMERS branch.
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Add failing source-pin test for the 6th (claimer-remediation) mutating call site</name>
+  <files>tests/test_skip_upload_delete_gating.py</files>
+  <behavior>
+    - New test class TestRemediationGatesOnSkipUpload with one test method.
+    - Test: `inspect.getsource(pipeline.orchestrate)`, slice the REMEDIATE_CLAIMERS
+      branch (index from `if REMEDIATE_CLAIMERS:` to its `return`), and assert the
+      run_claimer_remediation call passes `dry_run=REMEDIATION_DRY_RUN or SKIP_UPLOAD`.
+    - Assertion substring: "REMEDIATION_DRY_RUN or SKIP_UPLOAD".
+    - Must FAIL against current source (which still reads `dry_run=REMEDIATION_DRY_RUN`).
+    - Do NOT change the existing `>= 5` count assertion in
+      test_orchestrate_gates_untracked_cleanup_and_purge.
+  </behavior>
+  <action>Append a new class TestRemediationGatesOnSkipUpload to
+tests/test_skip_upload_delete_gating.py mirroring the existing source-inspection
+pattern (TestUploadWorkerWiresSkipUpload). Locate the branch with
+`src.index("if REMEDIATE_CLAIMERS:")`, take a ~600-char window, and assert it contains
+`"REMEDIATION_DRY_RUN or SKIP_UPLOAD"`. Add a short docstring noting this pins the 6th
+mutating call site (isolated claimer-remediation sweep) to the SKIP_UPLOAD invariant.
+Run to confirm RED before implementing Task 2. Follow this file's documented
+signature/version-pin convention if the harness references a call-site hash (bump to
+v6 only if an explicit hash constant in this file requires it — otherwise no bump).</action>
+  <verify>
+    <automated>python -m pytest tests/test_skip_upload_delete_gating.py::TestRemediationGatesOnSkipUpload -v 2>&1 | grep -Ev '^#' | grep -q "1 failed" && echo RED_CONFIRMED</automated>
+  </verify>
+  <done>New test exists and FAILS against unmodified orchestrate.py (RED state confirmed); existing 5-site count assertion untouched.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Gate the remediation call on SKIP_UPLOAD and correct the log line (GREEN)</name>
+  <files>pipeline/orchestrate.py</files>
+  <action>In the REMEDIATE_CLAIMERS branch (pipeline/orchestrate.py:451-463) make two
+surgical edits and nothing else — do NOT modify run_claimer_remediation itself:
+1. Change the call argument from `dry_run=REMEDIATION_DRY_RUN` to
+   `dry_run=REMEDIATION_DRY_RUN or SKIP_UPLOAD`.
+2. Update the adjacent `logging.info(...)` so the reported dry_run reflects the
+   effective value. Introduce a local `_effective_dry_run = REMEDIATION_DRY_RUN or
+   SKIP_UPLOAD` immediately before the log call, log `dry_run={_effective_dry_run}`,
+   and pass `dry_run=_effective_dry_run` to run_claimer_remediation so the logged and
+   applied values cannot drift. Keep the existing window_weeks text.
+SKIP_UPLOAD is already imported (orchestrate.py:112); no new import needed. Preserve
+the isolation semantics (early `return` after the sweep).</action>
+  <verify>
+    <automated>python -m pytest tests/test_skip_upload_delete_gating.py -v && python -m py_compile generate_weekly_pdfs.py && echo GREEN_OK</automated>
+  </verify>
+  <done>All tests in test_skip_upload_delete_gating.py pass (including the new 6th-site pin); py_compile clean; SKIP_UPLOAD=true now forces dry_run at the remediation call and the log line reports the effective value.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| pipeline → Smartsheet API | `run_claimer_remediation` can issue `delete_attachment` (irreversible production mutation) |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-nst-01 | Tampering | orchestrate.py REMEDIATE_CLAIMERS branch | mitigate | Force `dry_run` True when SKIP_UPLOAD set (`REMEDIATION_DRY_RUN or SKIP_UPLOAD`); pinned by source-inspection test so future edits that drop the gate fail CI |
+| T-nst-02 | Repudiation | remediation log line | mitigate | Log the effective dry_run (post-OR) so run history accurately records whether deletes could have fired |
+| T-nst-SC | Tampering | npm/pip installs | accept | No new dependencies added; test uses stdlib `inspect`/`unittest.mock` already in the suite |
+</threat_model>
+
+<verification>
+- `python -m pytest tests/test_skip_upload_delete_gating.py -v` — all pass, 6th call site pinned.
+- `python -m py_compile generate_weekly_pdfs.py` — clean.
+- Broader safety net: `python -m pytest tests/test_skip_upload_delete_gating.py tests/test_billing_audit_shadow.py -v`.
+- Manual reasoning check: with SKIP_UPLOAD=true + REMEDIATION_DRY_RUN=0, effective dry_run is True → zero `delete_attachment` calls; invariant holds.
+</verification>
+
+<success_criteria>
+- SKIP_UPLOAD=true guarantees the isolated claimer-remediation sweep performs zero Smartsheet mutations regardless of REMEDIATION_DRY_RUN.
+- The remediation log line reports the effective dry_run value (no drift between logged and applied).
+- Only two files changed; run_claimer_remediation body untouched; existing 5-site pins intact.
+- PR #286 review issue resolved.
+</success_criteria>
+
+<output>
+Create `.planning/quick/260722-nst-gate-claimer-remediation-on-skip-upload-/260722-nst-SUMMARY.md` when done.
+</output>

--- a/.planning/quick/260722-nst-gate-claimer-remediation-on-skip-upload-/260722-nst-SUMMARY.md
+++ b/.planning/quick/260722-nst-gate-claimer-remediation-on-skip-upload-/260722-nst-SUMMARY.md
@@ -1,0 +1,96 @@
+---
+phase: quick-260722-nst
+plan: 01
+subsystem: billing-pipeline-safety
+tags: [skip-upload, claimer-remediation, orchestrate, tdd, pr-286]
+dependency-graph:
+  requires: []
+  provides:
+    - "SKIP_UPLOAD-gated dry_run at the isolated REMEDIATE_CLAIMERS call site"
+  affects:
+    - pipeline/orchestrate.py
+    - tests/test_skip_upload_delete_gating.py
+tech-stack:
+  added: []
+  patterns:
+    - "Boolean OR gate: dry_run = REMEDIATION_DRY_RUN or SKIP_UPLOAD (mirrors the existing dry_run=SKIP_UPLOAD pattern at 5 other mutating call sites)"
+    - "Source-inspection pinning via inspect.getsource + substring assertion (existing convention in test_skip_upload_delete_gating.py)"
+key-files:
+  created: []
+  modified:
+    - tests/test_skip_upload_delete_gating.py
+    - pipeline/orchestrate.py
+decisions:
+  - "Introduced local _effective_dry_run variable so the logged dry_run value and the value passed to run_claimer_remediation cannot drift (T-nst-02 repudiation mitigation)."
+  - "Did not bump the existing `>= 5` dry_run=SKIP_UPLOAD count assertion — the new call site uses the literal `REMEDIATION_DRY_RUN or SKIP_UPLOAD`, which does not match that substring, so it required its own dedicated pin (TestRemediationGatesOnSkipUpload)."
+metrics:
+  duration: 12m
+  completed: 2026-07-22
+---
+
+# Quick Task 260722-nst: Gate Claimer Remediation on SKIP_UPLOAD Summary
+
+One-liner: Closed the 6th unguarded Smartsheet-mutating call site (isolated
+`REMEDIATE_CLAIMERS` sweep) by folding `SKIP_UPLOAD` into its `dry_run`
+argument via boolean OR, matching the pattern already pinned at the other 5
+call sites.
+
+## What Was Built
+
+PR #286 review flagged that `pipeline/orchestrate.py`'s isolated
+claimer-remediation branch called `run_claimer_remediation(client,
+dry_run=REMEDIATION_DRY_RUN, ...)` without considering `SKIP_UPLOAD`. With
+`SKIP_UPLOAD=true`, `REMEDIATE_CLAIMERS=1`, and `REMEDIATION_DRY_RUN=0`, the
+sweep could still call `delete_attachment` against production — violating the
+"SKIP_UPLOAD = zero Smartsheet mutations" invariant established in the Living
+Ledger ([2026-07-22 14:37]).
+
+Fix: the branch now computes `_effective_dry_run = REMEDIATION_DRY_RUN or
+SKIP_UPLOAD` once, logs that effective value, and passes it to
+`run_claimer_remediation`. `run_claimer_remediation` itself was not touched —
+only the caller's argument and log line changed.
+
+## Deviations from Plan
+
+None — plan executed exactly as written. Both tasks completed in order (RED
+test committed first, GREEN fix committed second), matching the plan's
+task-by-task specification.
+
+## TDD Gate Compliance
+
+- RED gate: `test(260722-nst): pin 6th mutating call site to SKIP_UPLOAD`
+  (commit `458d7e5`) — confirmed FAILED (`AssertionError:
+  'REMEDIATION_DRY_RUN or SKIP_UPLOAD' not found`) before any implementation
+  change.
+- GREEN gate: `fix(260722-nst): gate claimer remediation on SKIP_UPLOAD`
+  (commit `60d0473`) — all 8 tests in
+  `tests/test_skip_upload_delete_gating.py` pass, including the new pin.
+- No REFACTOR commit needed (change was a 3-line surgical edit).
+
+## Verification Evidence
+
+- `python -m pytest tests/test_skip_upload_delete_gating.py -v` — 8 passed
+  (including the new `TestRemediationGatesOnSkipUpload` pin and the
+  unmodified `>= 5`-count assertion for the other 5 sites).
+- `python -m py_compile generate_weekly_pdfs.py` — clean (facade re-exports
+  `pipeline.orchestrate`, no syntax regressions).
+- Broader safety net: `python -m pytest tests/test_skip_upload_delete_gating.py
+  tests/test_billing_audit_shadow.py -v` — 214 passed, 61 subtests passed.
+- Manual reasoning check: with `SKIP_UPLOAD=true` and
+  `REMEDIATION_DRY_RUN=0`, `_effective_dry_run` evaluates to `True` →
+  `run_claimer_remediation` receives `dry_run=True` → zero
+  `delete_attachment` calls. Invariant holds.
+
+## Threat Flags
+
+None — this change closes an existing threat register item (T-nst-01,
+T-nst-02 from the plan's `<threat_model>`) and introduces no new surface.
+`run_claimer_remediation`'s body, signature, and all other mutating call
+sites are unchanged.
+
+## Self-Check: PASSED
+
+- FOUND: tests/test_skip_upload_delete_gating.py (TestRemediationGatesOnSkipUpload class present)
+- FOUND: pipeline/orchestrate.py (`_effective_dry_run = REMEDIATION_DRY_RUN or SKIP_UPLOAD` present)
+- FOUND commit 458d7e5 (test RED)
+- FOUND commit 60d0473 (fix GREEN)

--- a/generate_weekly_pdfs.py
+++ b/generate_weekly_pdfs.py
@@ -17,33 +17,6 @@ import logging
 import smartsheet
 import smartsheet.exceptions as ss_exc
 
-# Upstream SDK workaround: smartsheet-python-sdk 3.8.0 raises an
-# AttributeError from smartsheet.smartsheet.Smartsheet._request_with_retry
-# whenever the API returns a retryable error (429, 5xx). At
-# smartsheet/smartsheet.py:303 it does
-# ``getattr(sys.modules[__name__], native.result.name)`` to look up the
-# exception class to raise, but that module's top-level imports only
-# expose ApiError / HttpError / UnexpectedRequestError. The retryable
-# exception classes (RateLimitExceededError, UnexpectedErrorShouldRetry-
-# Error, InternalServerError, ServerTimeoutExceededError, SystemMainte-
-# nanceError) live in smartsheet.exceptions and were never re-exported
-# into smartsheet.smartsheet, so the getattr fails and our retry
-# wrapper never gets the real exception. Re-export the missing names
-# here so the SDK's internal lookup succeeds. The ``if not hasattr``
-# guard makes this a no-op if the upstream SDK ever re-exports them.
-import smartsheet.smartsheet as _ss_smartsheet_module
-_exc_name = None
-for _exc_name in (
-    'RateLimitExceededError',
-    'UnexpectedErrorShouldRetryError',
-    'InternalServerError',
-    'ServerTimeoutExceededError',
-    'SystemMaintenanceError',
-):
-    if not hasattr(_ss_smartsheet_module, _exc_name) and hasattr(ss_exc, _exc_name):
-        setattr(_ss_smartsheet_module, _exc_name, getattr(ss_exc, _exc_name))
-del _ss_smartsheet_module
-del _exc_name
 from dotenv import load_dotenv
 import signal
 

--- a/memory-bank/living-ledger.md
+++ b/memory-bank/living-ledger.md
@@ -4858,3 +4858,35 @@ API), and the emergency `>=3.1.0,<4.0.0` pin lifted to the exact
   bump to actually land under the 18:20 exact-pin rule — future SDK bumps
   must repeat this shape (changelog review date + commit hash + 6-gate +
   live-probe evidence) before merge.
+
+## [2026-07-22 10:20] Phase 08 D-05 live probe SIGNED OFF — SDK 4.3.0 real-transport green, one pre-existing SKIP_UPLOAD finding
+
+Operator (Juan) ran the D-05 bounded read-only probe against real
+Smartsheet on 4.3.0 (~10:07 CDT, `SKIP_UPLOAD=true
+WR_FILTER=84157414,89881161 MAX_GROUPS=5`, SDK version confirmed 4.3.0 via
+`python -m pip`). Result: **PASSED** for all SDK-facing criteria — all
+source sheets fetched, "Grouping validation passed: 2771 groups", 676
+target-row + 545 PPP attachment-list calls completed via the retry wrapper
+(12.8s/9.5s, 8 workers, 0 cancelled), 5 Excel files generated locally under
+`generated_docs/`, zero `ModuleNotFoundError`/`AttributeError`/retry-path
+exceptions. No SDK 4.3.0 error-shape drift observed — `pipeline/retry.py`'s
+`ApiError.error.result` introspection matches the real 4.3.0 response shape.
+
+- **Pre-existing finding, NOT SDK drift:** `SKIP_UPLOAD=true` gates only the
+  upload half of the engine's delete-then-upload sequence, not the delete
+  half. The probe deleted 2 prior WR 89881161 attachments on the production
+  `TARGET_SHEET_ID` sheet before correctly skipping the re-upload — this is
+  byte-identical behavior on 3.x, unrelated to the SDK migration. Full
+  detail + suggested fix logged in
+  `.planning/phases/08-smartsheet-python-sdk-4-0-0-compatibility-migration/deferred-items.md`.
+- **Self-healing rule confirmed:** the hash-history write is withheld
+  whenever an upload does not complete (`SKIP_UPLOAD=true` counts), so a
+  deleted-then-skipped attachment always regenerates and re-uploads on the
+  next scheduled run — no silent permanent data loss from this class of
+  defect. Operator let the next weekday cron self-heal rather than manually
+  restoring.
+- **SDK-06 live half CLOSED:** this is the real-transport confirmation
+  mocks and TEST_MODE cannot give (per the 18:20 entry's validation
+  blind-spot rule) — commits `76e2471` (exact pin) / `038816c` (prior
+  ledger entry) are now proven against production data, not just synthetic
+  suites.

--- a/memory-bank/living-ledger.md
+++ b/memory-bank/living-ledger.md
@@ -4832,3 +4832,29 @@ commit `631f757`). Durable rules and facts:
   workflow edits, 6-gate harness + live probe, staged rollout) overrides
   stale `08-RESEARCH.md` (written vs 4.0) via D-08 corrections. PLAN.md
   files not yet written — planner/checker loop pending.
+
+## [2026-07-22 02:31] Phase 08 SDK 4.x migration — exact pin ==4.3.0 landed, dead re-export block removed
+
+Phase 08 code change complete on branch `feat/phase-08-sdk-430-migration`:
+`generate_weekly_pdfs.py`'s dead 3.x `smartsheet.smartsheet` re-export shim
+(27 lines) removed (Plan 08-01, commit `b2e76bf`), `tests/golden/baseline_names.json`
+rebaselined 178 -> 177 names (the `_exc_name` import-time temp, never public
+API), and the emergency `>=3.1.0,<4.0.0` pin lifted to the exact
+`smartsheet-python-sdk==4.3.0` (Plan 08-02, commit `76e2471`).
+
+- **Verification evidence:** `scripts/run_6_gates.sh` on 4.3.0 -> `=== ALL 6
+  GATES PASSED ===` (AST equality 177 names, facade completeness 108 names,
+  pytest 1164 passed/130 subtests, mypy delta neutral, py_compile clean,
+  golden run_summary 21-key match). Full `pytest tests/ -v` independently:
+  1164 passed, 130 subtests passed, 0 failed.
+- **Live probe status:** the D-05 live read-only `SKIP_UPLOAD=true` probe
+  against real Smartsheet on 4.3.0 is this plan's Task 3 — human-gated
+  (operator-run, `checkpoint:human-verify` / `gate=blocking-human`), writes
+  nothing to Smartsheet. Result recorded in `08-02-SUMMARY.md` once the
+  operator runs it; not fabricated here.
+- **`--no-binary` retirement:** already recorded in the 2026-07-21 18:20
+  entry above — cross-referenced, not restated.
+- **Exact-pin rule applied:** this entry is the first transport-critical dep
+  bump to actually land under the 18:20 exact-pin rule — future SDK bumps
+  must repeat this shape (changelog review date + commit hash + 6-gate +
+  live-probe evidence) before merge.

--- a/memory-bank/living-ledger.md
+++ b/memory-bank/living-ledger.md
@@ -4819,3 +4819,16 @@ commit `631f757`). Durable rules and facts:
   cron missed-check-in storm stopped (margin 60 live). The single 07-18
   "timeout check-in" was a lost closing check-in on a 65-min successful run
   (GH 29620427187) — benign one-off.
+
+## [2026-07-21 19:10] Phase 08 planning started — validation strategy committed
+
+- `/gsd-plan-phase 08` in progress on `feat/phase-08-sdk-430-migration`.
+  `08-VALIDATION.md` created + committed (`68ac4ae`): pytest quick/full
+  commands, and a **manual-only** live read-only Smartsheet probe row
+  (SDK-05) encoding the mocked-ApiError blind-spot rule above — mocks
+  cannot prove real SDK exception shapes, so the probe is part of the
+  phase's validation contract, not an afterthought.
+- Planning inputs: `08-CONTEXT.md` (locked: exact pin `==4.3.0`, no
+  workflow edits, 6-gate harness + live probe, staged rollout) overrides
+  stale `08-RESEARCH.md` (written vs 4.0) via D-08 corrections. PLAN.md
+  files not yet written — planner/checker loop pending.

--- a/memory-bank/living-ledger.md
+++ b/memory-bank/living-ledger.md
@@ -4890,3 +4890,34 @@ exceptions. No SDK 4.3.0 error-shape drift observed — `pipeline/retry.py`'s
   blind-spot rule) — commits `76e2471` (exact pin) / `038816c` (prior
   ledger entry) are now proven against production data, not just synthetic
   suites.
+
+## [2026-07-22 14:37] Phase 08 secure-phase: SKIP_UPLOAD is now fully read-only (T-08-03 fix)
+
+- **Rule (new invariant):** `SKIP_UPLOAD=true` ⇒ **zero Smartsheet
+  mutations** — deletes included, not just uploads. Any future code path
+  that mutates a sheet must be gated on it (pattern: `dry_run: bool =
+  False` param, wired `dry_run=SKIP_UPLOAD` at the orchestrate call
+  site). Read-only decisions (legacy hash short-circuit, identity
+  matching, skip logging) still run so dry-run output stays
+  representative.
+- **Why:** the D-05 live probe (`SKIP_UPLOAD=true`) deleted 2 real
+  production attachments (WR 89881161, weeks 072025/081725) because
+  `delete_old_excel_attachments()` ran unconditionally in `_upload_one`
+  while `SKIP_UPLOAD` gated only the `attach_file_to_row` call.
+  Pre-existing defect (identical under SDK 3.x), surfaced by the probe,
+  self-healed by the withheld-hash → next-cron regeneration.
+- **Fix (Juan-approved via /gsd:secure-phase 08):** `dry_run` param added
+  to `delete_old_excel_attachments`, `cleanup_untracked_sheet_attachments`,
+  and `purge_existing_hashed_outputs` (`pipeline/cleanup.py`); all five
+  mutating call sites in `pipeline/orchestrate.py` pass
+  `dry_run=SKIP_UPLOAD`. Default `False` keeps every existing call site
+  byte-identical (signature-pin test updated in-place to v6 per the
+  [2026-05-20 00:26] rule).
+- **Evidence:** TDD RED→GREEN in `tests/test_skip_upload_delete_gating.py`
+  (7 tests: dry-run preserves candidates, legacy hash skip still fires,
+  default-False regression guard, source-wiring pins); full suite
+  **1171 passed + 130 subtests**. Threat register: `08-SECURITY.md`
+  (6/6 closed, threats_open: 0).
+- **Carry-forward flag (unregistered, WARNING):** `TEST_MODE=true` with a
+  real token still performs real Smartsheet READS (synthetic path only
+  `if not API_TOKEN`) — add to the next phase's threat register.

--- a/memory-bank/living-ledger.md
+++ b/memory-bank/living-ledger.md
@@ -4788,3 +4788,34 @@ Validation: targeted suites 17/17 + 5/5; full suite 1163 passed / 1 failed —
 from a subprocess pipe; Ubuntu CI unaffected). Known-footgun note: that test
 harness should eventually pass `encoding='utf-8'` to its subprocess reader —
 separate test-infra fix, do not band-aid production code for it.
+
+## [2026-07-21 18:20] Phase 08 SDK 4.x migration — decisions locked; exact-pin rule for transport-critical deps
+
+Phase 08 (lift the `<4.0.0` smartsheet-python-sdk pin) unblocked and context
+gathered (`/gsd-discuss-phase 08`, branch `feat/phase-08-sdk-430-migration`,
+commit `631f757`). Durable rules and facts:
+
+- **Exact-pin rule (extends 260608-gwm):** transport-critical deps get an
+  EXACT pin (`smartsheet-python-sdk==4.3.0`), not just an upper bound.
+  Version bumps are deliberate, changelog-reviewed PRs. Rationale: the June
+  2026 CI crash happened because an unreviewed release auto-entered
+  production through an open range.
+- **`--no-binary` is obsolete:** the 4.0.0 wheel packaging bug (7,842 B
+  wheel shipping only `version.py`) was fixed upstream in 4.0.1 (issue
+  #144). Wheel sizes verified via PyPI JSON 2026-07-21: 4.0.1–4.3.0 =
+  259–271 KB, none yanked. The 08-RESEARCH.md prescription to add
+  `--no-binary` to the workflows is retired; the migration makes ZERO
+  GitHub Actions edits.
+- **Changelog 4.0.1→4.3.0 reviewed 2026-07-21:** all additive; nothing
+  touches `smartsheet.exceptions`, `ApiError.error.result` internals, or
+  any in-use call signature. Only 4.3.0 grazes in-use models (additive
+  `Row.proof` field; template case in `PaginatedChildrenResult.append_data`).
+- **Validation blind-spot rule:** `tests/test_smartsheet_retry.py` builds
+  `ApiError.error.result` with `mock.Mock()` and TEST_MODE synthetic runs
+  never touch the transport — neither can catch real SDK error-shape drift.
+  Any SDK version change must therefore include a LIVE read-only probe
+  (real `get_sheet` + attachment list) in addition to the 6-gate harness.
+- Post-merge validation of PR #284 closed: 503-retry fix quiet since merge;
+  cron missed-check-in storm stopped (margin 60 live). The single 07-18
+  "timeout check-in" was a lost closing check-in on a 65-min successful run
+  (GH 29620427187) — benign one-off.

--- a/pipeline/cleanup.py
+++ b/pipeline/cleanup.py
@@ -99,6 +99,7 @@ def cleanup_untracked_sheet_attachments(
     sub_legacy_primary_variants: set[str] | None = None,
     vac_legacy_wr_scope: set[str] | None = None,
     primary_wr_scope: set[str] | None = None,
+    dry_run: bool = False,
 ):
     """Prune only older variants for identities processed this run (VARIANT-AWARE).
 
@@ -193,6 +194,9 @@ def cleanup_untracked_sheet_attachments(
     KEEP_HISTORICAL_WEEKS = _gwp.KEEP_HISTORICAL_WEEKS
     if test_mode:
         logging.info("🧪 Test mode – skipping sheet attachment pruning")
+        return
+    if dry_run:
+        logging.info("⏭️  Dry run (SKIP_UPLOAD) – skipping sheet attachment pruning")
         return
     try:
         sheet = target_sheet if target_sheet is not None else client.Sheets.get_sheet(target_sheet_id)
@@ -448,7 +452,7 @@ def cleanup_untracked_sheet_attachments(
         f"removed_off_contract={removed_off_contract}"
     )
 
-def delete_old_excel_attachments(client, target_sheet_id, target_row, wr_num, week_raw, current_data_hash, variant='primary', identifier=None, force_generation=False, cached_attachments: list | None = None):
+def delete_old_excel_attachments(client, target_sheet_id, target_row, wr_num, week_raw, current_data_hash, variant='primary', identifier=None, force_generation=False, cached_attachments: list | None = None, dry_run: bool = False):
     """Delete prior Excel attachment(s) ONLY for the specific (WR, week, variant, identifier) identity.
 
     VARIANT-AWARE BEHAVIOR:
@@ -462,6 +466,10 @@ def delete_old_excel_attachments(client, target_sheet_id, target_row, wr_num, we
         variant: 'primary' or 'helper'
         identifier: For helper variant, the helper name; for primary+user, the user identifier
         cached_attachments: Pre-fetched attachment list (avoids redundant API call)
+        dry_run: When True (SKIP_UPLOAD runs), keep every read-only
+            decision (identity matching, legacy hash skip) but never
+            call delete_attachment — a validation run must not mutate
+            the sheet (Phase 08 T-08-03).
 
     Returns (deleted_count, skipped_due_to_same_data)
     """
@@ -526,6 +534,10 @@ def delete_old_excel_attachments(client, target_sheet_id, target_row, wr_num, we
                 logging.info(f"⏩ Unchanged ({variant} WR {wr_num} Week {week_raw}) hash {current_data_hash}; skipping regeneration & upload")
                 return 0, True
 
+    if dry_run:
+        logging.info(f"⏭️  Dry run (SKIP_UPLOAD): preserving {len(candidates)} prior {variant} attachment(s) for WR {wr_num} Week {week_raw}")
+        return 0, False
+
     logging.info(f"🗑️ Removing {len(candidates)} prior {variant} attachment(s) for WR {wr_num} Week {week_raw}")
     for att in candidates:
         try:
@@ -570,7 +582,7 @@ def _has_existing_week_attachment(client, target_sheet_id, target_row, wr_num: s
     
     return False
 
-def purge_existing_hashed_outputs(client, target_sheet_id: int, wr_subset: set | None, test_mode: bool):
+def purge_existing_hashed_outputs(client, target_sheet_id: int, wr_subset: set | None, test_mode: bool, dry_run: bool = False):
     """Delete existing hashed Excel attachments and local files so hashes recompute fresh.
 
     wr_subset: if provided, only purge attachments for these WR numbers; otherwise purge all WR_*.xlsx attachments.
@@ -601,6 +613,9 @@ def purge_existing_hashed_outputs(client, target_sheet_id: int, wr_subset: set |
 
     if test_mode:
         logging.info("🧪 Test mode active – skipping remote attachment purge")
+        return
+    if dry_run:
+        logging.info("⏭️  Dry run (SKIP_UPLOAD) – skipping remote attachment purge")
         return
     try:
         sheet = client.Sheets.get_sheet(target_sheet_id)

--- a/pipeline/orchestrate.py
+++ b/pipeline/orchestrate.py
@@ -449,14 +449,15 @@ def main():  # pyright: ignore[reportGeneralTypeIssues]
         # When active, the sweep runs and main() returns immediately (isolation:
         # no Excel generation occurs in this session).
         if REMEDIATE_CLAIMERS:
+            _effective_dry_run = REMEDIATION_DRY_RUN or SKIP_UPLOAD
             logging.info(
                 f"🧹 REMEDIATE_CLAIMERS=True — running isolated claimer "
-                f"remediation sweep (dry_run={REMEDIATION_DRY_RUN}, "
+                f"remediation sweep (dry_run={_effective_dry_run}, "
                 f"window_weeks={REMEDIATION_WINDOW_WEEKS})"
             )
             run_claimer_remediation(
                 client,
-                dry_run=REMEDIATION_DRY_RUN,
+                dry_run=_effective_dry_run,
                 window_weeks=REMEDIATION_WINDOW_WEEKS,
                 valid_wr_weeks=None,  # isolated path: no live-identity set
             )

--- a/pipeline/orchestrate.py
+++ b/pipeline/orchestrate.py
@@ -567,11 +567,11 @@ def main():  # pyright: ignore[reportGeneralTypeIssues]
                     logging.info(f"🧨 Hash reset requested for specific WRs: {sorted(list(RESET_WR_LIST))}")
                     span.set_data("purge_type", "wr_subset")
                     span.set_data("wr_count", len(RESET_WR_LIST))
-                    purge_existing_hashed_outputs(client, TARGET_SHEET_ID, RESET_WR_LIST, TEST_MODE)
+                    purge_existing_hashed_outputs(client, TARGET_SHEET_ID, RESET_WR_LIST, TEST_MODE, dry_run=SKIP_UPLOAD)
                 else:
                     logging.info("🧨 Global hash reset requested (RESET_HASH_HISTORY=1)")
                     span.set_data("purge_type", "global")
-                    purge_existing_hashed_outputs(client, TARGET_SHEET_ID, None, TEST_MODE)
+                    purge_existing_hashed_outputs(client, TARGET_SHEET_ID, None, TEST_MODE, dry_run=SKIP_UPLOAD)
             # After purge, any regenerated files get new timestamp+hash filenames and re-upload
         
         if not groups:
@@ -2142,7 +2142,8 @@ def main():  # pyright: ignore[reportGeneralTypeIssues]
                         task['week_raw'], task['data_hash'],
                         variant=task['variant'], identifier=task['file_identifier'],
                         force_generation=force_this,
-                        cached_attachments=attachment_cache.get(target_row.id)
+                        cached_attachments=attachment_cache.get(target_row.id),
+                        dry_run=SKIP_UPLOAD
                     )
                     if force_this and skipped:
                         skipped = False
@@ -2478,6 +2479,7 @@ def main():  # pyright: ignore[reportGeneralTypeIssues]
                     sub_legacy_primary_variants=_target_legacy_primary,
                     vac_legacy_wr_scope=_vac_scope,
                     primary_wr_scope=_primary_scope,
+                    dry_run=SKIP_UPLOAD,
                 )
 
             # Phase 01 gap closure (REVIEW-WR-01): parallel cleanup pass
@@ -2556,6 +2558,7 @@ def main():  # pyright: ignore[reportGeneralTypeIssues]
                             if _sub_scope and SUBCONTRACTOR_LEGACY_PRIMARY_CLEANUP_ENABLED
                             else None
                         ),
+                        dry_run=SKIP_UPLOAD,
                     )
 
         # Cleanup legacy / stale Excel files so only current system outputs remain

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,11 @@
 sentry-sdk>=2.54.0
 
 # Core Dependencies
-# 3.1.0+ required for Folders.get_folder_children (replacement for deprecated get_folder)
-# Upper bound excludes the breaking 4.0.0 (2026-06-08) major release, which removed
-# smartsheet.exceptions + Folders.get_folder/list_folders + Templates and changed pagination.
-smartsheet-python-sdk>=3.1.0,<4.0.0
+# Exact pin (not a range): extends the 260608-gwm "upper-bound transport-critical
+# deps" Living Ledger rule to its strongest form (D-01) -- an unreviewed SDK
+# release can never auto-enter production. 4.0.1->4.3.0 changelog reviewed
+# 2026-07-21, additive-only. See memory-bank/living-ledger.md for full rationale.
+smartsheet-python-sdk==4.3.0
 openpyxl==3.1.5
 Pillow==12.2.0
 python-dateutil==2.9.0.post0

--- a/tests/golden/baseline_names.json
+++ b/tests/golden/baseline_names.json
@@ -112,7 +112,6 @@
   "_cutoff_str",
   "_default_hist_path",
   "_env_hist_path",
-  "_exc_name",
   "_has_existing_week_attachment",
   "_normalize_column_title_for_vac_crew",
   "_parse_sentry_enable_logs",

--- a/tests/test_entrypoint_no_double_import.py
+++ b/tests/test_entrypoint_no_double_import.py
@@ -35,7 +35,13 @@ class TestEntrypointNoDoubleImport(unittest.TestCase):
         result = subprocess.run(
             [sys.executable, 'generate_weekly_pdfs.py'],
             cwd=repo_root, env=env,
-            capture_output=True, text=True, timeout=180,
+            capture_output=True, text=True,
+            # Parent-side decode must match the child's forced UTF-8: on a
+            # vanilla Windows shell the default cp1252 codec dies on the
+            # emoji banner bytes, returning stdout/stderr as None and
+            # masking the assertion diagnostics with a TypeError.
+            encoding='utf-8', errors='replace',
+            timeout=180,
         )
         combined = result.stdout + result.stderr
         count = combined.count('CRITICAL FIXES APPLIED')

--- a/tests/test_entrypoint_no_double_import.py
+++ b/tests/test_entrypoint_no_double_import.py
@@ -25,7 +25,12 @@ class TestEntrypointNoDoubleImport(unittest.TestCase):
         env['SKIP_UPLOAD'] = 'true'        # no Smartsheet writes
         env['PYTHONUTF8'] = '1'            # emoji banners on Windows cp1252
         env['PYTHONIOENCODING'] = 'utf-8'
-        env.pop('SMARTSHEET_API_TOKEN', None)  # force the synthetic path
+        # Force the synthetic path. An EMPTY string (not pop): the engine's
+        # load_dotenv() re-injects the token from a developer .env when the
+        # var is absent, flipping this test into a real multi-minute API
+        # fetch. load_dotenv never overrides an existing var, and empty is
+        # falsy so orchestrate falls back to the synthetic dataset.
+        env['SMARTSHEET_API_TOKEN'] = ''
 
         result = subprocess.run(
             [sys.executable, 'generate_weekly_pdfs.py'],

--- a/tests/test_security_audit_followup.py
+++ b/tests/test_security_audit_followup.py
@@ -2906,20 +2906,30 @@ class TestPppCleanupUntrackedAttachments(unittest.TestCase):
         # D Task 10 (2026-05-25) appends one more trailing kwarg:
         # primary_wr_scope. All six are optional (None default) so
         # existing TARGET / PPP call sites remain byte-identical.
+        # Phase 08 security follow-up T-08-03 (2026-07-22) appends one
+        # more trailing kwarg: dry_run (bool, default False) — gates
+        # the SKIP_UPLOAD dry-run so validation runs never delete
+        # attachments. Reviewed against D-09: default False preserves
+        # byte-identical legacy behavior.
         # IN-PLACE UPDATE per [2026-05-20 00:26] rule 2 — the assertion
-        # follows the v5 signature contract.
+        # follows the v6 signature contract.
         self.assertEqual(
             params,
             ['client', 'target_sheet_id', 'valid_wr_weeks',
              'test_mode', 'attachment_cache', 'target_sheet',
              'variant_whitelist', 'sub_wr_scope', 'sub_offcontract_variants',
              'sub_legacy_primary_variants', 'vac_legacy_wr_scope',
-             'primary_wr_scope'],
-            "Subproject D Task 10 appends a trailing kwarg after "
-            "'vac_legacy_wr_scope': 'primary_wr_scope'. "
+             'primary_wr_scope', 'dry_run'],
+            "Phase 08 T-08-03 appends a trailing kwarg after "
+            "'primary_wr_scope': 'dry_run'. "
             "Any further drift must be reviewed against D-09 (TARGET "
             "legacy behavior). "
             f"Got: {params}"
+        )
+        self.assertIs(
+            sig.parameters['dry_run'].default, False,
+            'dry_run must default to False (Phase 08 T-08-03) so all '
+            'existing call sites keep mutating behavior unchanged.'
         )
         # All trailing kwargs must default to None (D-09) so
         # existing call sites without the new kwargs are unaffected.

--- a/tests/test_skip_upload_delete_gating.py
+++ b/tests/test_skip_upload_delete_gating.py
@@ -1,0 +1,134 @@
+"""Phase 08 security follow-up (T-08-03) — SKIP_UPLOAD must gate deletes.
+
+The D-05 live probe (SKIP_UPLOAD=true) deleted prior production
+attachments because ``delete_old_excel_attachments`` ran
+unconditionally in the upload worker while ``SKIP_UPLOAD`` gated only
+the subsequent upload. These tests pin the fix: a ``dry_run`` flag on
+``delete_old_excel_attachments`` that preserves the read-only skip
+decision but never calls ``delete_attachment``, wired from the upload
+worker as ``dry_run=SKIP_UPLOAD``.
+"""
+import inspect
+import unittest
+from unittest import mock
+
+from tests.test_billing_audit_shadow import _ensure_smartsheet_mocked
+
+_ensure_smartsheet_mocked()
+
+import generate_weekly_pdfs as gwp  # noqa: E402
+
+
+class _FakeAtt:
+    def __init__(self, name, id_):
+        self.name = name
+        self.id = id_
+
+
+class TestDeleteOldDryRun(unittest.TestCase):
+    """``dry_run=True`` must never mutate Smartsheet."""
+
+    def setUp(self):
+        self._saved_auth = gwp.SUPABASE_HASH_STORE_AUTHORITATIVE
+
+    def tearDown(self):
+        gwp.SUPABASE_HASH_STORE_AUTHORITATIVE = self._saved_auth
+
+    def _client(self):
+        c = mock.Mock()
+        c.Attachments.delete_attachment.return_value = None
+        return c
+
+    def _row(self):
+        r = mock.Mock()
+        r.id = 99
+        return r
+
+    def test_dry_run_preserves_matching_prior_attachment(self):
+        # Authoritative mode (production): a changed group would
+        # normally delete the prior same-identity attachment. Under
+        # dry_run the candidate must survive untouched.
+        gwp.SUPABASE_HASH_STORE_AUTHORITATIVE = True
+        att = _FakeAtt(
+            "WR_90001_WeekEnding_041926_120000_deadbeefcafe0001.xlsx", 1)
+        client = self._client()
+        deleted, skipped = gwp.delete_old_excel_attachments(
+            client, 123, self._row(), "90001", "041926",
+            "newhash0000000000", variant="primary", identifier=None,
+            cached_attachments=[att], dry_run=True)
+        self.assertEqual((deleted, skipped), (0, False))
+        client.Attachments.delete_attachment.assert_not_called()
+
+    def test_dry_run_keeps_legacy_hash_skip_decision(self):
+        # Legacy (non-authoritative) mode: the same-hash short-circuit
+        # is a read-only decision and must still fire under dry_run.
+        gwp.SUPABASE_HASH_STORE_AUTHORITATIVE = False
+        att = _FakeAtt(
+            "WR_90001_WeekEnding_041926_120000_deadbeefcafe0001.xlsx", 1)
+        client = self._client()
+        deleted, skipped = gwp.delete_old_excel_attachments(
+            client, 123, self._row(), "90001", "041926",
+            "deadbeefcafe0001", variant="primary", identifier=None,
+            cached_attachments=[att], dry_run=True)
+        self.assertEqual((deleted, skipped), (0, True))
+        client.Attachments.delete_attachment.assert_not_called()
+
+    def test_dry_run_default_false_preserves_delete_behavior(self):
+        # Callers that do not pass dry_run keep today's behavior.
+        gwp.SUPABASE_HASH_STORE_AUTHORITATIVE = True
+        att = _FakeAtt(
+            "WR_90001_WeekEnding_041926_120000_deadbeefcafe0001.xlsx", 1)
+        client = self._client()
+        deleted, skipped = gwp.delete_old_excel_attachments(
+            client, 123, self._row(), "90001", "041926",
+            "newhash0000000000", variant="primary", identifier=None,
+            cached_attachments=[att])
+        self.assertEqual((deleted, skipped), (1, False))
+        client.Attachments.delete_attachment.assert_called_once()
+
+
+class TestCleanupUntrackedDryRun(unittest.TestCase):
+    """``dry_run=True`` must short-circuit untracked-attachment pruning."""
+
+    def test_dry_run_returns_before_any_sheet_mutation(self):
+        client = mock.Mock()
+        gwp.cleanup_untracked_sheet_attachments(
+            client, 123, set(), False, dry_run=True)
+        client.Attachments.delete_attachment.assert_not_called()
+        client.Sheets.get_sheet.assert_not_called()
+
+
+class TestPurgeDryRun(unittest.TestCase):
+    """``dry_run=True`` must skip the remote purge (local reset only)."""
+
+    def test_dry_run_skips_remote_attachment_purge(self):
+        client = mock.Mock()
+        gwp.purge_existing_hashed_outputs(
+            client, 123, None, False, dry_run=True)
+        client.Attachments.delete_attachment.assert_not_called()
+        client.Sheets.get_sheet.assert_not_called()
+
+
+class TestUploadWorkerWiresSkipUpload(unittest.TestCase):
+    """Every Smartsheet-mutating cleanup path must receive
+    dry_run=SKIP_UPLOAD from orchestrate."""
+
+    def test_orchestrate_gates_delete_on_skip_upload(self):
+        import pipeline.orchestrate as orch
+        src = inspect.getsource(orch)
+        call_start = src.index("delete_old_excel_attachments(",
+                               src.index("def _upload_one"))
+        call_src = src[call_start:call_start + 600]
+        self.assertIn("dry_run=SKIP_UPLOAD", call_src)
+
+    def test_orchestrate_gates_untracked_cleanup_and_purge(self):
+        import pipeline.orchestrate as orch
+        src = inspect.getsource(orch)
+        # Two cleanup_untracked_sheet_attachments call sites (TARGET +
+        # PPP) and two purge_existing_hashed_outputs call sites must
+        # all pass dry_run=SKIP_UPLOAD.
+        self.assertGreaterEqual(src.count("dry_run=SKIP_UPLOAD"), 5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_skip_upload_delete_gating.py
+++ b/tests/test_skip_upload_delete_gating.py
@@ -130,5 +130,25 @@ class TestUploadWorkerWiresSkipUpload(unittest.TestCase):
         self.assertGreaterEqual(src.count("dry_run=SKIP_UPLOAD"), 5)
 
 
+class TestRemediationGatesOnSkipUpload(unittest.TestCase):
+    """PR #286 follow-up: the 6th mutating call site.
+
+    The isolated REMEDIATE_CLAIMERS sweep calls
+    ``run_claimer_remediation(..., dry_run=REMEDIATION_DRY_RUN)``
+    without folding in SKIP_UPLOAD, so SKIP_UPLOAD=true +
+    REMEDIATION_DRY_RUN=0 could still issue delete_attachment calls
+    against production. This pins the fix: the effective dry_run must
+    be ``REMEDIATION_DRY_RUN or SKIP_UPLOAD``.
+    """
+
+    def test_remediation_call_ors_in_skip_upload(self):
+        import pipeline.orchestrate as orch
+        src = inspect.getsource(orch)
+        branch_start = src.index("if REMEDIATE_CLAIMERS:")
+        branch_end = src.index("return", branch_start)
+        branch_src = src[branch_start:branch_end]
+        self.assertIn("REMEDIATION_DRY_RUN or SKIP_UPLOAD", branch_src)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Objective

Migrate the production billing engine off the emergency `smartsheet-python-sdk>=3.1.0,<4.0.0` pin (hotfix 260608-gwm / PR #273) to an exact, changelog-reviewed `==4.3.0` pin — with zero behavior change to the Smartsheet → Excel → Smartsheet pipeline — and close the SKIP_UPLOAD mutation gap surfaced by the live probe.

## Changes Made

- **`requirements.txt`** — pin lifted `>=3.1.0,<4.0.0` → exact `smartsheet-python-sdk==4.3.0` (D-01 exact-pin rule; comment records changelog review + ledger pointer).
- **`generate_weekly_pdfs.py`** — removed the dead 27-line 3.x `smartsheet.smartsheet` re-export shim (D-04); imports are now just `import smartsheet` + `import smartsheet.exceptions as ss_exc`.
- **`tests/golden/baseline_names.json`** — Gate 1 frozen name-set 178 → 177 (`_exc_name`, the shim's loop temp — authorized removal).
- **`pipeline/cleanup.py` + `pipeline/orchestrate.py`** — security fix (T-08-03): new `dry_run` param on `delete_old_excel_attachments` / `cleanup_untracked_sheet_attachments` / `purge_existing_hashed_outputs`, wired `dry_run=SKIP_UPLOAD` at all 5 mutating call sites. New invariant: `SKIP_UPLOAD=true` ⇒ zero Smartsheet mutations. TDD'd in `tests/test_skip_upload_delete_gating.py` (7 tests).
- **`tests/test_entrypoint_no_double_import.py`** — hermeticity fix: sets `SMARTSHEET_API_TOKEN=''` so `load_dotenv()` can't re-inject a real token and flip the banner test into a live API fetch.
- **Docs/planning** — Living Ledger migration + D-05 sign-off entries, D-06 rollout / D-07 rollback runbooks, phase 08 planning artifacts (plans, summaries, security register 6/6 closed, verification passed, UAT 6/6 passed).

## Production Safety Check

Existing production logic is confirmed unbroken:

- **Six-gate behavior-neutrality harness: ALL 6 GATES PASSED** under 4.3.0 (AST import equality, facade completeness, pytest, mypy delta, py_compile, golden run_summary).
- **Full suite: 1171 passed + 130 subtests, 0 failures.**
- **D-05 live read-only probe (operator-run, real transport):** 2,771 groups validated, 676 target-row + 545 PPP attachment listings via the retry wrapper, 5 Excel files generated, zero SDK error-shape drift — `pipeline/retry.py`'s `ApiError.error.result` introspection matches real 4.3.0 responses.
- **UAT: 6/6 passed, 0 issues** (`.planning/phases/08-*/08-UAT.md`); security register 6/6 threats closed (`threats_open: 0`).
- **Rollout (D-06):** merge in a weekday daytime window right after a green scheduled run (not the Sunday-night window before the Monday 05:00 UTC deep run), then fire one watched `workflow_dispatch` canary.
- **Rollback (D-07):** revert the PR — pip cache auto-busts on the `requirements.txt` hash; no workflow-file or retry-logic changes were made.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JF9p46CYvTHeJbbNnFGNv2

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR migrates the billing pipeline to Smartsheet SDK 4.3.0 and closes the upload-skip mutation gap. The main changes are:

- Pins `smartsheet-python-sdk` to version 4.3.0.
- Removes the obsolete SDK 3.x exception re-export shim.
- Prevents remote attachment deletion when `SKIP_UPLOAD` is enabled.
- Applies the same dry-run boundary to claimer remediation.
- Adds tests for the updated mutation guards and entrypoint environment.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

The remediation path now treats `SKIP_UPLOAD` as a dry run. Remote cleanup, purge, replacement, and upload mutations are suppressed under the same flag. No blocking issues were found in the updated code.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The revision 458d7e5 initially failed the remediation SKIP\_UPLOAD assertion with exit code 1.
- The requested focused pytest command was run and it passed 8 tests in 0.40 seconds with exit code 0.
- End-to-end verification showed SMARTSHEET\_API\_TOKEN length=0, the synthetic in-memory dataset was selected, and two generated files completed with exit code 0.
- The environment was verified to include SKIP\_UPLOAD=true, which prevents the remote upload path.

<a href="https://app.greptile.com/trex/runs/15492598/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pipeline/orchestrate.py | Combines `SKIP_UPLOAD` with remediation dry-run behavior and passes the flag through remote cleanup paths. |
| pipeline/cleanup.py | Adds dry-run guards before remote attachment deletion in cleanup, replacement, and purge operations. |
| generate_weekly_pdfs.py | Removes the obsolete SDK 3.x exception re-export shim while retaining supported exception imports. |
| requirements.txt | Pins the Smartsheet Python SDK to version 4.3.0. |
| tests/test_skip_upload_delete_gating.py | Adds tests for the remote mutation guards and remediation dry-run combination. |

</details>

<sub>Reviews (2): Last reviewed commit: ["docs: record 260722-nst review fix in pr..."](https://github.com/jflo21/generate-weekly-pdfs-dsr-resiliency/commit/2569a8f998aa1670d54891ec94405d483df9f469) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46454191)</sub>

<!-- /greptile_comment -->