### PR TITLE
feat: rate-sanity audit check (260812-isx)

### DIFF
--- a/.claude/project-state.md
+++ b/.claude/project-state.md
@@ -23,7 +23,41 @@ write-back reminder). Keep it terse; link to history rather than duplicating it.
    "Snapshot Date is blank" write-once condition; fix the template
    sheet so backup copies inherit it. Recommendation delivered to Juan;
    NOT yet applied (his action).
-3. **Quick task 260812-isx (GSD quick) COMPLETE → PR #329 OPEN:**
+3. **SESSION HANDOFF (2026-08-12 ~15:20 CDT) — resume points:**
+   - **PR #329 Greptile fixes DONE + PUSHED:** gsd-code-fixer landed
+     3 atomic commits on `feat/260812-isx-rate-sanity-audit` —
+     `64d7249` (fold total_rate_sanity_mismatches into history/
+     audit-sheet/trend total_issues aggregates + 2 regression tests),
+     `e003124` (website/blog/2026-08-12-rate-sanity-audit-check.md
+     runbook changelog incl. RATE_SANITY_AUDIT_ENABLED=false emergency
+     disable), `8802e98` (test return-type annotations). Suite 1230
+     passed + 130 subtests. Pushed 8802e98 → PR #329 updated. Known
+     latent quirk (out of scope, untouched): risk_trend.json write
+     silently no-ops on a truly fresh generated_docs/ dir because
+     makedirs happens later in _save_audit_state().
+   - **Quick task 260812-jqx APPROVED-TO-EXECUTE, not started:**
+     snapshot-drift audit. Plan/context/research complete + plan-check
+     PASSED (0 blockers, 1 warning: add post-seam Sentry capture for
+     holds). Planning docs are UNTRACKED in
+     `.planning/quick/260812-jqx-snapshot-date-drift-audit-detect-snapsho/`
+     (CONTEXT/RESEARCH/PLAN — commit them). Execution recipe: after
+     PR #329 fixes land, `git switch -c feat/260812-jqx-snapshot-drift-audit`
+     from the isx tip (plan line numbers assume isx code present),
+     spawn gsd-core:gsd-executor (sonnet) on 260812-jqx-PLAN.md, then
+     gsd-verifier + code review + haiku-verifier, docs commit, PR
+     stacked on #329. Locked decisions: hold-prior-week+HIGH for
+     automation self-fires ONLY (SNAPSHOT_DRIFT_HOLD_ENABLED default
+     OFF), never hold manual edits, fail-open gating/fail-closed
+     logging, 40-row capped ~2s-paced cell-history lookups
+     (week-movers only), NEW additive Supabase tables appended to
+     billing_audit/schema.sql (Juan manual-applies DDL), NO new
+     mutating AUDIT_SHEET_ID write in v1.
+   - **Juan's own actions pending:** Smartsheet automation trigger fix
+     in UI per living-ledger [2026-08-12 13:40] (field-scoped trigger
+     + "Snapshot Date is blank" condition, per sheet + template);
+     review/merge PR #329; later: apply jqx DDL, enable hold gate
+     after burn-in.
+4. **Quick task 260812-isx (GSD quick) COMPLETE → PR #329 OPEN:**
    report-only rate-sanity audit check (Units Total Price vs expected
    New-Rates rate × Quantity via `_SUBCONTRACTOR_RATES`, kill-switch
    `RATE_SANITY_AUDIT_ENABLED`). Commits a7f5d77/2cb9897/ad3fa19 +

--- a/.claude/project-state.md
+++ b/.claude/project-state.md
@@ -23,15 +23,17 @@ write-back reminder). Keep it terse; link to history rather than duplicating it.
    "Snapshot Date is blank" write-once condition; fix the template
    sheet so backup copies inherit it. Recommendation delivered to Juan;
    NOT yet applied (his action).
-3. **Quick task 260812-isx (GSD quick) IN FLIGHT:** report-only
-   rate-sanity audit check (Units Total Price vs expected New-Rates
-   rate × Quantity via `_SUBCONTRACTOR_RATES`, kill-switch
-   `RATE_SANITY_AUDIT_ENABLED`, diff guard: only
-   `audit_billing_changes.py` + `tests/test_rate_sanity_audit.py` +
-   living ledger). Plan committed to
-   `.planning/quick/260812-isx-.../260812-isx-PLAN.md`; Sonnet executor
-   running in background. Next: verify diff + haiku-verifier pass +
-   STATE.md row + docs commit.
+3. **Quick task 260812-isx (GSD quick) COMPLETE → PR #329 OPEN:**
+   report-only rate-sanity audit check (Units Total Price vs expected
+   New-Rates rate × Quantity via `_SUBCONTRACTOR_RATES`, kill-switch
+   `RATE_SANITY_AUDIT_ENABLED`). Commits a7f5d77/2cb9897/ad3fa19 +
+   docs c61bacb on branch `feat/260812-isx-rate-sanity-audit`
+   (local master reset to origin/master — nothing pushed to main).
+   Full suite 1228 passed + 130 subtests, 0 regressions; independent
+   haiku-verifier PASS 8/8 (report-only, no hunks in pipeline/ or
+   generate_weekly_pdfs.py). Next: Juan reviews/merges PR #329; apply
+   the Snapshot Date automation UI fix per living-ledger
+   `[2026-08-12 13:40]`.
 
 ## Previous work (2026-07-22) — Phase 08 SDK 4.3.0 migration EXECUTED (both plans)
 1. **Phase 08 executed via `/gsd-execute-phase 08`** on branch

--- a/.claude/project-state.md
+++ b/.claude/project-state.md
@@ -1,10 +1,39 @@
 # Project State — Generate-Weekly-PDFs-DSR-Resiliency
 
