### PR TITLE
fix: qty parse unification, crash-handler hoist, 403 diagnosis, dependency security

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,52 @@
+# Dependabot configuration — automated dependency update PRs.
+#
+# Security-update PRs are always enabled by GitHub once this file exists;
+# the schedules below additionally keep routine version bumps flowing so
+# vulnerable ranges never linger. Weekly cadence + small PR limits keep
+# the noise manageable for a single-maintainer repo.
+#
+# NOTE: requirements.txt intentionally pins transport-critical deps
+# exactly (see memory-bank/living-ledger.md, 260608-gwm rule) — review
+# Dependabot PRs against that rule before merging; do NOT auto-merge
+# smartsheet-python-sdk bumps.
+version: 2
+updates:
+  # Python billing engine (production pipeline)
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels: ["dependencies", "python"]
+
+  # GitHub Actions workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels: ["dependencies", "github-actions"]
+
+  # Utility scripts (Notion sync, runbook, manifest tools)
+  - package-ecosystem: "npm"
+    directory: "/scripts"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels: ["dependencies", "javascript"]
+
+  # React + Vite + Supabase frontend
+  - package-ecosystem: "npm"
+    directory: "/portal-v2"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels: ["dependencies", "javascript"]
+
+  # Docusaurus runbook
+  - package-ecosystem: "npm"
+    directory: "/website"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels: ["dependencies", "javascript"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,10 @@
-# Dependabot configuration — automated dependency update PRs.
+# Dependabot configuration — automated VERSION-update PRs.
 #
-# Security-update PRs are always enabled by GitHub once this file exists;
-# the schedules below additionally keep routine version bumps flowing so
-# vulnerable ranges never linger. Weekly cadence + small PR limits keep
-# the noise manageable for a single-maintainer repo.
+# This file schedules routine version bumps so vulnerable ranges never
+# linger. Security-update PRs are governed separately: enable
+# "Dependabot security updates" under the repository's Settings →
+# Code security. Weekly cadence + small PR limits keep the noise
+# manageable for a single-maintainer repo.
 #
 # NOTE: requirements.txt intentionally pins transport-critical deps
 # exactly (see memory-bank/living-ledger.md, 260608-gwm rule) — review

--- a/memory-bank/living-ledger.md
+++ b/memory-bank/living-ledger.md
@@ -5161,3 +5161,42 @@ exceptions. No SDK 4.3.0 error-shape drift observed — `pipeline/retry.py`'s
   time. Docs aligned in the same PR: `CLAUDE.md`, `AGENTS.md`,
   `.github/prompts/configuration-environment.md`,
   `.planning/intel/constraints.md`.
+
+## [2026-08-05 21:10] Quantity parsing unified across pricing + display; early-failure counter hoist; 403 auth diagnosis (BKT-IP8-F incident)
+
+- **Incident 1 (BKT-IP8-F, qty-2 priced as 1 unit):** a subcontractor
+  variant workbook showed `Quantity=2` for CU `BKT-IP8-F` but priced the
+  row at the single-unit rate. Root cause: `_resolve_row_price` (and
+  `_subcontractor_rescue_price`) parsed Quantity with a bare
+  `float(qty_raw)`, which raises on operator-decorated values such as
+  `'2 EA'` → `qty=0.0` → silent safety-floor fall-through to the raw
+  SmartSheet `Units Total Price` (which held the per-unit price). The
+  Excel writer's display parser strips non-numerics via
+  `_RE_EXTRACT_NUMBERS` first, so the same cell displayed `2`. Two
+  parsers, one column, different answers.
+- **Fix:** both pricing helpers in `pipeline/pricing.py` now apply the
+  identical `_RE_EXTRACT_NUMBERS.sub('', str(...))` normalization the
+  Excel writer uses, and the degenerate fall-through now logs a WARNING
+  naming the CU, variant, rate, and raw Quantity.
+- **Rule:** every consumer of the canonical `Quantity` key MUST parse it
+  through the `_RE_EXTRACT_NUMBERS` strip — a value that displays as N
+  must never price as anything other than N. Guarded by
+  `TestResolveRowPriceQuantityCoercion` (decorated-string test +
+  source-inspection assertion on `_RE_EXTRACT_NUMBERS.sub`).
+- **Incident 2 (2026-08-05 GHA run, all-sheets 403):** every folder and
+  sheet call returned HTTP 403 (token revoked/expired or sharing
+  removed — an ops issue, not code). The run died with the generic
+  "No valid data rows found", and the except handler then crashed with
+  `UnboundLocalError: _groups_errored` because the group counters were
+  initialized AFTER the fetch phase inside `main()`'s try block —
+  masking the real failure in both the log and Sentry.
+- **Fix:** counters (`_groups_skipped/_generated/_uploaded/_errored`,
+  `_api_calls_count`, `history_updates`) are hoisted above the try
+  (same rationale as the existing `_txn = None` hoist);
+  `get_all_source_rows` now counts 401/403 ApiErrors per sheet
+  (`_is_auth_api_error`) and, when ZERO rows return and ALL sheets hit
+  auth errors, raises an explicit "Smartsheet authorization failure"
+  message naming the token rotation / re-sharing remediation.
+- **Rule:** any variable referenced by `main()`'s except/finally
+  handlers must be initialized BEFORE the try block. When adding new
+  session counters, hoist them next to `_txn`.

--- a/memory-bank/living-ledger.md
+++ b/memory-bank/living-ledger.md
@@ -5200,3 +5200,21 @@ exceptions. No SDK 4.3.0 error-shape drift observed — `pipeline/retry.py`'s
 - **Rule:** any variable referenced by `main()`'s except/finally
   handlers must be initialized BEFORE the try block. When adding new
   session counters, hoist them next to `_txn`.
+
+## [2026-08-05 21:20] Quantity parsing refined: shared float-first `_parse_quantity` helper (supersedes the strip-only rule above)
+
+- **Refinement (Copilot review, PR #297):** the [2026-08-05 21:10] rule
+  ("parse Quantity through the `_RE_EXTRACT_NUMBERS` strip") corrupted
+  purely numeric scientific-notation values — `str(1e+20)` strips to
+  `'120'`, a silently WRONG number rather than a safe fall-through.
+- **Rule (updated):** every consumer of the canonical `Quantity` key —
+  pricing (`_resolve_row_price`, `_subcontractor_rescue_price`) AND the
+  Excel display path (`pipeline/excel.py`) — MUST parse through the
+  single shared `pipeline.pricing._parse_quantity` helper: direct
+  `float()` first (preserves every purely numeric form), decoration
+  strip (`'2 EA'` → `2.0`) only on failure, `0.0` otherwise. Never
+  reintroduce a strip-first or bare-float parse at any call site.
+- **Sentry PII:** the pricing fall-through WARNING
+  ("Subcontractor price fall-through …") embeds CU, rate, and the raw
+  Quantity cell, so its prefix is registered in `_PII_LOG_MARKERS`
+  (covers both the Sentry Logs plane and the breadcrumb plane).

--- a/pipeline/excel.py
+++ b/pipeline/excel.py
@@ -33,7 +33,7 @@ from pipeline.config import (
     _RE_SANITIZE_HELPER_NAME,
     _RE_SANITIZE_IDENTIFIER,
 )
-from pipeline.pricing import _resolve_row_price, parse_price
+from pipeline.pricing import _parse_quantity, _resolve_row_price, parse_price
 from pipeline.utils import excel_serial_to_date
 
 logger = logging.getLogger(__name__)
@@ -652,14 +652,13 @@ def generate_excel(group_key, group_rows, snapshot_date, ai_analysis_results=Non
             else:
                 price = parse_price(row_data.get('Units Total Price'))
             
-            # Safely parse quantity - extract only numbers
-            qty_str = str(row_data.get('Quantity', '') or 0)
-            # PERFORMANCE: Use pre-compiled regex for quantity normalization
-            qty_str = _RE_EXTRACT_NUMBERS.sub('', qty_str)
-            try:
-                quantity = float(qty_str) if qty_str not in ('', '.', '-', '-.', '.-') else 0.0
-            except Exception:
-                quantity = 0.0
+            # Parse quantity through the SHARED helper — the same
+            # parser pricing uses (2026-08-05 BKT-IP8-F incident +
+            # Copilot review, PR #297). Float-first preserves
+            # scientific notation that the old strip-first path
+            # corrupted; a displayed quantity can never differ from
+            # the quantity pricing computed with.
+            quantity = _parse_quantity(row_data.get('Quantity'))
                 
             total_price_day += price
             

--- a/pipeline/fetch.py
+++ b/pipeline/fetch.py
@@ -66,6 +66,25 @@ logger = logging.getLogger(__name__)
 _RATES_FINGERPRINT: str = ''   # rebound inside get_all_source_rows via `global`
 
 
+def _is_auth_api_error(exc: Exception) -> bool:
+    """Return True when *exc* is a Smartsheet ApiError carrying an HTTP
+    401/403 status (revoked/expired API token or removed sheet sharing).
+
+    Prefers the SDK's structured ``exc.error.result.status_code``
+    attribute; falls back to matching the serialized error payload
+    (``'"statusCode": 403'``) so a plain-Exception wrapper is still
+    recognized. Added after the 2026-08-05 incident where every source
+    sheet returned 403 and the run died with the unactionable generic
+    message "No valid data rows found".
+    """
+    result = getattr(getattr(exc, 'error', None), 'result', None)
+    status = getattr(result, 'status_code', None) if result is not None else None
+    if status in (401, 403):
+        return True
+    msg = str(exc)
+    return '"statusCode": 401' in msg or '"statusCode": 403' in msg
+
+
 def get_all_source_rows(client, source_sheets):
     """Fetch rows from all source sheets with filtering.
     
@@ -107,6 +126,10 @@ def get_all_source_rows(client, source_sheets):
     SUBCONTRACTOR_SHEET_IDS = _gwp.SUBCONTRACTOR_SHEET_IDS
     _FOLDER_DISCOVERED_ORIG_IDS = _gwp._FOLDER_DISCOVERED_ORIG_IDS
     merged_rows = []
+    # Sheet IDs that failed with a 401/403 ApiError. list.append is
+    # atomic under the GIL, so the worker threads below can share this
+    # accumulator without extra locking.
+    auth_error_sheet_ids = []
     global_row_counter = 0
     original_rates = load_contract_rates(OLD_RATES_CSV)
     # Load new rate versions if rate cutoff is configured
@@ -797,6 +820,8 @@ def get_all_source_rows(client, source_sheets):
                         )
 
             except Exception as e:
+                if _is_auth_api_error(e):
+                    auth_error_sheet_ids.append(source.get('id'))
                 logging.error(f"Error processing sheet {source['id']}: {e}")
                 sentry_capture_with_context(
                     exception=e,
@@ -813,6 +838,8 @@ def get_all_source_rows(client, source_sheets):
                 )
             
         except Exception as e:
+            if _is_auth_api_error(e):
+                auth_error_sheet_ids.append(source.get('id'))
             logging.error(f"Could not process Sheet ID {source.get('id', 'N/A')}: {e}")
             sentry_capture_with_context(
                 exception=e,
@@ -885,5 +912,31 @@ def get_all_source_rows(client, source_sheets):
         logging.info("🎯 Change detection ACTIVE: Existing attachment with matching data hash will skip regeneration & upload")
     else:
         logging.warning("⚠️ No valid rows found with updated filtering (missing Work Request #, Weekly Reference Logged Date, Units Completed?, or Units Total Price)")
+
+    # 2026-08-05 incident: every one of the 113 source sheets returned
+    # 403 and the run failed with the generic "No valid data rows
+    # found" — the real cause (revoked token / removed sharing) was
+    # invisible without reading 113 per-sheet error lines. When zero
+    # rows came back AND auth errors occurred, surface an actionable
+    # authorization diagnosis. Total auth failure raises directly
+    # (the caller raises on the empty list anyway, so the run outcome
+    # is unchanged — only the message improves); a partial auth
+    # failure logs loudly and returns whatever rows were fetched.
+    if not merged_rows and auth_error_sheet_ids:
+        distinct_auth_failures = len(set(auth_error_sheet_ids))
+        if distinct_auth_failures >= len(source_sheets):
+            raise Exception(
+                f"Smartsheet authorization failure: all {len(source_sheets)} "
+                f"source sheets returned 401/403. The SMARTSHEET_API_TOKEN "
+                f"is likely revoked/expired, or sheet sharing for the token's "
+                f"account was removed. Rotate the token secret (GitHub "
+                f"Actions → SMARTSHEET_API_TOKEN) or restore sharing, then "
+                f"re-run."
+            )
+        logging.error(
+            f"🔐 {distinct_auth_failures} of {len(source_sheets)} source "
+            f"sheets failed with 401/403 (authorization) — check token "
+            f"scopes / sheet sharing for those sheets."
+        )
 
     return merged_rows

--- a/pipeline/fetch.py
+++ b/pipeline/fetch.py
@@ -916,15 +916,17 @@ def get_all_source_rows(client, source_sheets):
     # 2026-08-05 incident: every one of the 113 source sheets returned
     # 403 and the run failed with the generic "No valid data rows
     # found" — the real cause (revoked token / removed sharing) was
-    # invisible without reading 113 per-sheet error lines. When zero
-    # rows came back AND auth errors occurred, surface an actionable
-    # authorization diagnosis. Total auth failure raises directly
-    # (the caller raises on the empty list anyway, so the run outcome
-    # is unchanged — only the message improves); a partial auth
-    # failure logs loudly and returns whatever rows were fetched.
-    if not merged_rows and auth_error_sheet_ids:
+    # invisible without reading 113 per-sheet error lines. Surface an
+    # actionable authorization diagnosis whenever auth errors occurred
+    # (Copilot review, PR #297: the aggregate summary must emit even
+    # when other sheets returned rows, otherwise a 5-of-113 partial
+    # authorization loss hides in scattered per-sheet errors). Total
+    # auth failure with zero rows raises directly — the caller raises
+    # on the empty list anyway, so the run outcome is unchanged and
+    # only the message improves.
+    if auth_error_sheet_ids:
         distinct_auth_failures = len(set(auth_error_sheet_ids))
-        if distinct_auth_failures >= len(source_sheets):
+        if not merged_rows and distinct_auth_failures >= len(source_sheets):
             raise Exception(
                 f"Smartsheet authorization failure: all {len(source_sheets)} "
                 f"source sheets returned 401/403. The SMARTSHEET_API_TOKEN "

--- a/pipeline/fetch.py
+++ b/pipeline/fetch.py
@@ -925,18 +925,25 @@ def get_all_source_rows(client, source_sheets):
     # on the empty list anyway, so the run outcome is unchanged and
     # only the message improves.
     if auth_error_sheet_ids:
+        # Compare distinct-to-distinct (Codex review, PR #297): the
+        # accumulator appends once per source ENTRY while discovery can
+        # legitimately seed duplicate sheet IDs, so measuring the raise
+        # condition against len(source_sheets) would let an
+        # every-sheet-403 run slip into the partial branch and die with
+        # the generic zero-rows message instead of this diagnosis.
         distinct_auth_failures = len(set(auth_error_sheet_ids))
-        if not merged_rows and distinct_auth_failures >= len(source_sheets):
+        distinct_source_count = len({s.get('id') for s in source_sheets})
+        if not merged_rows and distinct_auth_failures >= distinct_source_count:
             raise Exception(
-                f"Smartsheet authorization failure: all {len(source_sheets)} "
-                f"source sheets returned 401/403. The SMARTSHEET_API_TOKEN "
-                f"is likely revoked/expired, or sheet sharing for the token's "
-                f"account was removed. Rotate the token secret (GitHub "
-                f"Actions → SMARTSHEET_API_TOKEN) or restore sharing, then "
-                f"re-run."
+                f"Smartsheet authorization failure: all "
+                f"{distinct_source_count} source sheets returned 401/403. "
+                f"The SMARTSHEET_API_TOKEN is likely revoked/expired, or "
+                f"sheet sharing for the token's account was removed. Rotate "
+                f"the token secret (GitHub Actions → SMARTSHEET_API_TOKEN) "
+                f"or restore sharing, then re-run."
             )
         logging.error(
-            f"🔐 {distinct_auth_failures} of {len(source_sheets)} source "
+            f"🔐 {distinct_auth_failures} of {distinct_source_count} source "
             f"sheets failed with 401/403 (authorization) — check token "
             f"scopes / sheet sharing for those sheets."
         )

--- a/pipeline/observability.py
+++ b/pipeline/observability.py
@@ -532,6 +532,12 @@ _PII_LOG_MARKERS: tuple[str, ...] = (
     # containment with pre-existing markers (body does not overlap
     # "Subproject B hash-history prune" or "Vac crew hash-history prune").
     "Subproject D hash-history prune",
+    # 2026-08-05 BKT-IP8-F incident (PR #297): the pricing fall-through
+    # WARNING embeds CU code, rate, and the raw Quantity cell value —
+    # row-level billing data per the registry's classification. Marker
+    # covers both the Sentry Logs plane and the breadcrumb plane; the
+    # local GHA log keeps the full diagnostic.
+    "Subcontractor price fall-through",
 )
 
 

--- a/pipeline/orchestrate.py
+++ b/pipeline/orchestrate.py
@@ -423,6 +423,21 @@ def main():  # pyright: ignore[reportGeneralTypeIssues]
     # further down, which would otherwise leave _txn unbound and turn any
     # main() exit through finally into an UnboundLocalError.
     _txn = None
+    # Group-processing counters. Hoisted for the same reason as _txn:
+    # the general except handler and the finally-block cron check-in
+    # reference these unconditionally, but their in-flow initialization
+    # sits AFTER the discovery/fetch phases. An early failure (e.g.
+    # "No valid data rows found" raised in Phase 2 — the 2026-08-05
+    # all-sheets-403 incident) previously turned the real error into
+    # ``UnboundLocalError: _groups_errored`` inside the handler,
+    # masking the root cause in both the log and Sentry. The later
+    # in-flow re-initialization is kept (harmless re-zeroing).
+    _groups_skipped = 0
+    _groups_generated = 0
+    _groups_uploaded = 0
+    _groups_errored = 0
+    _api_calls_count = 0
+    history_updates = 0
 
     # Sentry cron check-in: signal "in_progress" at session start
     _cron_monitor_slug = os.getenv("SENTRY_CRON_MONITOR_SLUG", "weekly-excel-generation")

--- a/pipeline/orchestrate.py
+++ b/pipeline/orchestrate.py
@@ -438,6 +438,13 @@ def main():  # pyright: ignore[reportGeneralTypeIssues]
     _groups_errored = 0
     _api_calls_count = 0
     history_updates = 0
+    # Explicit session-failure sentinel for the finally-block cron
+    # check-in (Copilot review, PR #297): _groups_errored == 0 alone
+    # cannot distinguish "clean run" from "died before any group was
+    # processed" — a pre-group exception (e.g. the all-sheets-403
+    # authorization failure) would otherwise check in as OK. Set True
+    # in every except handler below.
+    _session_failed = False
 
     # Sentry cron check-in: signal "in_progress" at session start
     _cron_monitor_slug = os.getenv("SENTRY_CRON_MONITOR_SLUG", "weekly-excel-generation")
@@ -2827,6 +2834,7 @@ def main():  # pyright: ignore[reportGeneralTypeIssues]
                 _txn = None
 
     except FileNotFoundError as e:
+        _session_failed = True
         error_context = f"Missing required file: {e}"
         logging.error(f"💥 {error_context}")
         sentry_capture_with_context(
@@ -2847,6 +2855,7 @@ def main():  # pyright: ignore[reportGeneralTypeIssues]
             _txn = None
             
     except Exception as e:
+        _session_failed = True
         session_duration = datetime.datetime.now() - session_start
         error_context = f"Session failed after {session_duration}"
         logging.error(f"💥 {error_context}: {e}")
@@ -2908,7 +2917,12 @@ def main():  # pyright: ignore[reportGeneralTypeIssues]
         # Sentry cron check-in: signal final status
         if SENTRY_DSN and _cron_checkin_id:
             try:
-                _cron_ok = '_groups_errored' not in dir() or _groups_errored == 0
+                # Session failure dominates: a run that died before (or
+                # during) group processing must check in ERROR even with
+                # zero per-group errors (Copilot review, PR #297). Both
+                # names are hoisted above the try, so no dir() guard is
+                # needed.
+                _cron_ok = (not _session_failed) and _groups_errored == 0
                 capture_checkin(
                     monitor_slug=_cron_monitor_slug,
                     check_in_id=_cron_checkin_id,

--- a/pipeline/pricing.py
+++ b/pipeline/pricing.py
@@ -507,9 +507,15 @@ def _subcontractor_rescue_price(row_data: dict) -> float:
         rate = rate_row.get('reduced_transfer_price', 0.0)
     else:
         return 0.0
-    qty_raw = row_data.get('Quantity', 0)
+    # 2026-08-05 BKT-IP8-F incident: normalize Quantity exactly like
+    # ``_resolve_row_price`` / the Excel writer (strip unit decorations
+    # such as '2 EA' via ``_RE_EXTRACT_NUMBERS``) so a decorated
+    # quantity cannot silently fail admission here while displaying a
+    # positive quantity downstream. Clean numeric inputs parse
+    # identically to the previous bare-float implementation.
+    qty_str = _RE_EXTRACT_NUMBERS.sub('', str(row_data.get('Quantity', '') or ''))
     try:
-        qty = float(qty_raw) if qty_raw not in (None, '') else 0.0
+        qty = float(qty_str) if qty_str not in ('', '.', '-', '-.', '.-') else 0.0
     except (TypeError, ValueError):
         qty = 0.0
     if rate <= 0 or qty <= 0:
@@ -637,23 +643,34 @@ def _resolve_row_price(row: dict, variant: str, missing_cus) -> float:
         rate = rate_row.get(f'reduced_{wt}_price', 0.0)
 
     # Canonical 'Quantity' ONLY — never 'Units Completed' (checkbox).
-    # Phase 01 gap closure (REVIEW-IN-02): explicit None / empty-string
-    # handling. The previous ``or 0`` short-circuit collapsed
-    # legitimate ``Quantity=0.0`` to int ``0`` (functionally correct
-    # after the subsequent ``float()`` coercion but opaque to readers).
-    # Numeric output is byte-identical for every pre-existing input case
-    # (None, '', 0, 0.0, '1.5', invalid → 0.0 / 0.0 / 0.0 / 0.0 / 1.5
-    # / 0.0 respectively).
-    qty_raw = row.get('Quantity', 0)
+    # 2026-08-05 BKT-IP8-F incident: parse Quantity with the SAME
+    # normalization the Excel writer uses (``_RE_EXTRACT_NUMBERS``
+    # strips unit decorations such as ``'2 EA'`` before ``float()``).
+    # The previous bare ``float(qty_raw)`` raised on any decorated
+    # value, silently falling through to the raw SmartSheet
+    # ``Units Total Price`` — the workbook then displayed Quantity=2
+    # (lenient display parser) alongside a 1-unit price (strict
+    # pricing parser). Clean numeric inputs (None, '', 0, 0.0, '1.5',
+    # invalid) parse identically to the previous implementation.
+    qty_str = _RE_EXTRACT_NUMBERS.sub('', str(row.get('Quantity', '') or ''))
     try:
-        qty = float(qty_raw) if qty_raw not in (None, '') else 0.0
+        qty = float(qty_str) if qty_str not in ('', '.', '-', '-.', '.-') else 0.0
     except (TypeError, ValueError):
         qty = 0.0
 
     if rate <= 0 or qty <= 0:
         # Degenerate row: SmartSheet pricing as the safety floor,
         # NEVER silently zero out (mirrors the recalc fall-through
-        # pattern in Living Ledger 2026-04-21 22:35).
+        # pattern in Living Ledger 2026-04-21 22:35). WARN so a
+        # known-CU row that falls back is visible in the run log —
+        # the 2026-08-05 incident was invisible precisely because
+        # this path was silent.
+        logging.warning(
+            f"⚠️ Subcontractor price fall-through for CU '{cu}' "
+            f"(variant={variant}): rate={rate}, parsed qty={qty} "
+            f"(raw Quantity={row.get('Quantity')!r}) — keeping "
+            f"SmartSheet Units Total Price"
+        )
         return parse_price(row.get('Units Total Price'))
     return rate * qty
 

--- a/pipeline/pricing.py
+++ b/pipeline/pricing.py
@@ -831,15 +831,16 @@ def recalculate_row_price(row_data, cu_to_group, rates_dict, *, out_status=None)
     elif 'tran' in work_type_raw or 'xfr' in work_type_raw:
         wt_key = 'transfer'
 
-    # Parse quantity — if missing or unparseable, keep SmartSheet price
-    qty_str = str(row_data.get('Quantity', '') or '')
-    try:
-        qty = float(_RE_EXTRACT_NUMBERS.sub('', qty_str) or 0)
-    except ValueError:
-        qty = 0.0
+    # Parse quantity — if missing or unparseable, keep SmartSheet price.
+    # Copilot review (PR #297): routed through the shared float-first
+    # ``_parse_quantity`` helper. The old strip-first parse corrupted
+    # scientific notation (str(1e+20) → '120') and this function writes
+    # its result IN-PLACE to 'Units Total Price', so the corrupted
+    # quantity became a wrong recalculated price, not a fall-through.
+    qty = _parse_quantity(row_data.get('Quantity'))
 
     if qty <= 0:
-        logging.debug(f"Rate recalculation: quantity '{qty_str}' is zero/missing for CU '{cu_code}', keeping SmartSheet price")
+        logging.debug(f"Rate recalculation: quantity {row_data.get('Quantity')!r} is zero/missing for CU '{cu_code}', keeping SmartSheet price")
         _set_status('invalid_quantity')
         return price_val
 
@@ -881,11 +882,10 @@ def revert_subcontractor_price(row_data, original_rates):
     elif 'tran' in work_type_raw or 'xfr' in work_type_raw:
         wt_key = 'transfer'
 
-    qty_str = str(row_data.get('Quantity', '') or '0')
-    try:
-        qty = float(_RE_EXTRACT_NUMBERS.sub('', qty_str) or 0)
-    except ValueError:
-        qty = 0.0
+    # Copilot review (PR #297): shared float-first parser — see
+    # ``_parse_quantity`` and the recalc comment above; same in-place
+    # price-write hazard applies here.
+    qty = _parse_quantity(row_data.get('Quantity'))
 
     if cu_code in original_rates:
         exact_original_rate = original_rates[cu_code].get(wt_key, 0.0)

--- a/pipeline/pricing.py
+++ b/pipeline/pricing.py
@@ -87,6 +87,40 @@ SUBCONTRACTOR_RATES_CSV = _sanitize_csv_path(
 )
 
 
+def _parse_quantity(qty_raw: "str | float | int | None") -> float:
+    """Parse a canonical ``Quantity`` cell value to a float.
+
+    THE single shared parser for pricing AND the Excel display path
+    (2026-08-05 BKT-IP8-F incident + Copilot review, PR #297):
+
+    1. Direct ``float()`` first — preserves every purely numeric form
+       exactly as the pre-incident code did, including scientific
+       notation, which the decoration-strip would silently corrupt
+       (``str(1e+20)`` regex-strips to ``'120'`` — a WRONG number,
+       not a safe fall-through).
+    2. On failure, strip unit decorations via ``_RE_EXTRACT_NUMBERS``
+       (``'2 EA'`` → ``'2'``) and retry.
+    3. Anything else parses to ``0.0`` — callers treat that as a
+       degenerate quantity.
+
+    Display and pricing MUST both route through this helper so a value
+    can never display as N while pricing as anything other than N.
+    """
+    if qty_raw is None:
+        return 0.0
+    try:
+        return float(qty_raw)
+    except (TypeError, ValueError):
+        pass
+    qty_str = _RE_EXTRACT_NUMBERS.sub('', str(qty_raw))
+    if qty_str in ('', '.', '-', '-.', '.-'):
+        return 0.0
+    try:
+        return float(qty_str)
+    except (TypeError, ValueError):
+        return 0.0
+
+
 def parse_price(price_str: str | float | int | None) -> float:
     """Safely convert a price string to a float.
     
@@ -507,17 +541,13 @@ def _subcontractor_rescue_price(row_data: dict) -> float:
         rate = rate_row.get('reduced_transfer_price', 0.0)
     else:
         return 0.0
-    # 2026-08-05 BKT-IP8-F incident: normalize Quantity exactly like
-    # ``_resolve_row_price`` / the Excel writer (strip unit decorations
-    # such as '2 EA' via ``_RE_EXTRACT_NUMBERS``) so a decorated
-    # quantity cannot silently fail admission here while displaying a
-    # positive quantity downstream. Clean numeric inputs parse
-    # identically to the previous bare-float implementation.
-    qty_str = _RE_EXTRACT_NUMBERS.sub('', str(row_data.get('Quantity', '') or ''))
-    try:
-        qty = float(qty_str) if qty_str not in ('', '.', '-', '-.', '.-') else 0.0
-    except (TypeError, ValueError):
-        qty = 0.0
+    # 2026-08-05 BKT-IP8-F incident: parse Quantity through the shared
+    # ``_parse_quantity`` helper (float-first, then decoration strip)
+    # so a decorated quantity ('2 EA') cannot silently fail admission
+    # here while displaying a positive quantity downstream. Clean
+    # numeric inputs parse identically to the previous bare-float
+    # implementation.
+    qty = _parse_quantity(row_data.get('Quantity'))
     if rate <= 0 or qty <= 0:
         return 0.0
     return rate * qty
@@ -643,20 +673,16 @@ def _resolve_row_price(row: dict, variant: str, missing_cus) -> float:
         rate = rate_row.get(f'reduced_{wt}_price', 0.0)
 
     # Canonical 'Quantity' ONLY — never 'Units Completed' (checkbox).
-    # 2026-08-05 BKT-IP8-F incident: parse Quantity with the SAME
-    # normalization the Excel writer uses (``_RE_EXTRACT_NUMBERS``
-    # strips unit decorations such as ``'2 EA'`` before ``float()``).
-    # The previous bare ``float(qty_raw)`` raised on any decorated
-    # value, silently falling through to the raw SmartSheet
-    # ``Units Total Price`` — the workbook then displayed Quantity=2
-    # (lenient display parser) alongside a 1-unit price (strict
-    # pricing parser). Clean numeric inputs (None, '', 0, 0.0, '1.5',
-    # invalid) parse identically to the previous implementation.
-    qty_str = _RE_EXTRACT_NUMBERS.sub('', str(row.get('Quantity', '') or ''))
-    try:
-        qty = float(qty_str) if qty_str not in ('', '.', '-', '-.', '.-') else 0.0
-    except (TypeError, ValueError):
-        qty = 0.0
+    # 2026-08-05 BKT-IP8-F incident: parse Quantity through the shared
+    # ``_parse_quantity`` helper — the SAME parser the Excel display
+    # path uses. The previous bare ``float(qty_raw)`` raised on any
+    # decorated value ('2 EA'), silently falling through to the raw
+    # SmartSheet ``Units Total Price`` — the workbook then displayed
+    # Quantity=2 (lenient display parser) alongside a 1-unit price
+    # (strict pricing parser). Clean numeric inputs (None, '', 0, 0.0,
+    # '1.5', scientific notation, invalid) parse identically to the
+    # pre-incident implementation.
+    qty = _parse_quantity(row.get('Quantity'))
 
     if rate <= 0 or qty <= 0:
         # Degenerate row: SmartSheet pricing as the safety floor,

--- a/pipeline/pricing.py
+++ b/pipeline/pricing.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import csv
 import hashlib
 import logging
+import math
 import os
 from collections.abc import Sequence
 
@@ -109,16 +110,23 @@ def _parse_quantity(qty_raw: "str | float | int | None") -> float:
     if qty_raw is None:
         return 0.0
     try:
-        return float(qty_raw)
+        qty = float(qty_raw)
     except (TypeError, ValueError):
-        pass
-    qty_str = _RE_EXTRACT_NUMBERS.sub('', str(qty_raw))
-    if qty_str in ('', '.', '-', '-.', '.-'):
-        return 0.0
-    try:
-        return float(qty_str)
-    except (TypeError, ValueError):
-        return 0.0
+        qty_str = _RE_EXTRACT_NUMBERS.sub('', str(qty_raw))
+        if qty_str in ('', '.', '-', '-.', '.-'):
+            return 0.0
+        try:
+            qty = float(qty_str)
+        except (TypeError, ValueError):
+            return 0.0
+    # Copilot review (PR #297): float() accepts non-finite forms —
+    # float('nan') and float('1e999') (→ inf) — which slip past every
+    # caller's ``qty <= 0`` degenerate gate (NaN compares False to
+    # everything) and would compute a non-finite billing price. The
+    # documented contract is 0.0 for degenerate values; gate BOTH parse
+    # paths (the strip path can also overflow to inf on a long digit
+    # run).
+    return qty if math.isfinite(qty) else 0.0
 
 
 def parse_price(price_str: str | float | int | None) -> float:

--- a/portal-v2/package-lock.json
+++ b/portal-v2/package-lock.json
@@ -19,7 +19,7 @@
         "lucide-react": "^0.460.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-router-dom": "^6.28.0",
+        "react-router-dom": "^7.18.2",
         "tailwind-merge": "^2.5.4"
       },
       "devDependencies": {
@@ -83,13 +83,13 @@
       "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -98,9 +98,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -108,21 +108,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -139,14 +139,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -156,14 +156,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -173,9 +173,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -183,29 +183,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -225,9 +225,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -235,9 +235,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -245,9 +245,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -255,27 +255,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
-      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -327,33 +327,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.8",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.8",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -361,14 +361,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1102,15 +1102,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@remix-run/router": {
-      "version": "1.23.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
-      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -2587,9 +2578,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2843,6 +2834,19 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/css.escape": {
       "version": "1.5.1",
@@ -3295,17 +3299,17 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -3526,9 +3530,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4357,9 +4361,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "dev": true,
       "funding": [
         {
@@ -4595,9 +4599,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -4615,7 +4619,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -4887,35 +4891,41 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
-      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2"
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
-      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2",
-        "react-router": "6.30.3"
+        "react-router": "7.18.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/read-cache": {
@@ -5101,6 +5111,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/siginfo": {
       "version": "2.0.0",
@@ -5509,9 +5525,9 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
-      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/portal-v2/package.json
+++ b/portal-v2/package.json
@@ -23,7 +23,7 @@
     "lucide-react": "^0.460.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.28.0",
+    "react-router-dom": "^7.18.2",
     "tailwind-merge": "^2.5.4"
   },
   "devDependencies": {

--- a/portal-v2/pnpm-lock.yaml
+++ b/portal-v2/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
       react-router-dom:
-        specifier: ^6.28.0
-        version: 6.30.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^7.18.2
+        version: 7.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tailwind-merge:
         specifier: ^2.5.4
         version: 2.6.1
@@ -447,10 +447,6 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@remix-run/router@1.23.2':
-    resolution: {integrity: sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==}
-    engines: {node: '>=14.0.0'}
-
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
@@ -488,66 +484,79 @@ packages:
     resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.1':
     resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.1':
     resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.1':
     resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.1':
     resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.1':
     resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.1':
     resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.1':
     resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.1':
     resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.1':
     resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.1':
     resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.1':
     resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.1':
     resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.1':
     resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==}
@@ -1002,6 +1011,10 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
 
   css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
@@ -1604,18 +1617,22 @@ packages:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
 
-  react-router-dom@6.30.3:
-    resolution: {integrity: sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==}
-    engines: {node: '>=14.0.0'}
+  react-router-dom@7.18.2:
+    resolution: {integrity: sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==}
+    engines: {node: '>=20.0.0'}
     peerDependencies:
-      react: '>=16.8'
-      react-dom: '>=16.8'
+      react: '>=18'
+      react-dom: '>=18'
 
-  react-router@6.30.3:
-    resolution: {integrity: sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==}
-    engines: {node: '>=14.0.0'}
+  react-router@7.18.2:
+    resolution: {integrity: sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==}
+    engines: {node: '>=20.0.0'}
     peerDependencies:
-      react: '>=16.8'
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
 
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
@@ -1668,6 +1685,9 @@ packages:
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -2244,8 +2264,6 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@remix-run/router@1.23.2': {}
-
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
   '@rollup/rollup-android-arm-eabi@4.60.1':
@@ -2780,6 +2798,8 @@ snapshots:
   commander@4.1.1: {}
 
   convert-source-map@2.0.0: {}
+
+  cookie@1.1.1: {}
 
   css.escape@1.5.1: {}
 
@@ -3360,17 +3380,19 @@ snapshots:
 
   react-refresh@0.17.0: {}
 
-  react-router-dom@6.30.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-router-dom@7.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@remix-run/router': 1.23.2
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      react-router: 6.30.3(react@18.3.1)
+      react-router: 7.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  react-router@6.30.3(react@18.3.1):
+  react-router@7.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@remix-run/router': 1.23.2
+      cookie: 1.1.1
       react: 18.3.1
+      set-cookie-parser: 2.7.2
+    optionalDependencies:
+      react-dom: 18.3.1(react@18.3.1)
 
   react@18.3.1:
     dependencies:
@@ -3448,6 +3470,8 @@ snapshots:
       loose-envify: 1.4.0
 
   semver@6.3.1: {}
+
+  set-cookie-parser@2.7.2: {}
 
   siginfo@2.0.0: {}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ sentry-sdk>=2.54.0
 # 2026-07-21, additive-only. See memory-bank/living-ledger.md for full rationale.
 smartsheet-python-sdk==4.3.0
 openpyxl==3.1.5
-Pillow==12.2.0
+Pillow==12.3.0
 python-dateutil==2.9.0.post0
 python-dotenv==1.2.2
 

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -15,9 +15,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
-      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
       "cpu": [
         "ppc64"
       ],
@@ -32,9 +32,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
-      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
       "cpu": [
         "arm"
       ],
@@ -49,9 +49,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
-      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
       "cpu": [
         "arm64"
       ],
@@ -66,9 +66,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
-      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
       "cpu": [
         "x64"
       ],
@@ -83,9 +83,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
-      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -100,9 +100,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
-      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
@@ -117,9 +117,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
       "cpu": [
         "arm64"
       ],
@@ -134,9 +134,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
-      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
       "cpu": [
         "x64"
       ],
@@ -151,9 +151,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
-      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
       "cpu": [
         "arm"
       ],
@@ -168,9 +168,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
-      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
       "cpu": [
         "arm64"
       ],
@@ -185,9 +185,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
-      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
       "cpu": [
         "ia32"
       ],
@@ -202,9 +202,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
-      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
       "cpu": [
         "loong64"
       ],
@@ -219,9 +219,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
-      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
       "cpu": [
         "mips64el"
       ],
@@ -236,9 +236,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
-      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
       "cpu": [
         "ppc64"
       ],
@@ -253,9 +253,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
-      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
       "cpu": [
         "riscv64"
       ],
@@ -270,9 +270,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
-      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
       "cpu": [
         "s390x"
       ],
@@ -287,9 +287,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
-      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
@@ -304,9 +304,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
       "cpu": [
         "arm64"
       ],
@@ -321,9 +321,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
       "cpu": [
         "x64"
       ],
@@ -338,9 +338,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
       "cpu": [
         "arm64"
       ],
@@ -355,9 +355,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
       "cpu": [
         "x64"
       ],
@@ -372,9 +372,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
-      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
       "cpu": [
         "arm64"
       ],
@@ -389,9 +389,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
-      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
       "cpu": [
         "x64"
       ],
@@ -406,9 +406,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
-      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
       "cpu": [
         "arm64"
       ],
@@ -423,9 +423,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
-      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
       "cpu": [
         "ia32"
       ],
@@ -440,9 +440,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
-      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
       "cpu": [
         "x64"
       ],
@@ -551,9 +551,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
-      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -564,32 +564,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.0",
-        "@esbuild/android-arm": "0.28.0",
-        "@esbuild/android-arm64": "0.28.0",
-        "@esbuild/android-x64": "0.28.0",
-        "@esbuild/darwin-arm64": "0.28.0",
-        "@esbuild/darwin-x64": "0.28.0",
-        "@esbuild/freebsd-arm64": "0.28.0",
-        "@esbuild/freebsd-x64": "0.28.0",
-        "@esbuild/linux-arm": "0.28.0",
-        "@esbuild/linux-arm64": "0.28.0",
-        "@esbuild/linux-ia32": "0.28.0",
-        "@esbuild/linux-loong64": "0.28.0",
-        "@esbuild/linux-mips64el": "0.28.0",
-        "@esbuild/linux-ppc64": "0.28.0",
-        "@esbuild/linux-riscv64": "0.28.0",
-        "@esbuild/linux-s390x": "0.28.0",
-        "@esbuild/linux-x64": "0.28.0",
-        "@esbuild/netbsd-arm64": "0.28.0",
-        "@esbuild/netbsd-x64": "0.28.0",
-        "@esbuild/openbsd-arm64": "0.28.0",
-        "@esbuild/openbsd-x64": "0.28.0",
-        "@esbuild/openharmony-arm64": "0.28.0",
-        "@esbuild/sunos-x64": "0.28.0",
-        "@esbuild/win32-arm64": "0.28.0",
-        "@esbuild/win32-ia32": "0.28.0",
-        "@esbuild/win32-x64": "0.28.0"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/fsevents": {

--- a/tests/test_fetch_auth_errors.py
+++ b/tests/test_fetch_auth_errors.py
@@ -75,6 +75,27 @@ class TestGetAllSourceRowsAuthFailure(unittest.TestCase):
         self.assertIn('all 2', msg)
         self.assertIn('SMARTSHEET_API_TOKEN', msg)
 
+    def test_duplicate_source_ids_still_raise_on_total_auth_failure(self):
+        # Codex review (PR #297): discovery can seed duplicate sheet
+        # IDs. The raise condition compares DISTINCT failed IDs against
+        # DISTINCT source IDs — with a naive len(source_sheets)
+        # denominator, an every-sheet-403 run with one duplicated entry
+        # would slip into the partial branch and lose the diagnosis.
+        sources_with_dupe = [
+            {'id': 111, 'name': 'Sheet A', 'column_mapping': {'Work Request #': 1}},
+            {'id': 111, 'name': 'Sheet A (dupe)', 'column_mapping': {'Work Request #': 1}},
+            {'id': 222, 'name': 'Sheet B', 'column_mapping': {'Work Request #': 1}},
+        ]
+        with mock.patch.object(
+            fetch, 'smartsheet_call_with_retry',
+            side_effect=Exception(_SERIALIZED_403),
+        ):
+            with self.assertRaises(Exception) as ctx:
+                fetch.get_all_source_rows(mock.Mock(), sources_with_dupe)
+        msg = str(ctx.exception)
+        self.assertIn('Smartsheet authorization failure', msg)
+        self.assertIn('all 2', msg)  # 2 distinct sheet IDs, not 3 entries
+
     def test_non_auth_failures_keep_legacy_empty_return(self):
         # Non-auth per-sheet failures (e.g. transient 500s) preserve the
         # legacy contract: swallow per sheet, return [] — the caller

--- a/tests/test_fetch_auth_errors.py
+++ b/tests/test_fetch_auth_errors.py
@@ -1,0 +1,91 @@
+"""Tests for the 401/403 authorization-failure diagnosis in
+``pipeline.fetch`` (2026-08-05 all-sheets-403 incident).
+
+Covers:
+  * ``_is_auth_api_error`` — structured SDK attribute path, serialized
+    payload fallback path, and negative cases.
+  * ``get_all_source_rows`` — the all-sheets-auth-failure raise carries
+    the actionable "Smartsheet authorization failure" message, while a
+    zero-row run WITHOUT auth errors keeps the legacy contract (returns
+    an empty list; the caller raises the generic message).
+"""
+import unittest
+from unittest import mock
+
+import pipeline.fetch as fetch
+
+
+class _StructuredApiError(Exception):
+    """Mimic the smartsheet SDK ApiError shape: exc.error.result.status_code."""
+
+    def __init__(self, status_code):
+        super().__init__("api error")
+        result = mock.Mock()
+        result.status_code = status_code
+        error = mock.Mock()
+        error.result = result
+        self.error = error
+
+
+# Serialized shape the SDK's ApiError stringifies to (matches the
+# 2026-08-05 production log lines verbatim).
+_SERIALIZED_403 = (
+    '{"result": {"code": 0, "errorCode": 0, "name": "ApiError", '
+    '"recommendation": "Do not retry without fixing the problem. ", '
+    '"shouldRetry": false, "statusCode": 403}}'
+)
+
+
+class TestIsAuthApiError(unittest.TestCase):
+    def test_structured_403_detected(self):
+        self.assertTrue(fetch._is_auth_api_error(_StructuredApiError(403)))
+
+    def test_structured_401_detected(self):
+        self.assertTrue(fetch._is_auth_api_error(_StructuredApiError(401)))
+
+    def test_structured_500_not_auth(self):
+        self.assertFalse(fetch._is_auth_api_error(_StructuredApiError(500)))
+
+    def test_serialized_403_payload_detected(self):
+        self.assertTrue(fetch._is_auth_api_error(Exception(_SERIALIZED_403)))
+
+    def test_plain_exception_not_auth(self):
+        self.assertFalse(fetch._is_auth_api_error(Exception("boom")))
+
+
+class TestGetAllSourceRowsAuthFailure(unittest.TestCase):
+    SOURCES = [
+        {'id': 111, 'name': 'Sheet A', 'column_mapping': {'Work Request #': 1}},
+        {'id': 222, 'name': 'Sheet B', 'column_mapping': {'Work Request #': 1}},
+    ]
+
+    def test_all_sheets_403_raises_authorization_failure(self):
+        # Every sheet fetch dies with the serialized 403 ApiError (the
+        # 2026-08-05 incident shape). Zero rows + all-auth-failure must
+        # raise the actionable diagnosis, not return an empty list that
+        # the caller turns into "No valid data rows found".
+        with mock.patch.object(
+            fetch, 'smartsheet_call_with_retry',
+            side_effect=Exception(_SERIALIZED_403),
+        ):
+            with self.assertRaises(Exception) as ctx:
+                fetch.get_all_source_rows(mock.Mock(), self.SOURCES)
+        msg = str(ctx.exception)
+        self.assertIn('Smartsheet authorization failure', msg)
+        self.assertIn('all 2', msg)
+        self.assertIn('SMARTSHEET_API_TOKEN', msg)
+
+    def test_non_auth_failures_keep_legacy_empty_return(self):
+        # Non-auth per-sheet failures (e.g. transient 500s) preserve the
+        # legacy contract: swallow per sheet, return [] — the caller
+        # owns the generic zero-rows raise.
+        with mock.patch.object(
+            fetch, 'smartsheet_call_with_retry',
+            side_effect=Exception("server exploded"),
+        ):
+            result = fetch.get_all_source_rows(mock.Mock(), self.SOURCES)
+        self.assertEqual(result, [])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_fetch_auth_errors.py
+++ b/tests/test_fetch_auth_errors.py
@@ -86,6 +86,29 @@ class TestGetAllSourceRowsAuthFailure(unittest.TestCase):
             result = fetch.get_all_source_rows(mock.Mock(), self.SOURCES)
         self.assertEqual(result, [])
 
+    def test_partial_auth_failure_logs_aggregate_summary_without_raise(self):
+        # One sheet 403s, the other dies with a non-auth error: not an
+        # all-sheets authorization failure, so no raise — but the
+        # aggregate 🔐 summary MUST still emit (Copilot review, PR #297)
+        # so a partial authorization loss is not buried in scattered
+        # per-sheet error lines.
+        def _per_sheet(_fn, sheet_id, **_kwargs):
+            if sheet_id == 111:
+                raise Exception(_SERIALIZED_403)
+            raise Exception("server exploded")
+
+        with mock.patch.object(
+            fetch, 'smartsheet_call_with_retry', side_effect=_per_sheet,
+        ):
+            with self.assertLogs(level='ERROR') as logs:
+                result = fetch.get_all_source_rows(mock.Mock(), self.SOURCES)
+        self.assertEqual(result, [])
+        self.assertTrue(
+            any('1 of 2 source sheets failed with 401/403' in line
+                for line in logs.output),
+            f"aggregate auth summary missing from: {logs.output}",
+        )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_fetch_auth_errors.py
+++ b/tests/test_fetch_auth_errors.py
@@ -9,10 +9,21 @@ Covers:
     zero-row run WITHOUT auth errors keeps the legacy contract (returns
     an empty list; the caller raises the generic message).
 """
+import sys
 import unittest
+from pathlib import Path
 from unittest import mock
 
-import pipeline.fetch as fetch
+# Ledger rule [2026-06-30 19:48]: test modules importing pipeline.*
+# MUST bootstrap the repo root into sys.path themselves — there is no
+# conftest.py, so relying on an alphabetically-earlier sibling's
+# bootstrap breaks the documented single-file workflow
+# (cd tests && python -m pytest test_fetch_auth_errors.py).
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+import pipeline.fetch as fetch  # noqa: E402
 
 
 class _StructuredApiError(Exception):

--- a/tests/test_subcontractor_helper_shadow_rescue.py
+++ b/tests/test_subcontractor_helper_shadow_rescue.py
@@ -197,6 +197,18 @@ class TestEndToEndPipeline(unittest.TestCase):
         })
         self.assertEqual(rescued, 100.0)
 
+    def test_bug_a_rescue_decorated_quantity_uses_rate_times_qty(self):
+        """2026-08-05 BKT-IP8-F incident: a decorated Quantity ('2 EA')
+        must rescue at reduced_install × 2, not fail admission. The
+        rescue runs BEFORE row acceptance, so a strict-parse regression
+        here drops the row before ``_resolve_row_price`` is reached."""
+        rescued = generate_weekly_pdfs._subcontractor_rescue_price({
+            'CU': 'ANC-M',
+            'Work Type': 'Inst',
+            'Quantity': '2 EA',
+        })
+        self.assertEqual(rescued, 100.0)
+
     def test_bug_a_rescue_returns_zero_for_unknown_cu(self):
         """Bug A rescue: unknown CU falls through to 0.0 (caller drops row)."""
         rescued = generate_weekly_pdfs._subcontractor_rescue_price({

--- a/tests/test_subcontractor_pricing.py
+++ b/tests/test_subcontractor_pricing.py
@@ -4075,6 +4075,17 @@ class TestResolveRowPriceQuantityCoercion(unittest.TestCase):
                 999.0,
             )
 
+    def test_quantity_scientific_notation_parses_directly(self):
+        # Copilot review (PR #297): the float-first parse preserves
+        # scientific notation exactly as the pre-incident code did.
+        # A strip-first parse corrupts it (str(1e+20) → '120') into a
+        # WRONG number rather than a safe fall-through.
+        with mock.patch.object(
+            generate_weekly_pdfs, '_SUBCONTRACTOR_RATES', self.RATES_STUB,
+        ):
+            self.assertEqual(self._resolve(self._row('2e0')), 200.0)
+            self.assertEqual(self._resolve(self._row(1e20)), 100.0 * 1e20)
+
     def test_quantity_decorated_string_uses_rate_times_qty(self):
         # 2026-08-05 BKT-IP8-F incident: operator-entered unit
         # decoration ('2 EA') previously raised in the bare float()
@@ -4105,11 +4116,12 @@ class TestResolveRowPriceQuantityCoercion(unittest.TestCase):
             "(2026-08-05 BKT-IP8-F incident) — see 01-11-PLAN.md for "
             "the original IN-02 rationale.",
         )
-        # Confirm the normalized parse is present: pricing MUST use the
-        # same _RE_EXTRACT_NUMBERS strip as the Excel display parser so
-        # a decorated Quantity ('2 EA') can never price differently
-        # than it displays (2026-08-05 BKT-IP8-F incident).
-        self.assertIn("_RE_EXTRACT_NUMBERS.sub", src)
+        # Confirm the SHARED parser is used: pricing MUST route through
+        # _parse_quantity — the same float-first-then-strip helper the
+        # Excel display path uses — so a Quantity value can never price
+        # differently than it displays (2026-08-05 BKT-IP8-F incident;
+        # float-first refinement per Copilot review, PR #297).
+        self.assertIn("_parse_quantity(", src)
 
 
 class TestPhase1FilenameRoundTripCoverage(unittest.TestCase):

--- a/tests/test_subcontractor_pricing.py
+++ b/tests/test_subcontractor_pricing.py
@@ -4112,6 +4112,18 @@ class TestResolveRowPriceQuantityCoercion(unittest.TestCase):
             self.assertEqual(self._resolve(self._row('2e0')), 200.0)
             self.assertEqual(self._resolve(self._row(1e20)), 100.0 * 1e20)
 
+    def test_quantity_non_finite_falls_through_to_units_total_price(self):
+        # Copilot review (PR #297): float() accepts 'nan' and '1e999'
+        # (→ inf), and NaN compares False to the callers' qty <= 0
+        # degenerate gate — without the isfinite() gate in
+        # _parse_quantity a non-finite billing price would be written.
+        with mock.patch.object(
+            generate_weekly_pdfs, '_SUBCONTRACTOR_RATES', self.RATES_STUB,
+        ):
+            self.assertEqual(self._resolve(self._row('nan')), 999.0)
+            self.assertEqual(self._resolve(self._row('1e999')), 999.0)
+            self.assertEqual(self._resolve(self._row(float('inf'))), 999.0)
+
     def test_quantity_decorated_string_uses_rate_times_qty(self):
         # 2026-08-05 BKT-IP8-F incident: operator-entered unit
         # decoration ('2 EA') previously raised in the bare float()

--- a/tests/test_subcontractor_pricing.py
+++ b/tests/test_subcontractor_pricing.py
@@ -4075,6 +4075,19 @@ class TestResolveRowPriceQuantityCoercion(unittest.TestCase):
                 999.0,
             )
 
+    def test_quantity_decorated_string_uses_rate_times_qty(self):
+        # 2026-08-05 BKT-IP8-F incident: operator-entered unit
+        # decoration ('2 EA') previously raised in the bare float()
+        # parse → qty=0.0 → silent fall-through to the SmartSheet
+        # price, while the Excel display parser (which strips
+        # non-numerics) still showed Quantity=2. The pricing parser
+        # now applies the same _RE_EXTRACT_NUMBERS normalization, so
+        # the row prices as rate × 2.
+        with mock.patch.object(
+            generate_weekly_pdfs, '_SUBCONTRACTOR_RATES', self.RATES_STUB,
+        ):
+            self.assertEqual(self._resolve(self._row('2 EA')), 200.0)
+
     def test_production_source_does_not_carry_or_zero_pattern(self):
         # Source-level guard: the ``or 0`` short-circuit is removed.
         # Phase 09 W2: ``_resolve_row_price`` was relocated to
@@ -4087,11 +4100,16 @@ class TestResolveRowPriceQuantityCoercion(unittest.TestCase):
             "row.get('Quantity') or 0",
             src,
             "IN-02 regression: the ``or 0`` short-circuit pattern has "
-            "been re-introduced. Use explicit ``row.get('Quantity', 0)`` "
-            "+ ``if qty_raw not in (None, '')`` per 01-11-PLAN.md.",
+            "been re-introduced on the Quantity read. Quantity parsing "
+            "must keep the _RE_EXTRACT_NUMBERS normalization "
+            "(2026-08-05 BKT-IP8-F incident) — see 01-11-PLAN.md for "
+            "the original IN-02 rationale.",
         )
-        # Confirm the explicit pattern is present.
-        self.assertIn("qty_raw not in (None, '')", src)
+        # Confirm the normalized parse is present: pricing MUST use the
+        # same _RE_EXTRACT_NUMBERS strip as the Excel display parser so
+        # a decorated Quantity ('2 EA') can never price differently
+        # than it displays (2026-08-05 BKT-IP8-F incident).
+        self.assertIn("_RE_EXTRACT_NUMBERS.sub", src)
 
 
 class TestPhase1FilenameRoundTripCoverage(unittest.TestCase):

--- a/tests/test_subcontractor_pricing.py
+++ b/tests/test_subcontractor_pricing.py
@@ -823,6 +823,32 @@ class TestRecalculateRowPrice(unittest.TestCase):
         expected = round(75.94 * 2, 2)  # 151.88
         self.assertAlmostEqual(result, expected)
 
+    def test_recalc_decorated_quantity_uses_rate_times_qty(self):
+        """PR #297: decorated Quantity ('3 EA') recalculates as rate × 3
+        through the shared _parse_quantity helper."""
+        row = {'CU': 'ANC-DHM-10-84-D1', 'Work Type': 'Install', 'Quantity': '3 EA', 'Units Total Price': '$650.00'}
+        result = generate_weekly_pdfs.recalculate_row_price(row, self.cu_to_group, self.rates_primary)
+        self.assertAlmostEqual(result, round(224.06 * 3, 2))
+
+    def test_recalc_scientific_notation_quantity_not_corrupted(self):
+        """PR #297 (Copilot round 3): the old strip-first parse turned
+        str(1e+20) into '120', and recalculate_row_price writes the
+        result IN-PLACE to 'Units Total Price' — a silently WRONG price.
+        The shared float-first parser preserves the true quantity."""
+        row = {'CU': 'ANC-DHM-10-84-D1', 'Work Type': 'Install', 'Quantity': 1e20, 'Units Total Price': '$650.00'}
+        result = generate_weekly_pdfs.recalculate_row_price(row, self.cu_to_group, self.rates_primary)
+        self.assertEqual(result, round(224.06 * 1e20, 2))
+        self.assertNotEqual(result, round(224.06 * 120, 2))
+
+    def test_revert_scientific_notation_quantity_not_corrupted(self):
+        """PR #297 (Copilot round 3): revert_subcontractor_price shares
+        the same in-place price-write hazard; float-first parse keeps
+        the true quantity."""
+        row = {'CU': 'ANC-M', 'Work Type': 'Install', 'Quantity': 1e20, 'Units Total Price': '$100.00'}
+        original_rates = {'ANC-M': {'install': 100.0, 'removal': 0.0, 'transfer': 0.0}}
+        result = generate_weekly_pdfs.revert_subcontractor_price(row, original_rates)
+        self.assertEqual(result, round(100.0 * 1e20, 2))
+
     def test_transfer_work_type(self):
         """Test transfer work type mapping."""
         row = {'CU': 'ARM-10D-60HS', 'Work Type': 'Transfer', 'Quantity': '1', 'Units Total Price': '$150.00'}

--- a/website/blog/2026-08-05-quantity-parse-unification-and-auth-failure-diagnosis.md
+++ b/website/blog/2026-08-05-quantity-parse-unification-and-auth-failure-diagnosis.md
@@ -1,0 +1,61 @@
+---
+slug: quantity-parse-unification-and-auth-failure-diagnosis
+title: "fix: decorated quantities now price correctly; all-sheets 403 runs diagnose themselves (#297)"
+authors: [runbook-bot]
+tags: [docs, project, workflows]
+date: 2026-08-05T21:30:00+00:00
+---
+
+**Component:** Python billing pipeline (`generate_weekly_pdfs.py` / `pipeline/`) — the
+GitHub Actions cron engine that turns Smartsheet field data into weekly Excel reports.
+
+<!-- truncate -->
+
+## What changed
+
+Three production fixes ship together in PR [#297](https://github.com/JFlo21/Generate-Weekly-PDFs-DSR-Resiliency/pull/297):
+
+1. **Decorated quantities now price correctly on subcontractor variants.** A
+   Smartsheet `Quantity` cell containing unit decoration (for example `2 EA`
+   instead of `2`) previously priced at the raw Smartsheet `Units Total Price`
+   — often a single-unit price — while the workbook still displayed the
+   quantity as `2`. The pricing parser now strips non-numeric characters
+   exactly like the display parser does, so the row prices as rate × quantity.
+   When pricing still has to fall back to the Smartsheet price (zero rate or
+   zero quantity), the run log now carries a `⚠️ Subcontractor price
+   fall-through` WARNING naming the CU, variant, rate, and raw quantity value.
+2. **An all-sheets authorization failure names itself.** When every source
+   sheet returns HTTP 401/403 and zero rows come back, the run now fails with
+   `Smartsheet authorization failure: all N source sheets returned 401/403`
+   instead of the generic `No valid data rows found`. A partial authorization
+   failure logs a `🔐` ERROR with the affected sheet count.
+3. **Early failures report cleanly.** A failure before the group-processing
+   phase (such as the authorization failure above) previously crashed the
+   error handler itself with `UnboundLocalError: _groups_errored`, hiding the
+   real cause from both the log and Sentry. Session counters are now
+   initialized before any work starts, so the true error always surfaces.
+
+## Why it changed
+
+On 2026-08-05 a production run failed with every one of its 113 source sheets
+returning 403 (revoked/expired `SMARTSHEET_API_TOKEN` or removed sheet
+sharing). The generic error plus the handler crash made the root cause
+invisible without reading 113 per-sheet log lines. Separately, a billing
+report for CU `BKT-IP8-F` showed quantity 2 priced as 1 unit — traced to the
+pricing parser rejecting a decorated quantity value that the display parser
+accepted.
+
+## What operators need to know
+
+- **If a run fails with `Smartsheet authorization failure`:** rotate the
+  `SMARTSHEET_API_TOKEN` secret (GitHub → repository settings → Actions
+  secrets) or restore sheet sharing for the token's account, then re-run the
+  workflow. No code change is needed; the pipeline recovers on the next run.
+- **If you see `⚠️ Subcontractor price fall-through` warnings:** the named
+  row kept its Smartsheet price. Check the row's `Quantity` cell — a zero or
+  truly non-numeric value is the usual cause. Decorated values like `2 EA` no
+  longer trigger this.
+- **After correcting quantity data for a past week**, force regeneration the
+  usual way (`REGEN_WEEKS` / `RESET_HASH_HISTORY` via the workflow's
+  `advanced_options`) so the corrected rate × quantity price reaches the
+  attached workbook.

--- a/website/blog/2026-08-05-quantity-parse-unification-and-auth-failure-diagnosis.md
+++ b/website/blog/2026-08-05-quantity-parse-unification-and-auth-failure-diagnosis.md
@@ -56,6 +56,9 @@ accepted.
   truly non-numeric value is the usual cause. Decorated values like `2 EA` no
   longer trigger this.
 - **After correcting quantity data for a past week**, force regeneration the
-  usual way (`REGEN_WEEKS` / `RESET_HASH_HISTORY` via the workflow's
-  `advanced_options`) so the corrected rate × quantity price reaches the
-  attached workbook.
+  usual way: pass the `regen_weeks:<MMDDYY>` key inside the workflow's
+  `advanced_options` field for targeted weeks, or set the separate
+  `reset_hash_history` workflow input to `true` for a full rebuild — so the
+  corrected rate × quantity price reaches the attached workbook.
+  (`RESET_HASH_HISTORY` is its own top-level `workflow_dispatch` input; the
+  `advanced_options` parser does not accept it.)

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -5268,9 +5268,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5283,9 +5280,6 @@
       "integrity": "sha512-i51WWI64aRpsfSki6rN0aepPqXkVfS+vZM7+4bWDcmnhUmdMvhIPcYg0QRk3DtyJnu33jqNLM0WHY78k00NyfA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5300,9 +5294,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5315,9 +5306,6 @@
       "integrity": "sha512-JcAMVKXOnjfpC3coWjCFPWD3Yl8RBw6a+IXQQ8mfRlHaHMIiOv8IfZqx15XRxMUn49CtP7Z0Na8iiAg2aKrcfw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5807,9 +5795,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -5825,9 +5810,6 @@
       "integrity": "sha512-3Yu3Uq/VgytqsPjTMbkPU1ExADytbdWbruJYhA584E9jrpE2Ki+R6VVPoZCeAVk1Cb7QxcRTgblw6bSa6a/R+w==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
@@ -5845,9 +5827,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -5863,9 +5842,6 @@
       "integrity": "sha512-3hHYBY0yx8Ez7GMRrkhXHQzMdR5IZA6Wq5Ee4svlgwvSECLpnAJ9+0AimEGUFDvuLwE7nV/2+PYe8+Nm4rvNcQ==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
@@ -5883,9 +5859,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -5901,9 +5874,6 @@
       "integrity": "sha512-CQpS8Ge/avfjZd0UEwG/sds83Uu32deQXcV1Jo3jD0mmvQQqtYAjpsDZXugmheeAwmt+YIuoVtVHro8LMYHqsQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
@@ -6049,9 +6019,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -6067,9 +6034,6 @@
       "integrity": "sha512-NyXRQiVBkeutgCwCxUUaFqZdDmpZONs7Zz3AZGoY35s9GwXF412Nt22fK/e7lO/sM6G/+S3rOom/0xTmUQSK6A==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
@@ -6087,9 +6051,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -6105,9 +6066,6 @@
       "integrity": "sha512-w6bitHrllrE3lqmf14cT3spmWhZHGts1O08O4adzxztSPto7O5GM3IerqZm/NtsqlxNsfbVHnhaNXxXWe/8Q+Q==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
@@ -6125,9 +6083,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -6143,9 +6098,6 @@
       "integrity": "sha512-g+K1GKUrj+S9o8Qsgii2g7ooMzZ750R4IAqH5CVElIA5FTMAx7KGnu9ga6aEnRwwLYxY3s1k/nN+ls0NEk240g==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
@@ -11589,9 +11541,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -11611,9 +11560,6 @@
       "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -11635,9 +11581,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -11657,9 +11600,6 @@
       "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -19060,12 +19000,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/value-equal": {

--- a/website/package.json
+++ b/website/package.json
@@ -35,7 +35,8 @@
     "webpackbar": "7.0.0",
     "serialize-javascript": ">=7.0.5",
     "fast-uri": ">=3.1.2",
-    "@babel/plugin-transform-modules-systemjs": ">=7.29.4"
+    "@babel/plugin-transform-modules-systemjs": ">=7.29.4",
+    "uuid": "^11.1.1"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
## Objective

Fix three production issues from the 2026-08-05 investigation: (1) the BKT-IP8-F pricing bug where a row displaying Quantity=2 priced at the single-unit rate, (2) the `UnboundLocalError` crash in the exception handler that masked the real cause of the 2026-08-05 run failure, and (3) an unactionable generic error when every source sheet returns 403. Also resolves the locally reproducible dependency security findings (Dependabot-class alerts) across the Python engine, `scripts/`, `portal-v2/`, and `website/`.

## Changes Made

- **`pipeline/pricing.py`** — `_resolve_row_price` and `_subcontractor_rescue_price` now parse `Quantity` with the same `_RE_EXTRACT_NUMBERS` normalization the Excel writer uses. Previously a decorated value like `'2 EA'` raised in the bare `float()`, silently falling back to the raw SmartSheet `Units Total Price` (a per-unit price), while the workbook displayed `2` — the exact BKT-IP8-F symptom. The degenerate fall-through now logs a WARNING naming the CU, variant, rate, and raw Quantity. Clean numeric inputs parse identically to before.
- **`pipeline/orchestrate.py`** — hoisted `_groups_skipped/_generated/_uploaded/_errored`, `_api_calls_count`, and `history_updates` above `main()`'s try block (same pattern as the existing `_txn = None` hoist) so early failures report cleanly to the log and Sentry instead of crashing with `UnboundLocalError: _groups_errored` at the handler.
- **`pipeline/fetch.py`** — added `_is_auth_api_error()` and a per-sheet 401/403 accumulator. When zero rows return and **all** sheets failed with auth errors, the run now raises an explicit "Smartsheet authorization failure" message pointing at token rotation / sheet re-sharing; partial auth failures log a loud 🔐 error. Run outcome is unchanged (the caller already raised on the empty list) — only the diagnosis improves.
- **`requirements.txt`** — Pillow 12.2.0 → 12.3.0 (20 known PYSEC advisories fixed in 12.3.0; patch-level bump, only used for logo rendering).
- **`portal-v2/`** — `npm audit fix` plus react-router-dom 6.30.4 → 7.18.2 (fixes the open-redirect advisories; all router APIs used are unchanged in v7). All 113 vitest tests and the production build pass. Note: `npm audit` still flags the RSC-mode CSRF advisory (GHSA-qwww-vcr4-c8h2) which has **no fixed release yet** and does not apply to this client-only SPA (no React Server Components / server actions); the only npm-suggested "fix" is downgrading to 7.11.0, which would reintroduce the open-redirect vulnerabilities.
- **`scripts/`** — `npm audit fix` (esbuild advisory) → 0 vulnerabilities.
- **`website/`** — added `uuid: ^11.1.1` to the existing `overrides` block (clears the uuid → sockjs → webpack-dev-server → Docusaurus chain, dev-server only) → 0 vulnerabilities; `npm run typecheck` and `docusaurus build` pass.
- **`.github/dependabot.yml`** — new: weekly update PRs for pip, github-actions, and the three npm roots, so future advisories surface as automated PRs.
- **`tests/test_subcontractor_pricing.py`** — new decorated-quantity regression test (`'2 EA'` → rate × 2); the source-inspection guard now asserts the `_RE_EXT RACT_NUMBERS` normalization is present while still banning the `or 0` short-circuit.
- **`memory-bank/living-ledger.md`** — dated entry documenting both incidents, root causes, and the new rules.

## Production Safety Check

The 2026-08-05 run failure itself is **operational, not code**: every Smartsheet folder/sheet call returned 403, meaning `SMARTSHEET_API_TOKEN` is revoked/expired or sheet sharing was removed — the secret must be rotated/re-shared for runs to succeed again; nothing in this PR (or any code change) can restore access.

Pipeline behavior is preserved: legacy variants (`primary`/`helper`/`vac_crew`) still pass SmartSheet prices through unchanged; the quantity parse is byte-identical for every clean numeric input (None, `''`, `0`, `0.0`, `'1.5'`, invalid) and only changes the decorated-value case that was mispricing; the counter hoist only pre-initializes values that the later in-flow initialization re-zeroes; the fetch-phase raise fires only in the all-sheets-auth-failure case where the run already failed with a worse message. Full suite: **1193 passed, 130 subtests** (`pytest tests/ -v`), `py_compile` clean, portal-v2 vitest + build green, website typecheck + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bHZ59sPp6f44SvMNrEQDt

---
_Generated by [Claude Code](https://claude.ai/code/session_018bHZ59sPp6f44SvMNrEQDt)_

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR fixes decorated-quantity pricing, preserves original errors during early pipeline failures, improves Smartsheet authorization diagnostics, and updates vulnerable dependencies.
- Introduces one shared quantity parser for pricing and workbook display.
- Hoists session state used by exception and cron handlers.
- Distinguishes complete and partial Smartsheet authorization failures.
- Adds the required operator-facing Docusaurus changelog entry.
- Updates Python and JavaScript dependencies and adds Dependabot configuration.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains, and the previously reported operator changelog omission is fixed by the new canonical Docusaurus entry.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pipeline/pricing.py | Adds a shared float-first quantity parser and applies it consistently to subcontractor pricing paths. |
| pipeline/excel.py | Routes displayed quantities through the same parser used for pricing. |
| pipeline/fetch.py | Aggregates per-sheet authorization errors and emits actionable complete or partial failure diagnostics. |
| pipeline/orchestrate.py | Initializes handler-visible session state before the protected pipeline and reports failed sessions correctly. |
| website/blog/2026-08-05-quantity-parse-unification-and-auth-failure-diagnosis.md | Fully addresses the prior operator-changelog finding in the canonical Docusaurus change log. |
| portal-v2/package.json | Upgrades React Router to the patched major release with corresponding lockfile updates. |
| .github/dependabot.yml | Adds weekly dependency-update coverage for Python, GitHub Actions, and all JavaScript roots. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Read Smartsheet sources] --> B{Authorization failures?}
  B -->|All sources, no rows| C[Raise actionable authorization error]
  B -->|Some sources| D[Log partial authorization failure]
  B -->|None| E[Continue pipeline]
  D --> E
  E --> F[Parse Quantity with shared helper]
  F --> G[Apply quantity consistently to pricing and workbook display]
  C --> H[Session exception handler]
  H --> I[Report original failure and failed cron check-in]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: shared float-first quantity parser,..."](https://github.com/jflo21/generate-weekly-pdfs-dsr-resiliency/commit/4785bcdf2e4c4c5c621500f42ce515bc63804ad6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50594152)</sub>

<!-- /greptile_comment -->