-_Last updated: 2026-07-22 · **overwrite-in-place each session** (this is the
+_Last updated: 2026-08-12 · **overwrite-in-place each session** (this is the
 canonical "where the project stands" landing spot for the global Stop
 write-back reminder). Keep it terse; link to history rather than duplicating it._
 
-## Latest work (2026-07-22) — Phase 08 SDK 4.3.0 migration EXECUTED (both plans)
+## Latest work (2026-08-12) — SAA-DE-20 overbill root-caused (upstream data, not code) + Snapshot Date automation defect proven + quick task 260812-isx in flight
+1. **Field-reported wrong pricing solved:** WR 91916464 / Point 27 /
+   SAA-DE-20 showed 3 EA @ $341.04 (should be 3 × $56.84 = $170.52).
+   Root cause: stale Smartsheet `Install Quantity` formula cell on
+   "Resiliency Promax Database Backup 86" (Quantity edited 6→3 on
+   2026-08-06, formula never recalculated). Contract rate and Python
+   pipeline both verified CORRECT (primary variant is pass-through by
+   design). Juan re-saved the row → now $170.52; next cron regenerates
+   the WE 080926 file via hash change. Full evidence chain in
+   `memory-bank/living-ledger.md` `[2026-08-12 13:40]`.
+2. **Snapshot Date automation defect proven via cell history:** the
+   per-sheet "record a date" automation uses a row-change trigger with
+   "Units Completed? is checked" as a condition, so ANY edit (even
+   same-value saves and bulk touches) re-stamps Snapshot Date to today
+   → units jump billing weeks → audit errors. Fix is UI-side per sheet:
+   field-scoped trigger ("Units Completed? changes to Checked") +
+   "Snapshot Date is blank" write-once condition; fix the template
+   sheet so backup copies inherit it. Recommendation delivered to Juan;
+   NOT yet applied (his action).
+3. **Quick task 260812-isx (GSD quick) IN FLIGHT:** report-only
+   rate-sanity audit check (Units Total Price vs expected New-Rates
+   rate × Quantity via `_SUBCONTRACTOR_RATES`, kill-switch
+   `RATE_SANITY_AUDIT_ENABLED`, diff guard: only
+   `audit_billing_changes.py` + `tests/test_rate_sanity_audit.py` +
+   living ledger). Plan committed to
+   `.planning/quick/260812-isx-.../260812-isx-PLAN.md`; Sonnet executor
+   running in background. Next: verify diff + haiku-verifier pass +
+   STATE.md row + docs commit.
+
+## Previous work (2026-07-22) — Phase 08 SDK 4.3.0 migration EXECUTED (both plans)
 1. **Phase 08 executed via `/gsd-execute-phase 08`** on branch
    `feat/phase-08-sdk-430-migration` (unpushed; no PR yet). Wave 1 (08-01,
    merge `6334531`): SDK 4.3.0 installed (env upgrade 3.9.0→4.3.0), dead

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -38,7 +38,7 @@ Status: Ready to plan
   change; all 7 waves independently 6-gate-verified. Next: /gsd-verify-work 09,
   then PR / milestone close. (Phase 08 SDK 4.0.0 migration still outstanding — same
   file, so it could not run concurrently; now unblocked.)
-Last activity: 2026-07-22
+Last activity: 2026-08-12 - Completed quick task 260812-isx: report-only rate-sanity audit check (SAA-DE-20 incident guardrail)
 
 ### Infrastructure Topology (discovered 2026-06-01 via Supabase MCP) — READ BEFORE PHASE 05
 
@@ -204,6 +204,7 @@ See PROJECT.md `<decisions>` table for the full 30+ entry log.
 
 | # | Description | Date | Commit | Directory |
 |---|-------------|------|--------|-----------|
+| 260812-isx | Report-only rate-sanity audit check: flag rows where Units Total Price ≠ expected New-Rates rate × Quantity (catches stale Smartsheet formula rows like SAA-DE-20; kill-switch RATE_SANITY_AUDIT_ENABLED) | 2026-08-12 | a7f5d77, 2cb9897, ad3fa19 | [260812-isx](./quick/260812-isx-add-report-only-rate-sanity-audit-check-/) |
 | 260722-nst | Gate claimer remediation on SKIP_UPLOAD (PR #286 review fix — 6th mutating call site) | 2026-07-22 | 458d7e5, 60d0473 | [260722-nst](./quick/260722-nst-gate-claimer-remediation-on-skip-upload-/) |
 | 260709-oa7 | Fix Sentry 503 ApiError retry gap (GENERATE-WEEKLY-EXCEL-89) and cron checkin_margin 5→60 (GENERATE-WEEKLY-EXCEL-6V) | 2026-07-09 | 1791246, 7469204 | [260709-oa7](./quick/260709-oa7-fix-sentry-503-apierror-retry-gap-and-cr/) |
 | 260528-lu6 | Reconcile AGENTS.md into a lean pointer mirroring CLAUDE.md | 2026-05-28 | d30be0e | [260528-lu6](./quick/260528-lu6-reconcile-agents-md-into-a-lean-pointer-/) |

--- a/.planning/quick/260812-isx-add-report-only-rate-sanity-audit-check-/260812-isx-PLAN.md
+++ b/.planning/quick/260812-isx-add-report-only-rate-sanity-audit-check-/260812-isx-PLAN.md
@@ -1,0 +1,410 @@
+---
+phase: 260812-isx
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - audit_billing_changes.py
+  - tests/test_rate_sanity_audit.py
+  - memory-bank/living-ledger.md
+autonomous: true
+requirements: [QUICK-260812-ISX]
+user_setup: []
+
+estimate:
+  tokens: 65000
+  raw_tokens: 45000
+  tasks: 3
+  confidence: low
+
+must_haves:
+  truths:
+    - "A row with CU=SAA-DE-20, Work Type=Inst, Quantity=3, Units Total
+       Price=341.04 is reported as a rate-sanity mismatch with
+       expected_price 170.52 and delta 170.52."
+    - "A row with CU=SAA-DE-20, Work Type=Inst, Quantity=1, Units Total
+       Price=56.84 is NOT reported."
+    - "Rows whose CU is absent from the rates table, whose Quantity is
+       zero/missing/unparseable, whose Units Total Price is unparseable,
+       or whose Work Type matches none of inst/rem/tran/xfr are counted
+       as skipped and never reported as mismatches."
+    - "The check never mutates row price, quantity, grouping, filenames,
+       hashes, or upload behavior — audit_financial_data returns the same
+       rows object it was handed and no pricing path is touched."
+    - "Setting RATE_SANITY_AUDIT_ENABLED=false disables the check and
+       returns the audit summary to its pre-change shape of counts."
+    - "pytest tests/ -v passes with zero regressions."
+  artifacts:
+    - audit_billing_changes.py
+    - tests/test_rate_sanity_audit.py
+    - memory-bank/living-ledger.md
+  key_links:
+    - "audit_financial_data() -> _detect_rate_sanity_mismatches() ->
+       audit_results['rate_sanity_mismatches']"
+    - "_check_row_rate_sanity() -> lazily-imported generate_weekly_pdfs
+       ._SUBCONTRACTOR_RATES (new_install/remove/transfer_price)"
+    - "_generate_audit_summary() -> total_rate_sanity_mismatches ->
+       risk_level escalation"
+---
+
+<objective>
+Add a REPORT-ONLY rate-sanity check to the billing audit layer that flags
+rows whose Smartsheet `Units Total Price` deviates from
+`expected rate x Quantity`, using the New Rates columns of
+`data/subcontractor_rates.csv` keyed by CU + Work Type.
+
+Purpose: catch the class of defect proven by the 2026-08-12 incident —
+WR 91916464 / Point 27 / CU SAA-DE-20 / Work Type Inst had Quantity
+edited 6 -> 3 by the foreman, but the Smartsheet "Install Quantity"
+formula cell kept the stale 6, so `Units Total Price` stayed
+56.84 x 6 = $341.04 instead of 56.84 x 3 = $170.52. The primary variant
+is a pass-through of the Smartsheet price by design, so the pipeline
+rendered "3 units @ $341.04" and a $170.52 overbill shipped, caught only
+by a foreman's email. The audit layer must detect this automatically.
+
+Output: a new detector in `audit_billing_changes.py`, a new pytest file
+with the SAA-DE-20 regression case, and a dated Living Ledger entry.
+</objective>
+
+<execution_context>
+@~/.claude/gsd-core/workflows/execute-plan.md
+@~/.claude/gsd-core/templates/summary.md
+</execution_context>
+
+<context>
+@CLAUDE.md
+@.claude/rules/billing-pipeline-guardrails.md
+@.claude/skills/investigate-price-anomaly/SKILL.md
+@audit_billing_changes.py
+@pipeline/pricing.py
+@tests/test_subcontractor_pricing.py
+</context>
+
+<design_facts>
+Verified against the repo before planning — do not re-derive:
+
+1. `pipeline/pricing.py` already owns every primitive needed:
+   - `parse_price(value) -> float` (strips `$` and thousands commas,
+     coerces non-numeric to 0.0) at L132.
+   - `_parse_quantity(value) -> float` (float-first, then decoration
+     strip, so `'2 EA'` parses) at L91.
+   - `_SUBCONTRACTOR_RATES: dict[str, dict]` at L499 — CU-keyed
+     (uppercased), loaded once at module import from
+     `SUBCONTRACTOR_RATES_CSV` (default `data/subcontractor_rates.csv`).
+     Each value carries `new_install_price`, `new_remove_price`,
+     `new_transfer_price` (plus the `reduced_*` trio and audit-only
+     `cu_wbs` / `compatible_unit_group`).
+   - Verified: `SAA-DE-20` -> group `SAA`, `new_install_price` 56.84,
+     `new_remove_price` 17.72, `new_transfer_price` 48.12. This confirms
+     the **New Rates** columns are the correct expected-rate source for
+     the Smartsheet `Units Total Price` pass-through.
+2. Work-type column selection uses the SHORTEST UNAMBIGUOUS PREFIX in
+   the `A in B` substring direction, per the [2026-05-16 23:45] ledger
+   rule and `pipeline/pricing.py` L667-673:
+   `'inst' in wt` -> install, `'rem' in wt` -> remove,
+   `'tran' in wt or 'xfr' in wt` -> transfer, else unknown.
+   Reproduce this exact matcher; do not use `'install' in wt`.
+3. `audit_billing_changes.py` already reads the canonical row keys
+   `'Work Request #'`, `'Units Total Price'`, `'Quantity'`, `'CU'`
+   in `_validate_data_consistency` (L201+), so the synonyms layer has
+   already run by the time the audit sees rows. `'Work Type'` is the
+   canonical key for the work-type token.
+4. **Import-cycle constraint.** `generate_weekly_pdfs.py` L35 imports
+   `audit_billing_changes` BEFORE it imports `pipeline.pricing` at
+   L196-210. A module-level `from pipeline.pricing import ...` inside
+   `audit_billing_changes.py` would pull the CSV-loading side effect
+   earlier in the import order. Therefore the new code MUST use a
+   function-local lazy import (`import generate_weekly_pdfs as _gwp`)
+   exactly like `pipeline/pricing.py` L629-633 does. This also makes the
+   rates table patchable by tests without any testability-driven API
+   change.
+5. Existing tests rebind the table via
+   `generate_weekly_pdfs._SUBCONTRACTOR_RATES.clear()` +
+   `.update({...})` in `setUp`, restoring the original in `tearDown`
+   (`tests/test_subcontractor_pricing.py` L1861-1877). Mirror that.
+6. `BillingAudit.__init__` reads/writes
+   `generated_docs/audit_state.json`; `audit_financial_data` also
+   appends to `generated_docs/risk_trend.json` and calls
+   `_log_to_audit_sheet`. End-to-end tests must neutralize those I/O
+   paths rather than let them write real files.
+</design_facts>
+
+<tasks>
+
+<task type="tracer" tdd="true">
+  <name>Task 1: End-to-end rate-sanity slice — one row, detector, audit result</name>
+  <files>audit_billing_changes.py, tests/test_rate_sanity_audit.py</files>
+  <behavior>
+    - Test 1 (the incident regression): row
+      `{'Work Request #': '91916464', 'CU': 'SAA-DE-20',
+        'Work Type': 'Inst', 'Quantity': '3',
+        'Units Total Price': '$341.04'}` against a patched rates table
+      containing `SAA-DE-20` with `new_install_price` 56.84 produces
+      exactly one mismatch record whose `expected_price` is 170.52,
+      `actual_price` is 341.04, and `delta` is 170.52.
+    - Test 2 (clean case): the same row with `Quantity` `'1'` and
+      `Units Total Price` `'$56.84'` produces zero mismatch records.
+    - Test 3 (end-to-end wiring): `audit_financial_data([], [incident_row])`
+      returns a dict whose `rate_sanity_mismatches` list has length 1,
+      with `_save_audit_state`, `_log_to_audit_sheet`, and the
+      `risk_trend.json` write neutralized (patch the two methods and run
+      with `cwd` pointed at a `tempfile.TemporaryDirectory`).
+  </behavior>
+  <action>
+    Write the failing tests first in a NEW file
+    `tests/test_rate_sanity_audit.py`, then implement until green.
+
+    Test file shape: `unittest`-based to match the surrounding suite;
+    `import generate_weekly_pdfs` at module top and
+    `from audit_billing_changes import BillingAudit`. In `setUp`, snapshot
+    `dict(generate_weekly_pdfs._SUBCONTRACTOR_RATES)`, `.clear()` it, then
+    `.update()` it with a single `SAA-DE-20` entry carrying
+    `new_install_price` 56.84, `new_remove_price` 17.72,
+    `new_transfer_price` 48.12, `cu_code` `'SAA-DE-20'`,
+    `compatible_unit_group` `'SAA'`; restore the snapshot in `tearDown`.
+    Construct the audit under test as `BillingAudit(client=None,
+    skip_cell_history=True)`. Mirror the setUp/tearDown pattern at
+    `tests/test_subcontractor_pricing.py` L1861-1877.
+
+    Implementation in `audit_billing_changes.py`, additive only:
+
+    (a) Add a module-level constant block near the existing imports:
+        `RATE_SANITY_ABS_TOLERANCE = 0.02` and
+        `RATE_SANITY_PCT_TOLERANCE = 0.005`.
+
+    (b) Add a private module-level function
+        `_rate_sanity_expected_price(row: Dict) -> Optional[float]`.
+        It performs the function-local lazy import
+        `import generate_weekly_pdfs as _gwp` (see design_facts #4),
+        reads `_gwp._SUBCONTRACTOR_RATES`, uppercases/strips
+        `row.get('CU')`, and returns `None` when the CU is empty or
+        absent from the table. It selects the rate column with the
+        shortest-prefix matcher from design_facts #2 against
+        `str(row.get('Work Type') or '').strip().lower()`, reading
+        `new_install_price` / `new_remove_price` / `new_transfer_price`,
+        and returns `None` for an unmatched work type. It parses
+        quantity via `_gwp._parse_quantity(row.get('Quantity'))` and
+        returns `None` when quantity is `<= 0` or the rate is `<= 0`.
+        Otherwise it returns `rate * qty`.
+
+    (c) Add a private module-level function
+        `_rate_sanity_is_mismatch(expected: float, actual: float) -> bool`
+        returning `abs(actual - expected) > max(RATE_SANITY_ABS_TOLERANCE,
+        RATE_SANITY_PCT_TOLERANCE * expected)`.
+
+    (d) Add the method
+        `_detect_rate_sanity_mismatches(self, rows: List[Dict]) -> List[Dict]`
+        to `BillingAudit`. Iterate rows; call
+        `_rate_sanity_expected_price(row)`; skip the row silently when it
+        returns `None`. Parse the actual price with
+        `_gwp.parse_price(row.get('Units Total Price'))`; skip when the
+        raw cell is empty/None (an unparseable cell coerces to 0.0 and
+        must NOT be reported as a mismatch — treat a raw cell that is
+        empty, None, or that `parse_price` maps to 0.0 from a non-zero
+        looking string as a skip). When
+        `_rate_sanity_is_mismatch(expected, actual)` is true, append a
+        record shaped exactly:
+        `{"type": "rate_sanity_mismatch", "work_request": <str>,
+          "cu": <str>, "work_type": <str>, "quantity": <float>,
+          "expected_price": <float rounded to 2>,
+          "actual_price": <float rounded to 2>,
+          "delta": <float rounded to 2>, "severity": "high",
+          "description": <short summary string>}`.
+        Wrap the whole body in `try/except Exception` that logs a
+        `self.logger.warning` and returns whatever was collected — mirror
+        the defensive shape of `_detect_price_anomalies` (L159-197) so a
+        detector bug can never abort a production run.
+
+    (e) Wire it into `audit_financial_data` as a new numbered step
+        placed immediately after step 2 (`_validate_data_consistency`)
+        and before step 3: seed
+        `audit_results["rate_sanity_mismatches"] = []` alongside the
+        other list keys in the initial dict, then extend it with the
+        detector result. Do NOT touch steps 3-7, the pricing paths in
+        `pipeline/`, or `generate_weekly_pdfs.py`.
+
+    PEP 8 throughout: type hints on every new signature, PEP 257
+    docstrings, lines <= 79 chars (the surrounding legacy code exceeds
+    this — new code must not).
+  </action>
+  <verify>
+    <automated>pytest tests/test_rate_sanity_audit.py -v</automated>
+  </verify>
+  <done>
+    The incident row is reported with expected_price 170.52 and delta
+    170.52; the clean row is not reported;
+    `audit_financial_data` surfaces the record under
+    `rate_sanity_mismatches`; `python -m py_compile
+    audit_billing_changes.py` exits 0.
+  </done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Skip semantics, tolerance edges, counters, and kill-switch</name>
+  <files>audit_billing_changes.py, tests/test_rate_sanity_audit.py</files>
+  <behavior>
+    - Missing CU: row with `CU` = `'NOT-IN-TABLE'` -> zero mismatches,
+      `rate_sanity_skipped` count 1.
+    - Zero / missing / unparseable quantity (`'0'`, `''`, `None`,
+      `'abc'`) -> zero mismatches, counted as skipped.
+    - Unparseable / empty `Units Total Price` -> zero mismatches,
+      counted as skipped (never reported as a $0 expected-vs-actual
+      mismatch).
+    - Unknown work type (`'Splice'`, `''`) -> zero mismatches, skipped.
+    - Rounding tolerance: expected 170.52 vs actual 170.53 -> NOT
+      flagged (within the $0.02 floor); expected 170.52 vs actual
+      171.00 -> flagged (0.48 exceeds both $0.02 and 0.5% = $0.85...
+      assert the correct branch: 0.5% of 170.52 is 0.8526, so 171.00 is
+      within tolerance and NOT flagged; use expected 170.52 vs actual
+      172.00 for the flagged large-drift case).
+    - Decorated quantity `'3 EA'` parses to 3.0 and still flags the
+      incident price.
+    - `RATE_SANITY_AUDIT_ENABLED=false` -> detector returns an empty
+      list, `rate_sanity_mismatches` is empty, and
+      `total_rate_sanity_mismatches` is 0.
+    - Summary: with one mismatch present, `summary
+      ["total_rate_sanity_mismatches"]` is 1 and `summary["risk_level"]`
+      is not `"LOW"`.
+  </behavior>
+  <action>
+    Extend `tests/test_rate_sanity_audit.py` with the behaviors above,
+    then extend the implementation.
+
+    Implementation changes, all additive:
+
+    (a) Kill-switch. Read the flag inside
+        `_detect_rate_sanity_mismatches` (not at import time, so tests
+        and operators can toggle it via `os.environ` without a reload):
+        `if os.getenv("RATE_SANITY_AUDIT_ENABLED", "true").lower() !=
+        "true": return []`. Default-on.
+
+    (b) Skip accounting. Track an integer skip counter inside the
+        detector and stash it on the instance as
+        `self._rate_sanity_skipped` so `_generate_audit_summary` can
+        read it. Skips are silent at row level — emit at most ONE
+        aggregate `self.logger.info` line per run with the checked and
+        skipped counts, never a per-row log.
+
+    (c) Summary. In `_generate_audit_summary`, add
+        `"total_rate_sanity_mismatches": len(audit_results.get(
+        "rate_sanity_mismatches", []))` and
+        `"rate_sanity_skipped": <counter>` to the returned dict, and
+        include the mismatch count in the existing `total_issues` sum
+        that drives `risk_level`. Append the recommendation string
+        `"Rate-sanity mismatches detected: Smartsheet Units Total Price
+        disagrees with rate x Quantity — check for a stale quantity
+        formula cell upstream."` when the count is above zero. Leave
+        every existing key, threshold, and message untouched.
+
+    (d) Logging discipline. In `_log_audit_results`, add ONE line
+        reporting the mismatch count alongside the existing
+        `Anomalies:` line. Log counts and the CU code only. Never log
+        `Units Total Price`, quantity values, foreman, or description
+        text at INFO level — see the threat model below.
+  </action>
+  <verify>
+    <automated>pytest tests/test_rate_sanity_audit.py -v</automated>
+  </verify>
+  <done>
+    Every skip class returns zero mismatches and increments the skip
+    counter; the tolerance boundary cases behave as specified;
+    `RATE_SANITY_AUDIT_ENABLED=false` fully disables the check; the
+    summary carries the two new counters and escalates `risk_level`
+    when a mismatch exists.
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Full-suite regression gate and Living Ledger entry</name>
+  <files>memory-bank/living-ledger.md</files>
+  <action>
+    Run the full gate and confirm zero regressions in the existing
+    suite — in particular `tests/test_billing_audit_shadow.py` and
+    `tests/test_subcontractor_pricing.py`, which are the two files most
+    likely to assert on audit summary shape or on the rates table. If
+    any existing test fails, the correct fix is to adjust the NEW code,
+    never to relax an existing assertion.
+
+    Then append a dated entry to the BOTTOM of
+    `memory-bank/living-ledger.md` per the "Autonomous Cloud Memory
+    Injection" rule in `CLAUDE.md`. Use the `[YYYY-MM-DD HH:MM]` stamp
+    format already used by the surrounding entries and record: the
+    2026-08-12 SAA-DE-20 stale-quantity-formula incident and its
+    $170.52 overbill; that the primary variant is a deliberate
+    pass-through of the Smartsheet `Units Total Price`, which is why the
+    engine could not catch it; the new report-only detector, its
+    New-Rates + Work-Type keying, its `max($0.02, 0.5%)` tolerance, its
+    skip classes, the `RATE_SANITY_AUDIT_ENABLED` kill-switch; and the
+    hard rule that this check is diagnostic only and must never mutate
+    price, quantity, grouping, filenames, hashes, or upload behavior.
+
+    Do NOT edit `CLAUDE.md` itself.
+  </action>
+  <verify>
+    <automated>pytest tests/ -v</automated>
+  </verify>
+  <done>
+    `pytest tests/ -v` passes with no regressions versus the
+    pre-change baseline, `python -m py_compile
+    audit_billing_changes.py` exits 0, and
+    `memory-bank/living-ledger.md` ends with the new dated entry.
+  </done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| Smartsheet rows -> audit detector | Operator-entered CU / Work Type / Quantity / price strings reach new parsing code |
+| Audit logs -> Sentry / CI logs | Audit output can carry billing row content off-box |
+| Rates CSV -> detector | Operator-maintained `data/subcontractor_rates.csv` supplies the expected rate |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Severity | Disposition | Mitigation Plan |
+|-----------|----------|-----------|----------|-------------|-----------------|
+| T-ISX-01 | Information Disclosure | `_detect_rate_sanity_mismatches` logging | medium | mitigate | Task 2(d): aggregate counts + CU code only at INFO; no price, quantity, foreman, or WR-level detail in log bodies. Complements the existing `before_send_log` sanitizer and the `SENTRY_ENABLE_LOGS=false` default |
+| T-ISX-02 | Denial of Service | detector inside the production run loop | high | mitigate | Task 1(d): whole detector body wrapped in `try/except Exception` that logs a warning and returns partial results, mirroring `_detect_price_anomalies`; plus the `RATE_SANITY_AUDIT_ENABLED=false` kill-switch from Task 2(a) so it can be disabled without a deploy |
+| T-ISX-03 | Tampering | billing pipeline pricing paths | high | mitigate | Report-only contract: no writes to row dicts, no changes to `pipeline/pricing.py`, `pipeline/grouping.py`, `pipeline/excel.py`, `pipeline/upload.py`, or `generate_weekly_pdfs.py`; `files_modified` is limited to the audit module, one new test file, and the ledger |
+| T-ISX-04 | Tampering | supply chain | low | accept | No new package-manager installs — every primitive (`parse_price`, `_parse_quantity`, `_SUBCONTRACTOR_RATES`) already exists in `pipeline/pricing.py`; no `requirements.txt` change |
+| T-ISX-05 | Repudiation | audit risk trend | low | accept | Escalating `risk_level` when a mismatch exists intentionally changes what `risk_trend.json` and the audit sheet record — that visibility is the point of the change and is reversible via the kill-switch |
+</threat_model>
+
+<verification>
+1. `pytest tests/test_rate_sanity_audit.py -v` — new tests pass,
+   including the SAA-DE-20 regression and the clean case.
+2. `pytest tests/ -v` — full suite green, no regressions in
+   `test_billing_audit_shadow.py` or `test_subcontractor_pricing.py`.
+3. `python -m py_compile audit_billing_changes.py` — exits 0.
+4. `git diff --stat` shows changes ONLY in `audit_billing_changes.py`,
+   `tests/test_rate_sanity_audit.py`, and
+   `memory-bank/living-ledger.md`. Any diff hunk in `pipeline/` or
+   `generate_weekly_pdfs.py` is a contract violation — revert it.
+5. Optional local smoke, read-only:
+   `SKIP_UPLOAD=true WR_FILTER=91916464 python generate_weekly_pdfs.py`
+   and confirm the audit section reports the mismatch without changing
+   any generated price.
+</verification>
+
+<success_criteria>
+- The 2026-08-12 SAA-DE-20 case (qty 3, price $341.04, expected
+  $170.52) is flagged by the audit layer automatically.
+- The clean case (qty 1, price $56.84) is not flagged.
+- Missing CU, zero/missing/unparseable quantity, unparseable price, and
+  unknown work type are skipped and counted, never flagged.
+- Tolerance is `max($0.02, 0.5% of expected)`.
+- Zero behavior change to pricing, grouping, hashing, filenames, or
+  upload; `git diff` touches three files only.
+- `RATE_SANITY_AUDIT_ENABLED=false` restores pre-change audit output.
+- `pytest tests/ -v` passes.
+- `memory-bank/living-ledger.md` carries a new dated entry.
+</success_criteria>
+
+<output>
+Create `.planning/quick/260812-isx-add-report-only-rate-sanity-audit-check-/260812-isx-SUMMARY.md`
+when done.
+</output>

--- a/.planning/quick/260812-isx-add-report-only-rate-sanity-audit-check-/260812-isx-SUMMARY.md
+++ b/.planning/quick/260812-isx-add-report-only-rate-sanity-audit-check-/260812-isx-SUMMARY.md
@@ -1,0 +1,231 @@
+---
+phase: 260812-isx
+plan: 01
+subsystem: billing-audit
+tags: [python, unittest, smartsheet, billing, audit, rate-sanity]
+
+# Dependency graph
+requires:
+  - phase: production (pipeline/pricing.py, data/subcontractor_rates.csv)
+    provides: _SUBCONTRACTOR_RATES table, parse_price, _parse_quantity,
+      the shortest-prefix Work Type matcher
+provides:
+  - Report-only rate-sanity detector on BillingAudit
+    (_detect_rate_sanity_mismatches) flagging rows whose Units Total
+    Price disagrees with New-Rates rate x Quantity
+  - RATE_SANITY_AUDIT_ENABLED kill-switch
+  - rate_sanity_mismatches / total_rate_sanity_mismatches /
+    rate_sanity_skipped keys in the audit results and summary
+affects: [billing-audit, investigate-price-anomaly skill, future audit-layer work]
+
+# Actuals (#2632)
+actuals:
+  tokens: 8227
+  tasks: 3
+  commits: 3
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "Function-local lazy import of pipeline submodules from
+       audit_billing_changes.py to avoid the generate_weekly_pdfs.py
+       import-order hazard (audit_billing_changes is imported before
+       pipeline.pricing)."
+    - "Report-only audit detector shape: whole body wrapped in
+       try/except, returns partial results on error, mirrors
+       _detect_price_anomalies."
+
+key-files:
+  created:
+    - tests/test_rate_sanity_audit.py
+  modified:
+    - audit_billing_changes.py
+    - memory-bank/living-ledger.md
+
+key-decisions:
+  - "Imported _parse_quantity directly from pipeline.pricing (not via
+     the generate_weekly_pdfs facade) because the facade does not
+     re-export it (verified: hasattr is False) — kept the same
+     function-local lazy-import pattern to avoid the import-order
+     hazard."
+  - "Combined Task 1 (tracer) and Task 2 (skip semantics / tolerance /
+     kill-switch / summary) into one RED test commit and one GREEN
+     implementation commit — the detector, tolerance check, and skip
+     logic are one cohesive unit with no natural seam for a separately
+     committable intermediate state."
+
+patterns-established:
+  - "Rate-sanity tolerance formula: max($0.02 flat, 0.5% of expected)
+     — reusable for any future expected-vs-actual price sanity check."
+
+requirements-completed: [QUICK-260812-ISX]
+
+coverage:
+  - id: D1
+    description: "Detector flags the SAA-DE-20 incident row (qty 3,
+      $341.04) with expected_price 170.52 and delta 170.52"
+    requirement: "QUICK-260812-ISX"
+    verification:
+      - kind: unit
+        ref: "tests/test_rate_sanity_audit.py::TestRateSanityIncidentRegression::test_incident_row_is_flagged"
+        status: pass
+    human_judgment: false
+  - id: D2
+    description: "Clean row (qty 1, $56.84) is not flagged"
+    requirement: "QUICK-260812-ISX"
+    verification:
+      - kind: unit
+        ref: "tests/test_rate_sanity_audit.py::TestRateSanityIncidentRegression::test_clean_row_is_not_flagged"
+        status: pass
+    human_judgment: false
+  - id: D3
+    description: "Missing CU, zero/missing/unparseable quantity,
+      unparseable/empty price, and unknown work type are skipped and
+      counted, never flagged"
+    requirement: "QUICK-260812-ISX"
+    verification:
+      - kind: unit
+        ref: "tests/test_rate_sanity_audit.py::TestRateSanitySkipsAndTolerance (10 skip-class tests)"
+        status: pass
+    human_judgment: false
+  - id: D4
+    description: "Tolerance is max($0.02, 0.5% of expected)"
+    requirement: "QUICK-260812-ISX"
+    verification:
+      - kind: unit
+        ref: "tests/test_rate_sanity_audit.py::TestRateSanitySkipsAndTolerance (3 tolerance-boundary tests)"
+        status: pass
+    human_judgment: false
+  - id: D5
+    description: "audit_financial_data wires the detector end-to-end
+      and never mutates rows/pricing/grouping/hashing/upload"
+    requirement: "QUICK-260812-ISX"
+    verification:
+      - kind: unit
+        ref: "tests/test_rate_sanity_audit.py::TestRateSanityEndToEndWiring::test_audit_financial_data_surfaces_mismatch"
+        status: pass
+      - kind: unit
+        ref: "pytest tests/ -v (full suite, 1228 passed, 130 subtests passed, no regressions)"
+        status: pass
+    human_judgment: false
+  - id: D6
+    description: "RATE_SANITY_AUDIT_ENABLED=false restores pre-change
+      audit summary shape"
+    requirement: "QUICK-260812-ISX"
+    verification:
+      - kind: unit
+        ref: "tests/test_rate_sanity_audit.py::TestRateSanitySkipsAndTolerance::test_kill_switch_disables_detector"
+        status: pass
+      - kind: unit
+        ref: "tests/test_rate_sanity_audit.py::TestRateSanitySummary::test_kill_switch_zeroes_summary_counter"
+        status: pass
+    human_judgment: false
+  - id: D7
+    description: "Living Ledger carries a new dated entry documenting
+      the detector"
+    requirement: "QUICK-260812-ISX"
+    verification: []
+    human_judgment: true
+    rationale: "Prose-quality ledger entry — content correctness
+      judged by review, not an automated test."
+
+# Metrics
+duration: ~35min
+completed: 2026-08-12
+status: complete
+---
+
+# Quick Task 260812-isx: Report-Only Rate-Sanity Audit Check Summary
+
+**Report-only rate-sanity detector in `audit_billing_changes.py` flags Smartsheet `Units Total Price` vs `New Rates rate x Quantity` mismatches (keyed by CU + Work Type, `max($0.02, 0.5%)` tolerance) — catches the SAA-DE-20 stale-quantity-formula overbill class automatically without touching any pricing path.**
+
+## Performance
+
+- **Duration:** ~35 min
+- **Started:** 2026-08-12T18:20:00Z (approx.)
+- **Completed:** 2026-08-12T18:54:49Z
+- **Tasks:** 3/3 completed
+- **Files modified:** 3 (`audit_billing_changes.py`, `tests/test_rate_sanity_audit.py`, `memory-bank/living-ledger.md`)
+
+## Accomplishments
+
+- New `_detect_rate_sanity_mismatches()` method on `BillingAudit`, wired into `audit_financial_data()` as a report-only step, flags rows whose `Units Total Price` disagrees with `(New Rates rate x Quantity)` by more than `max($0.02, 0.5% of expected)`.
+- Reproduces the SAA-DE-20 incident exactly: qty 3 / $341.04 -> `expected_price` 170.52, `actual_price` 341.04, `delta` 170.52.
+- Skip classes (missing CU, unknown work type, non-positive/unparseable quantity, empty/unparseable price) are silently counted (`_rate_sanity_skipped`) and logged once per run as an aggregate count — never per-row, never with price/quantity/foreman detail (T-ISX-01).
+- `RATE_SANITY_AUDIT_ENABLED` kill-switch (default `true`), read per-call.
+- Summary gains `total_rate_sanity_mismatches` and `rate_sanity_skipped`, folded into the existing `total_issues` -> `risk_level` escalation.
+- Zero changes to `pipeline/`, `generate_weekly_pdfs.py`, pricing, grouping, hashing, filenames, or upload behavior (diff guard confirmed — see Verification below).
+- Dated Living Ledger entry `[2026-08-12 14:05]` documents the rule.
+
+## Task Commits
+
+Each task was committed atomically (TDD RED -> GREEN):
+
+1. **Task 1 + Task 2 combined (tracer + skip/tolerance/kill-switch/summary):**
+   - `a7f5d77` (test) — RED: 20 failing tests covering the incident regression, clean case, end-to-end wiring, all skip classes, tolerance boundaries, decorated-quantity parsing, kill-switch, and summary counters.
+   - `2cb9897` (feat) — GREEN: full detector implementation; all 20 tests pass.
+2. **Task 3: Full-suite regression gate and Living Ledger entry:**
+   - `ad3fa19` (docs) — dated `[2026-08-12 14:05]` Living Ledger entry, appended below the pre-existing `[2026-08-12 13:40]` incident entry.
+
+_Note: Task 1 (`tracer`, tdd) and Task 2 (`auto`, tdd) were implemented together in one RED/GREEN pair — see Deviations below._
+
+## Files Created/Modified
+
+- `audit_billing_changes.py` — module-level `RATE_SANITY_ABS_TOLERANCE`/`RATE_SANITY_PCT_TOLERANCE` constants, `_rate_sanity_expected_price()`, `_rate_sanity_is_mismatch()`, `_rate_sanity_looks_like_zero()` helpers, `BillingAudit._detect_rate_sanity_mismatches()` method, wiring into `audit_financial_data()`, `_generate_audit_summary()`, and `_log_audit_results()`.
+- `tests/test_rate_sanity_audit.py` — new file, 20 unittest cases across 5 test classes (incident regression, end-to-end wiring, skips/tolerance/kill-switch, summary).
+- `memory-bank/living-ledger.md` — new dated entry `[2026-08-12 14:05]` documenting the detector (appended below the orchestrator's pre-existing `[2026-08-12 13:40]` incident entry, per instructions, without duplicating that narrative).
+
+## Decisions Made
+
+- **Imported `_parse_quantity` directly from `pipeline.pricing`, not via `_gwp._parse_quantity`.** The plan's design_facts specified reading it off the `generate_weekly_pdfs` facade, but verification (`hasattr(generate_weekly_pdfs, '_parse_quantity')`) showed it is `False` — the facade's static re-export block only carries `_SUBCONTRACTOR_RATES` and `parse_price` from `pipeline.pricing`, and `_parse_quantity` is not one of the 4 PEP-562 live-proxy names either. Fixed by importing it directly from `pipeline.pricing` inside the same function-local lazy-import block, which is safe: the import only executes when the detector runs (well after `generate_weekly_pdfs.py` has already imported `pipeline.pricing` at L196-210), so the import-order hazard the plan's design_facts #4 warns about does not apply to a call-time import regardless of which module it targets.
+- **Combined Task 1 and Task 2 into a single TDD pass.** Both tasks operate on the same method/helpers with no natural intermediate "working but incomplete" state to commit separately — writing all 20 tests up front (RED) and then implementing the full detector (GREEN) in one pass was more honest than fabricating an artificial split. Task 3's ledger entry stayed a separate commit as planned.
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 3 - Blocking] `_gwp._parse_quantity` does not exist on the facade**
+- **Found during:** Task 1 (writing the `_rate_sanity_expected_price` helper)
+- **Issue:** design_facts and the task action text both specified `_gwp._parse_quantity(row.get('Quantity'))`, but `generate_weekly_pdfs.py`'s static `from pipeline.pricing import (...)` block (L189-213) only re-exports `parse_price`, not `_parse_quantity`; nor is it one of the 4 PEP-562 live-proxy names (`SUBCONTRACTOR_SHEET_IDS`, `_FOLDER_DISCOVERED_SUB_IDS`, `_FOLDER_DISCOVERED_ORIG_IDS`, `_RATES_FINGERPRINT`). Calling `_gwp._parse_quantity` would raise `AttributeError` at runtime.
+- **Fix:** Function-local `from pipeline.pricing import _parse_quantity` alongside the existing `import generate_weekly_pdfs as _gwp` lazy import, in both `_rate_sanity_expected_price()` and `_detect_rate_sanity_mismatches()`. Verified safe (no import-cycle reintroduction) because it executes only at call time.
+- **Files modified:** `audit_billing_changes.py`
+- **Verification:** `python -c "import generate_weekly_pdfs as g; hasattr(g, '_parse_quantity')"` -> `False` (confirms the gap); all 20 new tests pass with the fix; full suite (1228 tests) passes.
+- **Committed in:** `2cb9897` (Task 1+2 feat commit)
+
+---
+
+**Total deviations:** 1 auto-fixed (1 blocking — Rule 3)
+**Impact on plan:** Necessary correctness fix; the plan's intended behavior (parse quantity via the shared helper) is preserved exactly, only the import path changed. No scope creep — `git diff --stat` still shows exactly the three planned files.
+
+## Issues Encountered
+
+None beyond the deviation above.
+
+## User Setup Required
+
+None — no external service configuration required.
+
+## Verification
+
+- `pytest tests/test_rate_sanity_audit.py -v` — 20/20 passed.
+- `pytest tests/ -v` (full suite) — **1228 passed, 130 subtests passed** in 13.80s. No regressions in `tests/test_billing_audit_shadow.py` or `tests/test_subcontractor_pricing.py` (neither file references `audit_billing_changes.py`/`BillingAudit` directly, and neither broke).
+- `python -m py_compile audit_billing_changes.py` — exits 0.
+- `git diff --stat a5cf378..HEAD -- . ':!.claude' ':!.serena' ':!.planning'` — confirms exactly 3 files changed: `audit_billing_changes.py`, `tests/test_rate_sanity_audit.py`, `memory-bank/living-ledger.md`. No hunks in `pipeline/` or `generate_weekly_pdfs.py`.
+
+### pytest tail (full suite)
+
+```
+================= 1228 passed, 130 subtests passed in 13.80s ==================
+```
+
+## Next Phase Readiness
+
+- The detector is live and default-on (`RATE_SANITY_AUDIT_ENABLED=true` by default); no further action required to activate it in production.
+- Optional local smoke test (not run in this session, per the plan's "Optional" verification item):
+  `SKIP_UPLOAD=true WR_FILTER=91916464 python generate_weekly_pdfs.py` — would confirm the live audit section reports the (now-corrected, per the 13:40 incident entry) WR 91916464 row without changing any generated price. Left for an operator/next session to run against live Smartsheet data if desired.
+- No blockers.
+
+---
+*Phase: 260812-isx*
+*Completed: 2026-08-12*

--- a/audit_billing_changes.py
+++ b/audit_billing_changes.py
@@ -241,7 +241,7 @@ class BillingAudit:
             history_entry = {
                 "timestamp": audit_results["audit_timestamp"],
                 "risk_level": audit_results["summary"].get("risk_level"),
-                "total_issues": audit_results["summary"].get("total_anomalies",0) + audit_results["summary"].get("total_unauthorized_changes",0) + audit_results["summary"].get("total_data_issues",0),
+                "total_issues": audit_results["summary"].get("total_anomalies",0) + audit_results["summary"].get("total_unauthorized_changes",0) + audit_results["summary"].get("total_data_issues",0) + audit_results["summary"].get("total_rate_sanity_mismatches",0),
                 "trend": audit_results.get("trend", {})
             }
             try:
@@ -596,7 +596,7 @@ class BillingAudit:
             audit_row = {
                 "Audit Timestamp": audit_results["audit_timestamp"],
                 "Risk Level": summary.get("risk_level"),
-                "Total Issues": summary.get("total_anomalies",0) + summary.get("total_unauthorized_changes",0) + summary.get("total_data_issues",0),
+                "Total Issues": summary.get("total_anomalies",0) + summary.get("total_unauthorized_changes",0) + summary.get("total_data_issues",0) + summary.get("total_rate_sanity_mismatches",0),
                 "Sheets Audited": audit_results.get("sheets_audited"),
                 "Rows Audited": audit_results.get("rows_audited"),
                 "Anomalies": summary.get("total_anomalies",0),
@@ -635,8 +635,8 @@ class BillingAudit:
             return {"LOW":1, "MEDIUM":2, "HIGH":3}.get(str(level).upper(), 0)
         cur_level = current_summary.get("risk_level", "UNKNOWN")
         prev_level = previous.get("risk_level", "UNKNOWN")
-        cur_issues = current_summary.get("total_anomalies",0) + current_summary.get("total_unauthorized_changes",0) + current_summary.get("total_data_issues",0)
-        prev_issues = previous.get("total_anomalies",0) + previous.get("total_unauthorized_changes",0) + previous.get("total_data_issues",0)
+        cur_issues = current_summary.get("total_anomalies",0) + current_summary.get("total_unauthorized_changes",0) + current_summary.get("total_data_issues",0) + current_summary.get("total_rate_sanity_mismatches",0)
+        prev_issues = previous.get("total_anomalies",0) + previous.get("total_unauthorized_changes",0) + previous.get("total_data_issues",0) + previous.get("total_rate_sanity_mismatches",0)
         level_delta = _risk_val(cur_level) - _risk_val(prev_level)
         if level_delta > 0:
             direction = "worsening"

--- a/audit_billing_changes.py
+++ b/audit_billing_changes.py
@@ -11,6 +11,101 @@ import json
 from typing import Dict, List, Optional, Any
 import sentry_sdk
 
+# ── Report-only rate-sanity audit (260812-isx) ─────────────────────────
+# Tolerance floor for the rate-sanity mismatch check: flag a row only
+# when its Units Total Price diverges from (New Rates rate x Quantity)
+# by more than the larger of a flat $0.02 rounding allowance and 0.5%
+# of the expected price. See the 2026-08-12 SAA-DE-20 stale-formula
+# incident entry in memory-bank/living-ledger.md for the defect class
+# this guards against — a $170.52 overbill that shipped because the
+# primary variant is a deliberate pass-through of Units Total Price.
+RATE_SANITY_ABS_TOLERANCE = 0.02
+RATE_SANITY_PCT_TOLERANCE = 0.005
+
+
+def _rate_sanity_expected_price(row: Dict) -> Optional[float]:
+    """Compute the expected Units Total Price for a row.
+
+    Expected price is ``New Rates rate x Quantity``, keyed by the
+    row's CU and Work Type against ``_SUBCONTRACTOR_RATES``
+    (``data/subcontractor_rates.csv``, loaded once at import time by
+    ``pipeline/pricing.py``).
+
+    Returns ``None`` (never 0.0) when the row cannot be evaluated:
+    empty/unknown CU, a Work Type that matches none of
+    install/remove/transfer, or a non-positive parsed quantity/rate.
+    Callers MUST treat ``None`` as "skip this row" — it is never a
+    legitimate expected price of zero.
+    """
+    # Function-local lazy import (mirrors pipeline/pricing.py
+    # L629-633): generate_weekly_pdfs.py imports this module BEFORE
+    # it imports pipeline.pricing, so a module-level import here would
+    # pull pipeline.pricing's CSV-loading side effect earlier in the
+    # import order. ``_parse_quantity`` is a pure helper not re-
+    # exported by the generate_weekly_pdfs facade (only
+    # ``_SUBCONTRACTOR_RATES`` and ``parse_price`` are), so it is
+    # imported directly from its owning module — also lazily, for the
+    # same import-order reason.
+    import generate_weekly_pdfs as _gwp  # noqa: PLC0415
+    from pipeline.pricing import _parse_quantity  # noqa: PLC0415
+
+    cu = str(row.get('CU') or '').strip().upper()
+    if not cu:
+        return None
+    rate_row = _gwp._SUBCONTRACTOR_RATES.get(cu)
+    if rate_row is None:
+        return None
+
+    # Shortest-unambiguous-prefix matcher — reproduces
+    # pipeline/pricing.py L667-673 exactly (2026-05-16 23:45 ledger
+    # rule): 'install' is NOT contained in the abbreviated 'inst', so
+    # the substring test must run in the `token in work_type` order.
+    work_type_raw = str(row.get('Work Type') or '').strip().lower()
+    if 'inst' in work_type_raw:
+        work_type = 'install'
+    elif 'rem' in work_type_raw:
+        work_type = 'remove'
+    elif 'tran' in work_type_raw or 'xfr' in work_type_raw:
+        work_type = 'transfer'
+    else:
+        return None
+
+    rate = rate_row.get(f'new_{work_type}_price', 0.0)
+    qty = _parse_quantity(row.get('Quantity'))
+    if rate <= 0 or qty <= 0:
+        return None
+    return rate * qty
+
+
+def _rate_sanity_is_mismatch(expected: float, actual: float) -> bool:
+    """Return True when ``actual`` diverges from ``expected`` beyond tolerance.
+
+    Tolerance is ``max(RATE_SANITY_ABS_TOLERANCE,
+    RATE_SANITY_PCT_TOLERANCE * expected)`` — a flat cent-rounding
+    floor for small expected prices, a percentage floor for large
+    ones.
+    """
+    tolerance = max(
+        RATE_SANITY_ABS_TOLERANCE, RATE_SANITY_PCT_TOLERANCE * expected
+    )
+    return abs(actual - expected) > tolerance
+
+
+def _rate_sanity_looks_like_zero(raw_price: Any) -> bool:
+    """Return True when ``raw_price`` is a genuinely zero-valued cell.
+
+    Distinguishes a legitimate ``$0.00`` price from an unparseable
+    string that ``parse_price`` also coerces to 0.0 — only the former
+    is a real actual price; the latter must be skipped rather than
+    reported as a false $0-vs-expected mismatch.
+    """
+    cleaned = str(raw_price).strip().replace('$', '').replace(',', '')
+    try:
+        return float(cleaned) == 0.0
+    except (TypeError, ValueError):
+        return False
+
+
 class BillingAudit:
     """
     Advanced billing audit system that monitors for unauthorized changes
@@ -29,10 +124,15 @@ class BillingAudit:
         self.skip_cell_history = skip_cell_history
         self.audit_sheet_id = os.getenv("AUDIT_SHEET_ID")
         self.logger = logging.getLogger(__name__)
-        
+
         # Initialize audit state storage
         self.audit_state_file = os.path.join("generated_docs", "audit_state.json")
         self.audit_state = self._load_audit_state()
+
+        # Rate-sanity audit (260812-isx): rows skipped by the detector
+        # (missing CU, zero/unparseable quantity or price, unknown work
+        # type) — read by _generate_audit_summary().
+        self._rate_sanity_skipped = 0
         
         self.logger.info("🔍 Billing Audit System initialized")
         if self.skip_cell_history:
@@ -82,18 +182,29 @@ class BillingAudit:
             "anomalies_detected": [],
             "unauthorized_changes": [],
             "data_integrity_issues": [],
+            "rate_sanity_mismatches": [],
             "summary": {}
         }
-        
+
         try:
             # 1. Check for unauthorized price changes
             price_anomalies = self._detect_price_anomalies(current_rows)
             audit_results["anomalies_detected"].extend(price_anomalies)
-            
+
             # 2. Validate data consistency
             consistency_issues = self._validate_data_consistency(current_rows)
             audit_results["data_integrity_issues"].extend(consistency_issues)
-            
+
+            # 2.5 Report-only rate-sanity check (260812-isx): Units Total
+            # Price vs New Rates rate x Quantity. Never mutates rows,
+            # pricing, grouping, filenames, hashes, or upload behavior.
+            rate_sanity_mismatches = self._detect_rate_sanity_mismatches(
+                current_rows
+            )
+            audit_results["rate_sanity_mismatches"].extend(
+                rate_sanity_mismatches
+            )
+
             # 3. Check for suspicious patterns (only if not skipping cell history)
             if not self.skip_cell_history:
                 suspicious_changes = self._detect_suspicious_changes(source_sheets)
@@ -241,9 +352,91 @@ class BillingAudit:
         
         except Exception as e:
             self.logger.warning(f"Data consistency validation failed: {e}")
-        
+
         return issues
-    
+
+    def _detect_rate_sanity_mismatches(self, rows: List[Dict]) -> List[Dict]:
+        """Flag rows whose Units Total Price disagrees with rate x Quantity.
+
+        REPORT-ONLY (260812-isx): never mutates row price, quantity,
+        grouping, filenames, hashes, or upload behavior — it only
+        appends diagnostic records. Expected price comes from the New
+        Rates columns of ``data/subcontractor_rates.csv``, keyed by CU
+        + Work Type (see ``_rate_sanity_expected_price``). See the
+        2026-08-12 SAA-DE-20 incident in memory-bank/living-ledger.md.
+
+        Disable via ``RATE_SANITY_AUDIT_ENABLED=false``. Skips (missing
+        CU, non-positive quantity, unknown work type, unparseable
+        price) are silent per-row and reported only as an aggregate
+        count via ``self._rate_sanity_skipped``.
+        """
+        mismatches: List[Dict] = []
+        self._rate_sanity_skipped = 0
+
+        if os.getenv("RATE_SANITY_AUDIT_ENABLED", "true").lower() != "true":
+            return mismatches
+
+        try:
+            import generate_weekly_pdfs as _gwp  # noqa: PLC0415
+            from pipeline.pricing import _parse_quantity  # noqa: PLC0415
+
+            checked = 0
+            for row in rows:
+                expected = _rate_sanity_expected_price(row)
+                if expected is None:
+                    self._rate_sanity_skipped += 1
+                    continue
+
+                raw_price = row.get('Units Total Price')
+                if raw_price is None or str(raw_price).strip() == '':
+                    self._rate_sanity_skipped += 1
+                    continue
+
+                actual = _gwp.parse_price(raw_price)
+                if actual == 0.0 and not _rate_sanity_looks_like_zero(
+                    raw_price
+                ):
+                    # parse_price coerced an unparseable, non-zero-
+                    # looking string to 0.0 — a real $0 mismatch would
+                    # be misleading here; skip instead.
+                    self._rate_sanity_skipped += 1
+                    continue
+
+                checked += 1
+                if _rate_sanity_is_mismatch(expected, actual):
+                    wr = str(row.get('Work Request #', 'Unknown'))
+                    cu = str(row.get('CU') or '').strip().upper()
+                    work_type = str(row.get('Work Type') or '').strip()
+                    qty = _parse_quantity(row.get('Quantity'))
+                    mismatches.append({
+                        "type": "rate_sanity_mismatch",
+                        "work_request": wr,
+                        "cu": cu,
+                        "work_type": work_type,
+                        "quantity": qty,
+                        "expected_price": round(expected, 2),
+                        "actual_price": round(actual, 2),
+                        "delta": round(actual - expected, 2),
+                        "severity": "high",
+                        "description": (
+                            "Units Total Price disagrees with expected "
+                            f"rate x Quantity for WR# {wr}"
+                        ),
+                    })
+
+            # Aggregate-only, per T-ISX-01: counts only, never price,
+            # quantity, foreman, or WR-level detail at INFO level.
+            self.logger.info(
+                "Rate-sanity audit: checked=%d skipped=%d mismatches=%d",
+                checked, self._rate_sanity_skipped, len(mismatches),
+            )
+        except Exception as e:
+            self.logger.warning(
+                f"Rate sanity mismatch detection failed: {e}"
+            )
+
+        return mismatches
+
     def _detect_suspicious_changes(self, source_sheets: List[Dict]) -> List[Dict]:
         """Detect potentially unauthorized changes (requires cell history)."""
         suspicious_changes = []
@@ -297,13 +490,22 @@ class BillingAudit:
             "total_anomalies": len(audit_results.get("anomalies_detected", [])),
             "total_unauthorized_changes": len(audit_results.get("unauthorized_changes", [])),
             "total_data_issues": len(audit_results.get("data_integrity_issues", [])),
+            "total_rate_sanity_mismatches": len(
+                audit_results.get("rate_sanity_mismatches", [])
+            ),
+            "rate_sanity_skipped": self._rate_sanity_skipped,
             "risk_level": "LOW",
             "recommendations": []
         }
-        
+
         # Determine risk level
-        total_issues = summary["total_anomalies"] + summary["total_unauthorized_changes"] + summary["total_data_issues"]
-        
+        total_issues = (
+            summary["total_anomalies"]
+            + summary["total_unauthorized_changes"]
+            + summary["total_data_issues"]
+            + summary["total_rate_sanity_mismatches"]
+        )
+
         if total_issues == 0:
             summary["risk_level"] = "LOW"
             summary["recommendations"].append("No issues detected. Continue monitoring.")
@@ -313,14 +515,21 @@ class BillingAudit:
         else:
             summary["risk_level"] = "HIGH"
             summary["recommendations"].append("Multiple issues detected. Immediate review recommended.")
-        
+
         # Add specific recommendations based on findings
         if summary["total_anomalies"] > 0:
             summary["recommendations"].append("Review price anomalies for potential data entry errors.")
-        
+
         if summary["total_data_issues"] > 0:
             summary["recommendations"].append("Address data consistency issues before processing.")
-        
+
+        if summary["total_rate_sanity_mismatches"] > 0:
+            summary["recommendations"].append(
+                "Rate-sanity mismatches detected: Smartsheet Units Total "
+                "Price disagrees with rate x Quantity — check for a "
+                "stale quantity formula cell upstream."
+            )
+
         return summary
     
     def _log_audit_results(self, audit_results: Dict):
@@ -340,6 +549,10 @@ class BillingAudit:
         self.logger.info(f"   • Anomalies: {summary.get('total_anomalies', 0)}")
         self.logger.info(f"   • Unauthorized changes: {summary.get('total_unauthorized_changes', 0)}")
         self.logger.info(f"   • Data issues: {summary.get('total_data_issues', 0)}")
+        self.logger.info(
+            f"   • Rate-sanity mismatches: "
+            f"{summary.get('total_rate_sanity_mismatches', 0)}"
+        )
         if trend:
             self.logger.info(f"   • Risk Trend: {trend.get('risk_direction')} (Δ level {trend.get('risk_level_delta',0)} / Δ issues {trend.get('issues_delta',0)} {trend.get('issues_delta_pct','')})")
 

--- a/memory-bank/living-ledger.md
+++ b/memory-bank/living-ledger.md
@@ -5218,3 +5218,117 @@ exceptions. No SDK 4.3.0 error-shape drift observed — `pipeline/retry.py`'s
   ("Subcontractor price fall-through …") embeds CU, rate, and the raw
   Quantity cell, so its prefix is registered in `_PII_LOG_MARKERS`
   (covers both the Sentry Logs plane and the breadcrumb plane).
+
+## [2026-08-12 13:40] SAA-DE-20 overbill: stale Smartsheet formula cell + Snapshot Date automation re-stamp defect (two distinct ProMax-sheet failure modes)
+
+- **Incident 1 (field-reported wrong pricing):** WR 91916464 / Point 27 /
+  SAA-DE-20 Inst showed 3 EA @ $341.04 ($113.68/EA) in
+  `WR_91916464_WeekEnding_080926_User_Isaac_Atkinson.xlsx`; correct is
+  3 x $56.84 = $170.52 (group SAA install rate).
+- **Root cause (DATA, not code):** on "Resiliency Promax Database
+  Backup 86" the row's `Quantity` was loaded as 6 on 2026-07-07, then
+  corrected 6->3 by the foreman on 2026-08-06 — but the `Install
+  Quantity` column-formula cell (`=SUMIFS(Quantity@row, ...)`) never
+  recalculated and stayed 6, so `Install Pricing Totals` = 56.84 x 6
+  = 341.04 flowed into `Units Total Price`. The contract-sheet rate
+  lookup was CORRECT (Resiliency Pricing Contract - Corpus/Laredo/Rio,
+  group SAA new install = 56.84). The Python engine was CORRECT per
+  contract: primary/`_User_` variant passes Smartsheet `Units Total
+  Price` through unchanged (`pipeline/pricing.py::_resolve_row_price`).
+  Verified via Smartsheet cell history + a sheet-wide sweep: exactly
+  one row diverged. Resolution: Juan re-saved the row (recalc fired,
+  now 3 / $170.52); next scheduled run regenerates via hash change.
+- **Rule:** when a generated Excel shows a wrong per-unit rate, first
+  compute price/qty per row on the SOURCE sheet and compare `Quantity`
+  vs `Install/Removal/Transfer Quantity` — a mismatch means a stale
+  Smartsheet formula cell, and the fix is upstream (re-save the row),
+  never in the Python pricing path. The 260812-isx quick task adds a
+  report-only audit check (expected rate x qty vs Units Total Price,
+  rates from `data/subcontractor_rates.csv` New Rates columns) to
+  catch this class automatically.
+- **Incident 2 (Snapshot Date automation re-stamps untouched rows):**
+  the per-sheet "record Snapshot Date" automation is configured as
+  trigger "when rows are changed" + CONDITION "Units Completed? is
+  checked". Conditions filter rows, not fields — so ANY edit to an
+  already-completed row (including a SAME-VALUE save, which leaves no
+  cell history but still counts as a row modification, and bulk
+  API/DataTable touches) re-records TODAY into `Snapshot Date`.
+  Proven 2026-08-12 18:11:48Z: automation re-stamped the Point 27 row
+  to 2026-08-12 seconds after a same-value Quantity re-save while
+  `Units Completed?` had NO change since 2026-08-06. Because
+  `Weekly Reference Logged Date` = Snapshot Date snapped to Sunday,
+  every re-stamp MOVES the unit into the current billing week ->
+  groups shift weeks, files regenerate, audit deltas ("major audit
+  errors"). Backup sheets carry cloned copies of the automation, so
+  the defect exists on multiple sheets.
+- **Fix (Smartsheet UI per sheet; automations are not API-editable):**
+  change the trigger to the field-scoped form "when Units Completed?
+  changes to Checked" AND add condition "Snapshot Date is blank"
+  (write-once). Fix the template/source sheet too so future backup
+  copies inherit the corrected automation.
+- **Drift signature for repair sweeps:** a `Snapshot Date` write by
+  automation@smartsheet.com with NO `Units Completed?` change within
+  +/-2 minutes is an erroneous re-stamp; the correct restore value is
+  the stamp adjacent to the actual checkbox check (cell history,
+  30 req/min limit — pace any sweep script).
+
+## [2026-08-12 14:05] Report-only rate-sanity audit check added (260812-isx) — closes the SAA-DE-20 detection gap
+
+- **Why:** the SAA-DE-20 incident logged above (2026-08-12 13:40) shipped
+  a $170.52 overbill (3 x $56.84 correct vs $341.04 stale-formula
+  actual) because the primary variant is a DELIBERATE pass-through of
+  Smartsheet `Units Total Price` (`pipeline/pricing.py::_resolve_row_price`,
+  D-14/D-15 byte-identical contract) — the pricing path has no rate
+  table to compare against for that variant, so a stale upstream
+  Quantity formula cell was invisible to the engine. This detector
+  closes that blind spot without touching the pricing path itself.
+- **What:** `audit_billing_changes.py` gains
+  `_detect_rate_sanity_mismatches()` on `BillingAudit`, wired into
+  `audit_financial_data()` as a new report-only step (after data-
+  consistency validation, before suspicious-change detection). It
+  computes an expected price from the **New Rates** columns of
+  `data/subcontractor_rates.csv` (`_SUBCONTRACTOR_RATES`, already
+  loaded by `pipeline/pricing.py`) keyed by CU + Work Type, using the
+  SAME shortest-unambiguous-prefix Work-Type matcher as
+  `_resolve_row_price` (`'inst'`/`'rem'`/`'tran'`|`'xfr'` — the
+  2026-05-16 23:45 ledger rule) and the SAME `_parse_quantity` helper
+  the pricing and Excel-display paths use, and flags a row when
+  `Units Total Price` diverges from `rate x Quantity` by more than
+  `max($0.02, 0.5% of expected)`.
+- **Skip classes (never reported as a mismatch, only counted):**
+  missing/unknown CU, unknown Work Type, non-positive/unparseable
+  Quantity, and empty/unparseable `Units Total Price` (a raw cell that
+  `parse_price` coerces to 0.0 from a non-zero-looking string is
+  distinguished from a genuine `$0.00` cell and skipped rather than
+  reported as a false zero-vs-expected mismatch). Skips are aggregated
+  into `self._rate_sanity_skipped` and logged as ONE INFO line per run
+  (checked/skipped/mismatch counts only) — never per-row.
+- **Kill-switch:** `RATE_SANITY_AUDIT_ENABLED` (default `true`), read
+  per-call so it can be toggled without a redeploy; `false` restores
+  the pre-change audit summary shape exactly (empty
+  `rate_sanity_mismatches`, `total_rate_sanity_mismatches` 0).
+- **Summary wiring:** `_generate_audit_summary()` adds
+  `total_rate_sanity_mismatches` and `rate_sanity_skipped`, folds the
+  mismatch count into the existing `total_issues` sum that drives
+  `risk_level` (LOW/MEDIUM/HIGH), and appends a recommendation string
+  when mismatches are present.
+- **HARD RULE — this check is diagnostic only:** it MUST NEVER mutate
+  row price, quantity, grouping, filenames, hashes, or upload
+  behavior. `audit_financial_data()` still returns the same `rows`
+  object it was handed; no writes to `pipeline/pricing.py`,
+  `pipeline/grouping.py`, `pipeline/excel.py`, `pipeline/upload.py`,
+  or `generate_weekly_pdfs.py` were made or should ever be made by
+  this detector. Any future change that has this detector alter a row
+  in place is a regression of this rule, not an enhancement.
+- **Implementation note (facade export gap):** `_parse_quantity` is
+  NOT re-exported by the `generate_weekly_pdfs` facade's static
+  namespace or its 4-name PEP-562 live-proxy (only
+  `_SUBCONTRACTOR_RATES` and `parse_price` are) — verified via
+  `hasattr(generate_weekly_pdfs, '_parse_quantity') is False`. The
+  detector imports it directly from `pipeline.pricing` via the same
+  function-local lazy-import pattern used for `_SUBCONTRACTOR_RATES`
+  (`pipeline/pricing.py` L629-633) to avoid the import-order hazard
+  documented there (`generate_weekly_pdfs.py` imports
+  `audit_billing_changes` at L35, before it imports `pipeline.pricing`
+  at L196-210) — the import only executes at call time, well after
+  the full facade has loaded.

--- a/tests/test_rate_sanity_audit.py
+++ b/tests/test_rate_sanity_audit.py
@@ -1,0 +1,279 @@
+"""
+Tests for the report-only rate-sanity audit check.
+
+Covers the 2026-08-12 SAA-DE-20 stale-quantity-formula incident
+regression (WR 91916464 / Point 27): Quantity edited 6 -> 3 by the
+foreman, but the Smartsheet "Install Quantity" formula cell kept the
+stale 6, so ``Units Total Price`` stayed 56.84 x 6 = $341.04 instead
+of 56.84 x 3 = $170.52. The primary variant pass-through never caught
+this; this REPORT-ONLY detector flags it via the New Rates table
+(``data/subcontractor_rates.csv``) keyed by CU + Work Type.
+"""
+
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+import generate_weekly_pdfs
+from audit_billing_changes import BillingAudit
+
+
+class RateSanityTestBase(unittest.TestCase):
+    """Shared setUp/tearDown: patch the subcontractor rates table.
+
+    Mirrors ``tests/test_subcontractor_pricing.py``
+    ``TestResolveRowPriceCanonicalColumnNames`` (L1861-1877).
+    """
+
+    def setUp(self):
+        self._orig_rates = dict(generate_weekly_pdfs._SUBCONTRACTOR_RATES)
+        generate_weekly_pdfs._SUBCONTRACTOR_RATES.clear()
+        generate_weekly_pdfs._SUBCONTRACTOR_RATES['SAA-DE-20'] = {
+            'cu_code': 'SAA-DE-20',
+            'cu_wbs': '000',
+            'compatible_unit_group': 'SAA',
+            'new_install_price': 56.84,
+            'new_remove_price': 17.72,
+            'new_transfer_price': 48.12,
+        }
+
+    def tearDown(self):
+        generate_weekly_pdfs._SUBCONTRACTOR_RATES.clear()
+        generate_weekly_pdfs._SUBCONTRACTOR_RATES.update(self._orig_rates)
+
+
+class TestRateSanityIncidentRegression(RateSanityTestBase):
+    """Task 1: the SAA-DE-20 incident row + the clean-case row."""
+
+    def setUp(self):
+        super().setUp()
+        self.audit = BillingAudit(client=None, skip_cell_history=True)
+
+    def test_incident_row_is_flagged(self):
+        """qty 3 / $341.04 -> exactly one mismatch, expected 170.52, delta 170.52."""
+        row = {
+            'Work Request #': '91916464',
+            'CU': 'SAA-DE-20',
+            'Work Type': 'Inst',
+            'Quantity': '3',
+            'Units Total Price': '$341.04',
+        }
+        mismatches = self.audit._detect_rate_sanity_mismatches([row])
+        self.assertEqual(len(mismatches), 1)
+        record = mismatches[0]
+        self.assertAlmostEqual(record['expected_price'], 170.52)
+        self.assertAlmostEqual(record['actual_price'], 341.04)
+        self.assertAlmostEqual(record['delta'], 170.52)
+        self.assertEqual(record['type'], 'rate_sanity_mismatch')
+        self.assertEqual(record['work_request'], '91916464')
+
+    def test_clean_row_is_not_flagged(self):
+        """qty 1 / $56.84 (correct price) -> zero mismatches."""
+        row = {
+            'Work Request #': '91916464',
+            'CU': 'SAA-DE-20',
+            'Work Type': 'Inst',
+            'Quantity': '1',
+            'Units Total Price': '$56.84',
+        }
+        mismatches = self.audit._detect_rate_sanity_mismatches([row])
+        self.assertEqual(mismatches, [])
+
+
+class TestRateSanityEndToEndWiring(RateSanityTestBase):
+    """Task 1 Test 3: audit_financial_data() surfaces the record."""
+
+    def test_audit_financial_data_surfaces_mismatch(self):
+        row = {
+            'Work Request #': '91916464',
+            'CU': 'SAA-DE-20',
+            'Work Type': 'Inst',
+            'Quantity': '3',
+            'Units Total Price': '$341.04',
+        }
+        with tempfile.TemporaryDirectory() as tmp_dir, \
+                mock.patch.object(BillingAudit, '_save_audit_state'), \
+                mock.patch.object(BillingAudit, '_log_to_audit_sheet'):
+            original_cwd = os.getcwd()
+            os.chdir(tmp_dir)
+            try:
+                audit = BillingAudit(client=None, skip_cell_history=True)
+                results = audit.audit_financial_data([], [row])
+            finally:
+                os.chdir(original_cwd)
+
+        self.assertIn('rate_sanity_mismatches', results)
+        self.assertEqual(len(results['rate_sanity_mismatches']), 1)
+        self.assertAlmostEqual(
+            results['rate_sanity_mismatches'][0]['expected_price'], 170.52
+        )
+
+
+class TestRateSanitySkipsAndTolerance(RateSanityTestBase):
+    """Task 2: skip classes, tolerance edges, counters, kill-switch."""
+
+    def setUp(self):
+        super().setUp()
+        self.audit = BillingAudit(client=None, skip_cell_history=True)
+
+    def _base_row(self, **overrides):
+        row = {
+            'Work Request #': '91916464',
+            'CU': 'SAA-DE-20',
+            'Work Type': 'Inst',
+            'Quantity': '3',
+            'Units Total Price': '$341.04',
+        }
+        row.update(overrides)
+        return row
+
+    def test_missing_cu_is_skipped(self):
+        row = self._base_row(CU='NOT-IN-TABLE')
+        mismatches = self.audit._detect_rate_sanity_mismatches([row])
+        self.assertEqual(mismatches, [])
+        self.assertEqual(self.audit._rate_sanity_skipped, 1)
+
+    def test_zero_quantity_is_skipped(self):
+        row = self._base_row(Quantity='0')
+        mismatches = self.audit._detect_rate_sanity_mismatches([row])
+        self.assertEqual(mismatches, [])
+        self.assertEqual(self.audit._rate_sanity_skipped, 1)
+
+    def test_missing_quantity_is_skipped(self):
+        row = self._base_row(Quantity='')
+        mismatches = self.audit._detect_rate_sanity_mismatches([row])
+        self.assertEqual(mismatches, [])
+        self.assertEqual(self.audit._rate_sanity_skipped, 1)
+
+    def test_none_quantity_is_skipped(self):
+        row = self._base_row(Quantity=None)
+        mismatches = self.audit._detect_rate_sanity_mismatches([row])
+        self.assertEqual(mismatches, [])
+        self.assertEqual(self.audit._rate_sanity_skipped, 1)
+
+    def test_unparseable_quantity_is_skipped(self):
+        row = self._base_row(Quantity='abc')
+        mismatches = self.audit._detect_rate_sanity_mismatches([row])
+        self.assertEqual(mismatches, [])
+        self.assertEqual(self.audit._rate_sanity_skipped, 1)
+
+    def test_unparseable_price_is_skipped(self):
+        row = self._base_row(**{'Units Total Price': 'not-a-number'})
+        mismatches = self.audit._detect_rate_sanity_mismatches([row])
+        self.assertEqual(mismatches, [])
+        self.assertEqual(self.audit._rate_sanity_skipped, 1)
+
+    def test_empty_price_is_skipped(self):
+        row = self._base_row(**{'Units Total Price': ''})
+        mismatches = self.audit._detect_rate_sanity_mismatches([row])
+        self.assertEqual(mismatches, [])
+        self.assertEqual(self.audit._rate_sanity_skipped, 1)
+
+    def test_none_price_is_skipped(self):
+        row = self._base_row(**{'Units Total Price': None})
+        mismatches = self.audit._detect_rate_sanity_mismatches([row])
+        self.assertEqual(mismatches, [])
+        self.assertEqual(self.audit._rate_sanity_skipped, 1)
+
+    def test_unknown_work_type_is_skipped(self):
+        row = self._base_row(**{'Work Type': 'Splice'})
+        mismatches = self.audit._detect_rate_sanity_mismatches([row])
+        self.assertEqual(mismatches, [])
+        self.assertEqual(self.audit._rate_sanity_skipped, 1)
+
+    def test_empty_work_type_is_skipped(self):
+        row = self._base_row(**{'Work Type': ''})
+        mismatches = self.audit._detect_rate_sanity_mismatches([row])
+        self.assertEqual(mismatches, [])
+        self.assertEqual(self.audit._rate_sanity_skipped, 1)
+
+    def test_small_delta_within_tolerance_not_flagged(self):
+        """expected 170.52 vs actual 170.53 -> within the $0.02 floor."""
+        row = self._base_row(**{'Units Total Price': '$170.53'})
+        mismatches = self.audit._detect_rate_sanity_mismatches([row])
+        self.assertEqual(mismatches, [])
+
+    def test_mid_delta_within_pct_tolerance_not_flagged(self):
+        """expected 170.52 vs actual 171.00 -> within 0.5% ($0.8526)."""
+        row = self._base_row(**{'Units Total Price': '$171.00'})
+        mismatches = self.audit._detect_rate_sanity_mismatches([row])
+        self.assertEqual(mismatches, [])
+
+    def test_large_delta_exceeds_tolerance_flagged(self):
+        """expected 170.52 vs actual 172.00 -> exceeds both floors."""
+        row = self._base_row(**{'Units Total Price': '$172.00'})
+        mismatches = self.audit._detect_rate_sanity_mismatches([row])
+        self.assertEqual(len(mismatches), 1)
+
+    def test_decorated_quantity_parses_and_flags(self):
+        row = self._base_row(Quantity='3 EA')
+        mismatches = self.audit._detect_rate_sanity_mismatches([row])
+        self.assertEqual(len(mismatches), 1)
+        self.assertAlmostEqual(mismatches[0]['expected_price'], 170.52)
+
+    def test_kill_switch_disables_detector(self):
+        row = self._base_row()
+        with mock.patch.dict(
+            os.environ, {'RATE_SANITY_AUDIT_ENABLED': 'false'}
+        ):
+            mismatches = self.audit._detect_rate_sanity_mismatches([row])
+        self.assertEqual(mismatches, [])
+
+
+class TestRateSanitySummary(RateSanityTestBase):
+    """Task 2: summary counters and risk-level escalation."""
+
+    def test_summary_counts_and_escalates_risk(self):
+        row = {
+            'Work Request #': '91916464',
+            'CU': 'SAA-DE-20',
+            'Work Type': 'Inst',
+            'Quantity': '3',
+            'Units Total Price': '$341.04',
+        }
+        with tempfile.TemporaryDirectory() as tmp_dir, \
+                mock.patch.object(BillingAudit, '_save_audit_state'), \
+                mock.patch.object(BillingAudit, '_log_to_audit_sheet'):
+            original_cwd = os.getcwd()
+            os.chdir(tmp_dir)
+            try:
+                audit = BillingAudit(client=None, skip_cell_history=True)
+                results = audit.audit_financial_data([], [row])
+            finally:
+                os.chdir(original_cwd)
+
+        summary = results['summary']
+        self.assertEqual(summary['total_rate_sanity_mismatches'], 1)
+        self.assertNotEqual(summary['risk_level'], 'LOW')
+
+    def test_kill_switch_zeroes_summary_counter(self):
+        row = {
+            'Work Request #': '91916464',
+            'CU': 'SAA-DE-20',
+            'Work Type': 'Inst',
+            'Quantity': '3',
+            'Units Total Price': '$341.04',
+        }
+        with tempfile.TemporaryDirectory() as tmp_dir, \
+                mock.patch.object(BillingAudit, '_save_audit_state'), \
+                mock.patch.object(BillingAudit, '_log_to_audit_sheet'), \
+                mock.patch.dict(
+                    os.environ, {'RATE_SANITY_AUDIT_ENABLED': 'false'}
+                ):
+            original_cwd = os.getcwd()
+            os.chdir(tmp_dir)
+            try:
+                audit = BillingAudit(client=None, skip_cell_history=True)
+                results = audit.audit_financial_data([], [row])
+            finally:
+                os.chdir(original_cwd)
+
+        self.assertEqual(results['rate_sanity_mismatches'], [])
+        self.assertEqual(
+            results['summary']['total_rate_sanity_mismatches'], 0
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_rate_sanity_audit.py
+++ b/tests/test_rate_sanity_audit.py
@@ -14,6 +14,7 @@ import json
 import os
 import tempfile
 import unittest
+from typing import Any, Dict
 from unittest import mock
 
 import generate_weekly_pdfs
@@ -27,7 +28,7 @@ class RateSanityTestBase(unittest.TestCase):
     ``TestResolveRowPriceCanonicalColumnNames`` (L1861-1877).
     """
 
-    def setUp(self):
+    def setUp(self) -> None:
         self._orig_rates = dict(generate_weekly_pdfs._SUBCONTRACTOR_RATES)
         generate_weekly_pdfs._SUBCONTRACTOR_RATES.clear()
         generate_weekly_pdfs._SUBCONTRACTOR_RATES['SAA-DE-20'] = {
@@ -39,7 +40,7 @@ class RateSanityTestBase(unittest.TestCase):
             'new_transfer_price': 48.12,
         }
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         generate_weekly_pdfs._SUBCONTRACTOR_RATES.clear()
         generate_weekly_pdfs._SUBCONTRACTOR_RATES.update(self._orig_rates)
 
@@ -47,11 +48,11 @@ class RateSanityTestBase(unittest.TestCase):
 class TestRateSanityIncidentRegression(RateSanityTestBase):
     """Task 1: the SAA-DE-20 incident row + the clean-case row."""
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.audit = BillingAudit(client=None, skip_cell_history=True)
 
-    def test_incident_row_is_flagged(self):
+    def test_incident_row_is_flagged(self) -> None:
         """qty 3 / $341.04 -> exactly one mismatch, expected 170.52, delta 170.52."""
         row = {
             'Work Request #': '91916464',
@@ -69,7 +70,7 @@ class TestRateSanityIncidentRegression(RateSanityTestBase):
         self.assertEqual(record['type'], 'rate_sanity_mismatch')
         self.assertEqual(record['work_request'], '91916464')
 
-    def test_clean_row_is_not_flagged(self):
+    def test_clean_row_is_not_flagged(self) -> None:
         """qty 1 / $56.84 (correct price) -> zero mismatches."""
         row = {
             'Work Request #': '91916464',
@@ -85,7 +86,7 @@ class TestRateSanityIncidentRegression(RateSanityTestBase):
 class TestRateSanityEndToEndWiring(RateSanityTestBase):
     """Task 1 Test 3: audit_financial_data() surfaces the record."""
 
-    def test_audit_financial_data_surfaces_mismatch(self):
+    def test_audit_financial_data_surfaces_mismatch(self) -> None:
         row = {
             'Work Request #': '91916464',
             'CU': 'SAA-DE-20',
@@ -114,11 +115,11 @@ class TestRateSanityEndToEndWiring(RateSanityTestBase):
 class TestRateSanitySkipsAndTolerance(RateSanityTestBase):
     """Task 2: skip classes, tolerance edges, counters, kill-switch."""
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.audit = BillingAudit(client=None, skip_cell_history=True)
 
-    def _base_row(self, **overrides):
+    def _base_row(self, **overrides: Any) -> Dict[str, Any]:
         row = {
             'Work Request #': '91916464',
             'CU': 'SAA-DE-20',
@@ -129,91 +130,91 @@ class TestRateSanitySkipsAndTolerance(RateSanityTestBase):
         row.update(overrides)
         return row
 
-    def test_missing_cu_is_skipped(self):
+    def test_missing_cu_is_skipped(self) -> None:
         row = self._base_row(CU='NOT-IN-TABLE')
         mismatches = self.audit._detect_rate_sanity_mismatches([row])
         self.assertEqual(mismatches, [])
         self.assertEqual(self.audit._rate_sanity_skipped, 1)
 
-    def test_zero_quantity_is_skipped(self):
+    def test_zero_quantity_is_skipped(self) -> None:
         row = self._base_row(Quantity='0')
         mismatches = self.audit._detect_rate_sanity_mismatches([row])
         self.assertEqual(mismatches, [])
         self.assertEqual(self.audit._rate_sanity_skipped, 1)
 
-    def test_missing_quantity_is_skipped(self):
+    def test_missing_quantity_is_skipped(self) -> None:
         row = self._base_row(Quantity='')
         mismatches = self.audit._detect_rate_sanity_mismatches([row])
         self.assertEqual(mismatches, [])
         self.assertEqual(self.audit._rate_sanity_skipped, 1)
 
-    def test_none_quantity_is_skipped(self):
+    def test_none_quantity_is_skipped(self) -> None:
         row = self._base_row(Quantity=None)
         mismatches = self.audit._detect_rate_sanity_mismatches([row])
         self.assertEqual(mismatches, [])
         self.assertEqual(self.audit._rate_sanity_skipped, 1)
 
-    def test_unparseable_quantity_is_skipped(self):
+    def test_unparseable_quantity_is_skipped(self) -> None:
         row = self._base_row(Quantity='abc')
         mismatches = self.audit._detect_rate_sanity_mismatches([row])
         self.assertEqual(mismatches, [])
         self.assertEqual(self.audit._rate_sanity_skipped, 1)
 
-    def test_unparseable_price_is_skipped(self):
+    def test_unparseable_price_is_skipped(self) -> None:
         row = self._base_row(**{'Units Total Price': 'not-a-number'})
         mismatches = self.audit._detect_rate_sanity_mismatches([row])
         self.assertEqual(mismatches, [])
         self.assertEqual(self.audit._rate_sanity_skipped, 1)
 
-    def test_empty_price_is_skipped(self):
+    def test_empty_price_is_skipped(self) -> None:
         row = self._base_row(**{'Units Total Price': ''})
         mismatches = self.audit._detect_rate_sanity_mismatches([row])
         self.assertEqual(mismatches, [])
         self.assertEqual(self.audit._rate_sanity_skipped, 1)
 
-    def test_none_price_is_skipped(self):
+    def test_none_price_is_skipped(self) -> None:
         row = self._base_row(**{'Units Total Price': None})
         mismatches = self.audit._detect_rate_sanity_mismatches([row])
         self.assertEqual(mismatches, [])
         self.assertEqual(self.audit._rate_sanity_skipped, 1)
 
-    def test_unknown_work_type_is_skipped(self):
+    def test_unknown_work_type_is_skipped(self) -> None:
         row = self._base_row(**{'Work Type': 'Splice'})
         mismatches = self.audit._detect_rate_sanity_mismatches([row])
         self.assertEqual(mismatches, [])
         self.assertEqual(self.audit._rate_sanity_skipped, 1)
 
-    def test_empty_work_type_is_skipped(self):
+    def test_empty_work_type_is_skipped(self) -> None:
         row = self._base_row(**{'Work Type': ''})
         mismatches = self.audit._detect_rate_sanity_mismatches([row])
         self.assertEqual(mismatches, [])
         self.assertEqual(self.audit._rate_sanity_skipped, 1)
 
-    def test_small_delta_within_tolerance_not_flagged(self):
+    def test_small_delta_within_tolerance_not_flagged(self) -> None:
         """expected 170.52 vs actual 170.53 -> within the $0.02 floor."""
         row = self._base_row(**{'Units Total Price': '$170.53'})
         mismatches = self.audit._detect_rate_sanity_mismatches([row])
         self.assertEqual(mismatches, [])
 
-    def test_mid_delta_within_pct_tolerance_not_flagged(self):
+    def test_mid_delta_within_pct_tolerance_not_flagged(self) -> None:
         """expected 170.52 vs actual 171.00 -> within 0.5% ($0.8526)."""
         row = self._base_row(**{'Units Total Price': '$171.00'})
         mismatches = self.audit._detect_rate_sanity_mismatches([row])
         self.assertEqual(mismatches, [])
 
-    def test_large_delta_exceeds_tolerance_flagged(self):
+    def test_large_delta_exceeds_tolerance_flagged(self) -> None:
         """expected 170.52 vs actual 172.00 -> exceeds both floors."""
         row = self._base_row(**{'Units Total Price': '$172.00'})
         mismatches = self.audit._detect_rate_sanity_mismatches([row])
         self.assertEqual(len(mismatches), 1)
 
-    def test_decorated_quantity_parses_and_flags(self):
+    def test_decorated_quantity_parses_and_flags(self) -> None:
         row = self._base_row(Quantity='3 EA')
         mismatches = self.audit._detect_rate_sanity_mismatches([row])
         self.assertEqual(len(mismatches), 1)
         self.assertAlmostEqual(mismatches[0]['expected_price'], 170.52)
 
-    def test_kill_switch_disables_detector(self):
+    def test_kill_switch_disables_detector(self) -> None:
         row = self._base_row()
         with mock.patch.dict(
             os.environ, {'RATE_SANITY_AUDIT_ENABLED': 'false'}
@@ -225,7 +226,7 @@ class TestRateSanitySkipsAndTolerance(RateSanityTestBase):
 class TestRateSanitySummary(RateSanityTestBase):
     """Task 2: summary counters and risk-level escalation."""
 
-    def test_summary_counts_and_escalates_risk(self):
+    def test_summary_counts_and_escalates_risk(self) -> None:
         row = {
             'Work Request #': '91916464',
             'CU': 'SAA-DE-20',
@@ -248,7 +249,7 @@ class TestRateSanitySummary(RateSanityTestBase):
         self.assertEqual(summary['total_rate_sanity_mismatches'], 1)
         self.assertNotEqual(summary['risk_level'], 'LOW')
 
-    def test_kill_switch_zeroes_summary_counter(self):
+    def test_kill_switch_zeroes_summary_counter(self) -> None:
         row = {
             'Work Request #': '91916464',
             'CU': 'SAA-DE-20',

--- a/tests/test_rate_sanity_audit.py
+++ b/tests/test_rate_sanity_audit.py
@@ -10,6 +10,7 @@ this; this REPORT-ONLY detector flags it via the New Rates table
 (``data/subcontractor_rates.csv``) keyed by CU + Work Type.
 """
 
+import json
 import os
 import tempfile
 import unittest
@@ -273,6 +274,87 @@ class TestRateSanitySummary(RateSanityTestBase):
         self.assertEqual(
             results['summary']['total_rate_sanity_mismatches'], 0
         )
+
+
+class TestRateSanityAggregateInclusion(RateSanityTestBase):
+    """CR-01 regression lock: rate-sanity mismatches must be counted in
+    EVERY total_issues aggregate (persisted history entry, audit-sheet
+    payload, and trend delta) -- not only in the risk-level sum inside
+    ``_generate_audit_summary()``. A mismatch-only run (zero anomalies,
+    zero unauthorized changes, zero data issues) previously recorded
+    ``total_issues == 0`` in ``risk_trend.json`` and produced a zero
+    trend delta, hiding the run from history/trend consumers even
+    though the top-level summary and risk level correctly escalated.
+    """
+
+    def test_mismatch_only_run_records_nonzero_history_total_issues(
+        self,
+    ) -> None:
+        row = {
+            'Work Request #': '91916464',
+            'CU': 'SAA-DE-20',
+            'Work Type': 'Inst',
+            'Quantity': '3',
+            'Units Total Price': '$341.04',
+        }
+        with tempfile.TemporaryDirectory() as tmp_dir, \
+                mock.patch.object(BillingAudit, '_save_audit_state'), \
+                mock.patch.object(BillingAudit, '_log_to_audit_sheet'):
+            original_cwd = os.getcwd()
+            os.chdir(tmp_dir)
+            try:
+                # Mirrors the real pipeline, where generated_docs/
+                # already exists before an audit runs.
+                os.makedirs('generated_docs', exist_ok=True)
+                audit = BillingAudit(client=None, skip_cell_history=True)
+                results = audit.audit_financial_data([], [row])
+                hist_path = os.path.join(
+                    'generated_docs', 'risk_trend.json'
+                )
+                with open(hist_path) as hist_file:
+                    history = json.load(hist_file)
+            finally:
+                os.chdir(original_cwd)
+
+        summary = results['summary']
+        self.assertEqual(summary['total_anomalies'], 0)
+        self.assertEqual(summary['total_unauthorized_changes'], 0)
+        self.assertEqual(summary['total_data_issues'], 0)
+        self.assertEqual(summary['total_rate_sanity_mismatches'], 1)
+        self.assertEqual(len(history), 1)
+        self.assertEqual(history[0]['total_issues'], 1)
+
+    def test_mismatch_only_run_produces_correct_trend_issue_delta(
+        self,
+    ) -> None:
+        clean_row = {
+            'Work Request #': '91916464',
+            'CU': 'SAA-DE-20',
+            'Work Type': 'Inst',
+            'Quantity': '1',
+            'Units Total Price': '$56.84',
+        }
+        mismatch_row = {
+            'Work Request #': '91916464',
+            'CU': 'SAA-DE-20',
+            'Work Type': 'Inst',
+            'Quantity': '3',
+            'Units Total Price': '$341.04',
+        }
+        with tempfile.TemporaryDirectory() as tmp_dir, \
+                mock.patch.object(BillingAudit, '_log_to_audit_sheet'):
+            original_cwd = os.getcwd()
+            os.chdir(tmp_dir)
+            try:
+                audit = BillingAudit(client=None, skip_cell_history=True)
+                audit.audit_financial_data([], [clean_row])
+                results = audit.audit_financial_data([], [mismatch_row])
+            finally:
+                os.chdir(original_cwd)
+
+        trend = results['trend']
+        self.assertEqual(trend['issues_delta'], 1)
+        self.assertEqual(trend['risk_direction'], 'worsening')
 
 
 if __name__ == '__main__':

--- a/website/blog/2026-08-12-rate-sanity-audit-check.md
+++ b/website/blog/2026-08-12-rate-sanity-audit-check.md
@@ -1,0 +1,68 @@
+---
+slug: rate-sanity-audit-check
+title: "feat: report-only rate-sanity audit flags stale-formula overbills (#329)"
+authors: [runbook-bot]
+tags: [project, python, tests, workflows]
+date: 2026-08-12T15:30:00+00:00
+---
+
+**Component:** Python billing pipeline (`audit_billing_changes.py`) — the audit
+system that runs alongside `generate_weekly_pdfs.py` on every scheduled billing run.
+
+<!-- truncate -->
+
+## What changed
+
+The billing audit gains a new **report-only rate-sanity check**. On every audit
+pass, each row's Smartsheet `Units Total Price` is compared against an expected
+price computed as `New Rates rate × Quantity` (rates come from
+`data/subcontractor_rates.csv`, keyed by CU + Work Type — the same table the
+pricing engine already loads). A row is flagged when the two diverge by more
+than the larger of a flat $0.02 rounding allowance or 0.5% of the expected
+price.
+
+This check is diagnostic only: it never mutates row price, quantity, grouping,
+filenames, hashes, or upload behavior. It only adds entries to the audit
+summary and, when applicable, raises the audit's `risk_level`.
+
+The same PR also fixes an inconsistency in how the audit counts issues:
+`total_issues` is computed in three separate places (the persisted local
+history in `generated_docs/risk_trend.json`, the audit-sheet payload, and the
+run-over-run trend delta), and only one of the three originally included the
+new rate-sanity mismatch count. A mismatch-only run — no price anomalies, no
+unauthorized changes, no data-consistency issues — could raise `risk_level`
+correctly while still recording `total_issues: 0` in history and a zero trend
+delta. All three aggregates now use the same definition.
+
+## Why it changed
+
+On 2026-08-12, WR 91916464 / Point 27 (CU `SAA-DE-20`) billed 3 EA at $341.04
+($113.68/EA) instead of the correct 3 × $56.84 = $170.52. Root cause: the
+source Smartsheet row's `Quantity` was corrected 6 → 3 by the foreman, but the
+sheet's `Install Quantity` formula cell never recalculated and stayed at 6, so
+the stale `56.84 × 6 = 341.04` flowed straight into `Units Total Price`. The
+Python pricing engine was behaving correctly per contract — the primary/`_User_`
+variant is a deliberate pass-through of Smartsheet's `Units Total Price` — so
+there was no rate table for that path to compare against, and the stale
+upstream cell was invisible to the pipeline. The only reason the overbill
+surfaced at all was a foreman email. This audit check closes that detection
+gap without touching the pricing path itself.
+
+## What operators need to know
+
+- **A rate-sanity mismatch shows up as a normal audit finding.** It raises
+  `total_issues` (now consistently, across history/trend/audit-sheet) and can
+  push `risk_level` from LOW to MEDIUM or HIGH, the same way a price anomaly or
+  data-integrity issue does today.
+- **When a mismatch is flagged**, compare the row's Smartsheet `Quantity`
+  against its `Install/Removal/Transfer Quantity` formula cell on the source
+  sheet. A mismatch between the two is the signature of this defect class —
+  fix it by re-saving the row upstream (forces the formula to recalculate),
+  never in the Python pricing path.
+- **Emergency disable, no deploy needed:** set the environment variable
+  `RATE_SANITY_AUDIT_ENABLED=false` to turn the check off. This restores the
+  pre-change audit summary shape exactly (empty `rate_sanity_mismatches`,
+  `total_rate_sanity_mismatches` 0) if the check ever produces noisy or
+  incorrect findings in production.
+- **Owner:** Python billing pipeline (`audit_billing_changes.py`). This check
+  does not touch Supabase, `portal/`, or `portal-v2/`.


### PR DESCRIPTION
## Objective
Automatically catch stale-Smartsheet-formula pricing rows in the billing audit. On 2026-08-12 a field email reported WR 91916464 / Point 27 / SAA-DE-20 billed 3 EA @ \$341.04 instead of 3 × \$56.84 = \$170.52 — the ProMax sheet's Install Quantity formula cell had frozen at a stale quantity (6) after the foreman corrected the claim to 3, and the pipeline (correctly, per its pass-through contract) rendered the stale price. This PR adds a report-only rate-sanity detector to the audit layer so this failure class surfaces on every run instead of waiting for a foreman's email. Root-cause evidence: memory-bank/living-ledger.md entry [2026-08-12 13:40].

## Changes Made
- **audit_billing_changes.py** — new report-only detector `_detect_rate_sanity_mismatches` + helpers (`_rate_sanity_expected_price`, `_rate_sanity_is_mismatch`, `_rate_sanity_looks_like_zero`): compares each row's parsed `Units Total Price` against expected New-Rates rate × Quantity from the existing `_SUBCONTRACTOR_RATES` table (function-local lazy imports to preserve import order); tolerance guard `max($0.02, 0.5%)`; unknown-CU / zero-qty / unparseable-price rows are skipped and counted, never flagged; kill-switch `RATE_SANITY_AUDIT_ENABLED` (default `true`); mismatches fold into `total_issues` so `risk_level` gains visibility.
- **tests/test_rate_sanity_audit.py** — 20 new tests written RED-first, including the exact SAA-DE-20 regression (qty 3, \$341.04, expected \$170.52 → flagged) and clean/tolerance/skip/kill-switch cases.
- **memory-bank/living-ledger.md** — incident root causes (stale formula cell + Snapshot Date automation re-stamp defect) and the new hard rule: the check is diagnostic only.
- **.planning/** + **.claude/project-state.md** — GSD quick-task 260812-isx PLAN/SUMMARY, STATE.md row, session state ledger.

## Production Safety Check
Existing production logic is unbroken. Diff guard verified: zero hunks in `generate_weekly_pdfs.py` or `pipeline/` — the Smartsheet → filter → group → Excel → upload path is untouched, and the detector never mutates price, quantity, grouping keys, filenames, hashes, or upload behavior (it only appends diagnostic records). Full suite: 1228 passed + 130 subtests, 0 regressions; `python -m py_compile audit_billing_changes.py` clean. Independent verifier passed all 8 rubric items (report-only, kill-switch default-on, lazy imports, shortest-prefix work-type matching per the 2026-05-16 ledger rule, tolerance/skip semantics, regression coverage, style). The only behavior change is additive audit output, reversible without a deploy via `RATE_SANITY_AUDIT_ENABLED=false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds a report-only billing-audit check that compares each row’s total price with its configured rate multiplied by quantity, including skip accounting, tolerance handling, risk aggregation, tests, and operator documentation.
- Adds rate-sanity mismatch detection and a default-on environment kill-switch.
- Includes mismatch counts in persisted history, audit-sheet totals, and trend calculations.
- Adds regression coverage for the reported stale-formula incident and detector edge cases.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| audit_billing_changes.py | Adds the report-only detector and consistently propagates mismatch counts through audit summaries, history, sheet output, and trends. |
| tests/test_rate_sanity_audit.py | Covers incident detection, clean rows, skip classes, tolerance boundaries, the kill-switch, and aggregate inclusion; prior annotation feedback is fully addressed. |
| website/blog/2026-08-12-rate-sanity-audit-check.md | Documents the new audit behavior and investigation procedure. |

</details>

<sub>Reviews (2): Last reviewed commit: ["docs: update state ledger — Greptile fix..."](https://github.com/jflo21/generate-weekly-pdfs-dsr-resiliency/commit/3f7be8276683642f0f7314c549c9af239bb915b9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52696347)</sub>

**Context used:**

- Context used - .claude/rules/documentation-maintenance.md ([source](https://github.com/jflo21/generate-weekly-pdfs-dsr-resiliency/blob/master/.claude/rules/documentation-maintenance.md))

<!-- /greptile_comment -->