### PR TITLE
feat: snapshot-date drift audit — detect automation re-stamps, optional hold gate

### DIFF
--- a/.claude/project-state.md
+++ b/.claude/project-state.md
@@ -50,8 +50,12 @@ write-back reminder). Keep it terse; link to history rather than duplicating it.
      15; WR-04 test pacing zeroed). Suite **1262 + 132 subtests**
      (~13s). Deferred to PR follow-ups: WR-02 (bulk .in_ → RPC),
      WR-03 (RLS on new tables — Juan's DDL call), WR-05 (direct
-     snapshot_store tests), info nits. Next: closeout docs commit,
-     push + PR stacked on #329 (base = isx branch).
+     snapshot_store tests), info nits. **SHIPPED: PR #330 → master**
+     (#329 was squash-merged as `647a688` at 20:33Z, isx branch
+     deleted; jqx rebased onto origin/master — new SHAs
+     b115e63..d3333e4 + this ledger commit — suite re-run green
+     post-rebase, force-pushed with lease). Local master is stale;
+     `git switch master && git pull` when convenient.
    - **A1/A4 VERIFIED LIVE (WINDOWS #1 closed):** read-only probes
      with Juan's token proved newest-first history + automation
      identity, captured the full Point 27 drift-and-revert chain, and

--- a/.claude/project-state.md
+++ b/.claude/project-state.md
@@ -23,40 +23,52 @@ write-back reminder). Keep it terse; link to history rather than duplicating it.
    "Snapshot Date is blank" write-once condition; fix the template
    sheet so backup copies inherit it. Recommendation delivered to Juan;
    NOT yet applied (his action).
-3. **SESSION HANDOFF (2026-08-12 ~15:20 CDT) — resume points:**
-   - **PR #329 Greptile fixes DONE + PUSHED:** gsd-code-fixer landed
-     3 atomic commits on `feat/260812-isx-rate-sanity-audit` —
-     `64d7249` (fold total_rate_sanity_mismatches into history/
-     audit-sheet/trend total_issues aggregates + 2 regression tests),
-     `e003124` (website/blog/2026-08-12-rate-sanity-audit-check.md
-     runbook changelog incl. RATE_SANITY_AUDIT_ENABLED=false emergency
-     disable), `8802e98` (test return-type annotations). Suite 1230
-     passed + 130 subtests. Pushed 8802e98 → PR #329 updated. Known
-     latent quirk (out of scope, untouched): risk_trend.json write
-     silently no-ops on a truly fresh generated_docs/ dir because
-     makedirs happens later in _save_audit_state().
-   - **Quick task 260812-jqx APPROVED-TO-EXECUTE, not started:**
-     snapshot-drift audit. Plan/context/research complete + plan-check
-     PASSED (0 blockers, 1 warning: add post-seam Sentry capture for
-     holds). Planning docs are UNTRACKED in
-     `.planning/quick/260812-jqx-snapshot-date-drift-audit-detect-snapsho/`
-     (CONTEXT/RESEARCH/PLAN — commit them). Execution recipe: after
-     PR #329 fixes land, `git switch -c feat/260812-jqx-snapshot-drift-audit`
-     from the isx tip (plan line numbers assume isx code present),
-     spawn gsd-core:gsd-executor (sonnet) on 260812-jqx-PLAN.md, then
-     gsd-verifier + code review + haiku-verifier, docs commit, PR
-     stacked on #329. Locked decisions: hold-prior-week+HIGH for
-     automation self-fires ONLY (SNAPSHOT_DRIFT_HOLD_ENABLED default
-     OFF), never hold manual edits, fail-open gating/fail-closed
-     logging, 40-row capped ~2s-paced cell-history lookups
-     (week-movers only), NEW additive Supabase tables appended to
-     billing_audit/schema.sql (Juan manual-applies DDL), NO new
-     mutating AUDIT_SHEET_ID write in v1.
+3. **SESSION HANDOFF (2026-08-12 ~16:35 CDT) — resume points:**
+   - **PR #329 Greptile fixes DONE + PUSHED** (`64d7249`/`e003124`/
+     `8802e98`, suite 1230+130). Latent quirk untouched:
+     risk_trend.json write no-ops on fresh generated_docs/.
+   - **Quick task 260812-jqx EXECUTED (reviews in flight):** branch
+     `feat/260812-jqx-snapshot-drift-audit` stacked on isx tip
+     `3f7be82`. Commits: `8db2845` (planning docs), `55329a1` (drift
+     detection, zero extra API calls: pipeline/snapshot_drift.py +
+     billing_audit/snapshot_store.py + additive schema.sql + config +
+     orchestrate seam), `c58a9bd` (cell-history classifier, 40-row cap
+     ~2s pacing sub-budget), `0a68aeb` (hold-prior-week override +
+     audit risk wiring + post-seam Sentry capture on holds), `0b5051a`
+     (SUMMARY docs). Full suite **1257 passed + 132 subtests** (27 new
+     tests), zero regressions; grouping/excel zero hunks; orchestrate
+     2 hunks. Deviations: test-only budget-boundary flake fix;
+     plan-check Sentry warning honored. Locked decisions held: hold
+     gate default OFF, never hold manual edits, fail-open gating/
+     fail-closed logging, no AUDIT_SHEET_ID mutation, DDL manual-apply.
+     **Reviews DONE:** gsd-verifier 8/8 zero gaps; haiku rubric 10/10
+     PASS; code review 2 Critical / 5 Warning / 7 Info → fix round
+     `a56190c` (CR-01 upsert gated on fetch status — no baseline
+     rebase on failed read), `81da106` (CR-02 null-prior-date holds
+     skipped), `7a58c62` (WR-01 unparseable ts → unclassified;
+     window env-tunable SNAPSHOT_DRIFT_UNITS_WINDOW_MINUTES default
+     15; WR-04 test pacing zeroed). Suite **1262 + 132 subtests**
+     (~13s). Deferred to PR follow-ups: WR-02 (bulk .in_ → RPC),
+     WR-03 (RLS on new tables — Juan's DDL call), WR-05 (direct
+     snapshot_store tests), info nits. Next: closeout docs commit,
+     push + PR stacked on #329 (base = isx branch).
+   - **A1/A4 VERIFIED LIVE (WINDOWS #1 closed):** read-only probes
+     with Juan's token proved newest-first history + automation
+     identity, captured the full Point 27 drift-and-revert chain, and
+     CORRECTED the signature: automation batches stamps (legit writes
+     up to 4m22s after the check → 15-min window), and Weekly
+     Reference Logged Date is automation-WRITTEN (repair must revert
+     it too). Ledger `[2026-08-12 17:05]`. Backup 86 scanned clean
+     (no stamps ≥ 08-08). Note: Juan's `.env` names the token
+     `SMARTSHEET_API_KEY`; the pipeline reads `SMARTSHEET_API_TOKEN`.
    - **Juan's own actions pending:** Smartsheet automation trigger fix
      in UI per living-ledger [2026-08-12 13:40] (field-scoped trigger
-     + "Snapshot Date is blank" condition, per sheet + template);
-     review/merge PR #329; later: apply jqx DDL, enable hold gate
-     after burn-in.
+     + "Snapshot Date is blank" condition, per sheet + template) —
+     REQUIRED before any snapshot-date repair sweep (writes would be
+     re-stamped); run the remediation prompt with a Smartsheet-capable
+     AI; review/merge PR #329; later: apply jqx DDL (2 blocks in
+     billing_audit/schema.sql), verify A1/A4, enable hold gate after
+     burn-in.
 4. **Quick task 260812-isx (GSD quick) COMPLETE → PR #329 OPEN:**
    report-only rate-sanity audit check (Units Total Price vs expected
    New-Rates rate × Quantity via `_SUBCONTRACTOR_RATES`, kill-switch

--- a/.claude/project-state.md
+++ b/.claude/project-state.md
@@ -56,6 +56,17 @@ write-back reminder). Keep it terse; link to history rather than duplicating it.
      b115e63..d3333e4 + this ledger commit — suite re-run green
      post-rebase, force-pushed with lease). Local master is stale;
      `git switch master && git pull` when convenient.
+     **Greptile round (post-open): `4104ca1`** — unclassified drifts
+     no longer rebase the provenance baseline (classification-aware
+     finalization; unclassified rows retry next run). Suite 1263+132.
+     **Live dry run (SKIP_UPLOAD, 53min):** drift audit no-op path
+     verified on 199,815 real rows (CR-01 skip observed live);
+     FINDING: #329 rate-sanity flags 115,272/199,717 rows (58% — old
+     historical rates vs New-Rates basis) → risk_level HIGH every CI
+     run; no Smartsheet writes exist (AUDIT_SHEET_ID never written);
+     Juan to choose kill-switch vs scoping follow-up. Also:
+     WR_FILTER only works with TEST_MODE (grouping.py:1222) — the
+     run-billing-pipeline-locally skill table is wrong on this.
    - **A1/A4 VERIFIED LIVE (WINDOWS #1 closed):** read-only probes
      with Juan's token proved newest-first history + automation
      identity, captured the full Point 27 drift-and-revert chain, and

--- a/.planning/WINDOWS.md
+++ b/.planning/WINDOWS.md
@@ -1,0 +1,35 @@
+---
+schema_version: 1
+open_count: 1
+waived_count: 0
+fixed_count: 0
+total_count: 1
+last_updated: 2026-08-12T21:28:42.447Z
+---
+
+# Broken Windows Ledger
+
+> Cross-phase defect register. With `workflow.windows_enforce` enabled, `/gsd-ship` blocks while `open_count > 0`.
+> Waive with `gsd-tools windows waive <id> "<reason>"` (reason required).
+> Mark fixed with `gsd-tools windows fixed <id>`.
+
+| id | phase | kind | file | line | description | status | reason | recorded_at | resolved_at |
+|----|-------|------|------|------|-------------|--------|--------|-------------|-------------|
+| 1 | quick-260812-jqx | unrun-verify | pipeline/snapshot_drift.py |  | Task 3 human-check (live operator verification of A1/A4 assumptions against a known-drifted Smartsheet row) not run — no SMARTSHEET_API_TOKEN available in this sandbox. Must be run by Juan before setting SNAPSHOT_DRIFT_HOLD_ENABLED=true in the workflow. | open |  | 2026-08-12T21:28:42.447Z |  |
+
+````json
+[
+  {
+    "id": 1,
+    "kind": "unrun-verify",
+    "phase": "quick-260812-jqx",
+    "file": "pipeline/snapshot_drift.py",
+    "line": null,
+    "description": "Task 3 human-check (live operator verification of A1/A4 assumptions against a known-drifted Smartsheet row) not run — no SMARTSHEET_API_TOKEN available in this sandbox. Must be run by Juan before setting SNAPSHOT_DRIFT_HOLD_ENABLED=true in the workflow.",
+    "status": "open",
+    "reason": "",
+    "recorded_at": "2026-08-12T21:28:42.447Z",
+    "resolved_at": null
+  }
+]
+````

--- a/.planning/WINDOWS.md
+++ b/.planning/WINDOWS.md
@@ -1,10 +1,10 @@
 ---
 schema_version: 1
-open_count: 1
+open_count: 0
 waived_count: 0
-fixed_count: 0
+fixed_count: 1
 total_count: 1
-last_updated: 2026-08-12T21:28:42.447Z
+last_updated: 2026-08-12T21:43:06.317Z
 ---
 
 # Broken Windows Ledger
@@ -15,7 +15,7 @@ last_updated: 2026-08-12T21:28:42.447Z
 
 | id | phase | kind | file | line | description | status | reason | recorded_at | resolved_at |
 |----|-------|------|------|------|-------------|--------|--------|-------------|-------------|
-| 1 | quick-260812-jqx | unrun-verify | pipeline/snapshot_drift.py |  | Task 3 human-check (live operator verification of A1/A4 assumptions against a known-drifted Smartsheet row) not run — no SMARTSHEET_API_TOKEN available in this sandbox. Must be run by Juan before setting SNAPSHOT_DRIFT_HOLD_ENABLED=true in the workflow. | open |  | 2026-08-12T21:28:42.447Z |  |
+| 1 | quick-260812-jqx | unrun-verify | pipeline/snapshot_drift.py |  | Task 3 human-check (live operator verification of A1/A4 assumptions against a known-drifted Smartsheet row) not run — no SMARTSHEET_API_TOKEN available in this sandbox. Must be run by Juan before setting SNAPSHOT_DRIFT_HOLD_ENABLED=true in the workflow. | fixed |  | 2026-08-12T21:28:42.447Z | 2026-08-12T21:43:06.317Z |
 
 ````json
 [
@@ -26,10 +26,10 @@ last_updated: 2026-08-12T21:28:42.447Z
     "file": "pipeline/snapshot_drift.py",
     "line": null,
     "description": "Task 3 human-check (live operator verification of A1/A4 assumptions against a known-drifted Smartsheet row) not run — no SMARTSHEET_API_TOKEN available in this sandbox. Must be run by Juan before setting SNAPSHOT_DRIFT_HOLD_ENABLED=true in the workflow.",
-    "status": "open",
+    "status": "fixed",
     "reason": "",
     "recorded_at": "2026-08-12T21:28:42.447Z",
-    "resolved_at": null
+    "resolved_at": "2026-08-12T21:43:06.317Z"
   }
 ]
 ````

--- a/.planning/quick/260812-jqx-snapshot-date-drift-audit-detect-snapsho/260812-jqx-CONTEXT.md
+++ b/.planning/quick/260812-jqx-snapshot-date-drift-audit-detect-snapsho/260812-jqx-CONTEXT.md
@@ -1,0 +1,103 @@
+# Quick Task 260812-jqx: Snapshot-date drift audit - Context
+
+**Gathered:** 2026-08-12
+**Status:** Ready for planning
+
+<domain>
+## Task Boundary
+
+Snapshot-date drift audit: detect Snapshot Date changes on rows whose
+week was already billed, classify automation self-fire vs legitimate
+manual edit via targeted cell-history lookups, flag all drift on the
+billing audit sheet plus a Supabase shadow layer, and gate
+regeneration only for automation self-fires (never block manual
+edits).
+
+Background (proven 2026-08-12, living-ledger `[2026-08-12 13:40]`):
+the per-sheet "record Snapshot Date" Smartsheet automation uses a
+row-change trigger with "Units Completed? is checked" as a condition,
+so ANY edit to a completed row (same-value saves, bulk API/DataTable
+touches) re-stamps Snapshot Date to today. Because Weekly Reference
+Logged Date = Snapshot Date snapped to Sunday, each re-stamp moves
+the unit into the current billing week -> already-billed units drift
+weeks -> audit chaos. The UI-side automation fix is being applied by
+Juan, but the pipeline needs defense-in-depth.
+
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### Gate action (automation self-fire on an already-billed row)
+- **Hold prior week + flag HIGH.** The pipeline keeps billing the
+  row under its previously-billed week (ignores the drifted date for
+  grouping), flags HIGH on the billing audit sheet + Supabase, and
+  reports which row to repair upstream. Files stay correct; nothing
+  silently moves weeks.
+- Manual edits are NEVER blocked or held — they flow through
+  normally and are shadow-logged.
+- Unclassifiable drift (history unavailable, cap exhausted, API
+  error) must NOT hold the row — flag it as `unclassified` and let
+  it flow (fail-open on gating, fail-closed on logging).
+
+### Cell-history budget (30 req/min hard limit)
+- **Only week-movers, capped.** Spend history lookups ONLY on rows
+  whose computed billing week differs from the previously-billed
+  week for that row, with a per-run cap (~40 rows) and pacing
+  (~2s between calls; ~2 calls per row: Snapshot Date +
+  Units Completed?). Everything else costs zero extra API calls.
+- Classifier signature: a Snapshot Date write by
+  automation@smartsheet.com with NO Units Completed? change within
+  +/-2 minutes = automation self-fire. Otherwise manual/legitimate.
+
+### Provenance / Supabase shadow layer
+- **New additive Supabase table** (e.g. `snapshot_drift` /
+  provenance: sheet_id, row_id, WR, CU, prior snapshot date, new
+  snapshot date, prior billed week, new week, changed_by,
+  classification, run_id, detected_at). Written additively by the
+  pipeline; the existing `billing_audit` tables stay untouched.
+- Approved as a Supabase schema ADDITION only — no RLS/policy/
+  schema changes to existing tables. Migration must be reviewed by
+  Juan before apply (protected area).
+
+### Claude's Discretion
+- Exact table/column naming and index choices.
+- Flag format on the billing audit sheet (reuse the existing
+  `_log_to_audit_sheet` shape from audit_billing_changes.py).
+- Env-var kill-switches and defaults (mirror RATE_SANITY pattern:
+  default enabled for detection/logging; the HOLD gate gets its OWN
+  kill-switch so gating can be disabled independently of detection).
+- Whether v1 per-row provenance is seeded from the first run that
+  sees a row (no history backfill required).
+
+</decisions>
+
+<specifics>
+## Specific Ideas
+
+- Reuse the 260812-isx patterns: function-local lazy imports,
+  report-only hard rules, RED-first tests, shortest-prefix work-type
+  tokens, `_parse_quantity`/`parse_price` helpers.
+- Time-budget awareness: drift classification must respect
+  TIME_BUDGET_MINUTES and degrade to `unclassified` (flag, no hold)
+  when the budget is tight — never stall the session.
+- The hold decision must be deterministic and visible: every held
+  row logs WR / row id / prior week / drifted week / evidence
+  timestamps to the run log, audit sheet, and Supabase.
+
+</specifics>
+
+<canonical_refs>
+## Canonical References
+
+- `memory-bank/living-ledger.md` `[2026-08-12 13:40]` — incident
+  root causes + drift signature (automation@smartsheet.com write
+  with no Units Completed? change within +/-2 min).
+- `memory-bank/living-ledger.md` — `billing_audit` Supabase
+  integration + Supabase hash-store migration entries (research
+  phase must read these before proposing the new table).
+- `.github/prompts/data-processing-business-logic.md` — domain
+  rules (snapshot date vs weekly reference log date is a protected
+  concept).
+
+</canonical_refs>

--- a/.planning/quick/260812-jqx-snapshot-date-drift-audit-detect-snapsho/260812-jqx-PLAN.md
+++ b/.planning/quick/260812-jqx-snapshot-date-drift-audit-detect-snapsho/260812-jqx-PLAN.md
@@ -1,0 +1,517 @@
+---
+phase: quick-260812-jqx
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - pipeline/snapshot_drift.py
+  - billing_audit/snapshot_store.py
+  - billing_audit/schema.sql
+  - pipeline/config.py
+  - pipeline/orchestrate.py
+  - audit_billing_changes.py
+  - tests/test_snapshot_drift_audit.py
+  - memory-bank/living-ledger.md
+autonomous: true
+requirements: [QT-260812-jqx]
+
+user_setup:
+  - service: supabase
+    why: "New additive tables billing_audit.snapshot_provenance + billing_audit.snapshot_drift (D-06, D-07). The pipeline NEVER runs DDL — schema.sql is documentation-grade and applied by hand."
+    dashboard_config:
+      - task: "Apply the two appended CREATE TABLE IF NOT EXISTS blocks from billing_audit/schema.sql"
+        location: "Supabase Dashboard -> project poeyztlmsawfoqlanucc -> SQL Editor"
+      - task: "Confirm 'billing_audit' is listed under Exposed schemas, then reload the PostgREST cache"
+        location: "Supabase Dashboard -> Project Settings -> API -> Exposed schemas"
+      - task: "Verify assumptions A1/A4 against ONE known-drifted row: cell-history entry ordering and the literal modified_by email for automation writes. If the email is not 'automation@smartsheet.com', set SNAPSHOT_DRIFT_AUTOMATION_EMAIL rather than editing code."
+        location: "Smartsheet UI -> a row from the 2026-08-12 drift incident -> Snapshot Date cell history"
+  - service: github-actions
+    why: "Both kill-switches ship at safe defaults; no workflow change is required to land this. Flipping the hold gate on is a deliberate operator action AFTER A1/A4 are verified."
+    env_vars:
+      - name: SNAPSHOT_DRIFT_HOLD_ENABLED
+        source: "Leave UNSET (defaults false, D-08). Set to 'true' in .github/workflows/weekly-excel-generation.yml only after a live run shows correct automation_self_fire classification."
+
+estimate:
+  tokens: 78000
+  raw_tokens: 78000
+  tasks: 3
+  confidence: low
+
+must_haves:
+  truths:
+    - "A row whose computed billing week differs from its recorded prior billed week is detected as a drift candidate using ZERO extra Smartsheet API calls (D-04)."
+    - "First sight of a row seeds provenance silently: no drift flag, no cell-history call, no hold (D-09)."
+    - "An automation self-fire on an already-billed row is held to BOTH its prior Weekly Reference Logged Date AND its prior Snapshot Date, so the row still appears in the workbook day-tables and the prior week's content hash is unchanged (D-01, RESEARCH caveat 1)."
+    - "A manual edit is shadow-logged and NEVER held (D-02)."
+    - "Any classification failure — API error, missing column id, per-run cap exhausted, sub-budget short — yields classification 'unclassified': flagged, never held (D-03, D-10)."
+    - "With SNAPSHOT_DRIFT_AUDIT_ENABLED=false and SNAPSHOT_DRIFT_HOLD_ENABLED=false, pipeline behaviour is byte-identical to today (D-08)."
+    - "Only automation self-fire holds inflate the audit total_issues / risk_level; manual and unclassified drift are counted but do not escalate risk (D-01, RESEARCH caveat 5)."
+    - "A missing Supabase client, an unapplied migration, or a PostgREST fetch failure makes the whole feature a no-op — it can never break the billing run (D-07)."
+  artifacts:
+    - "pipeline/snapshot_drift.py — apply_snapshot_drift_holds() + the classifier, the only place drift logic lives"
+    - "billing_audit/snapshot_store.py — bulk provenance read, bulk provenance upsert, append-only drift-event insert"
+    - "billing_audit/schema.sql — appended billing_audit.snapshot_provenance + billing_audit.snapshot_drift DDL (manual apply)"
+    - "pipeline/config.py — SNAPSHOT_DRIFT_AUDIT_ENABLED / SNAPSHOT_DRIFT_HOLD_ENABLED / SNAPSHOT_DRIFT_MAX_ROWS / SNAPSHOT_DRIFT_PACE_SEC / SNAPSHOT_DRIFT_MAX_MINUTES / SNAPSHOT_DRIFT_AUTOMATION_EMAIL"
+    - "pipeline/orchestrate.py — ONE call site at the pre-grouping seam"
+    - "audit_billing_changes.py — drift counters + escalate_risk_for_snapshot_drift()"
+    - "tests/test_snapshot_drift_audit.py — RED-first suite covering the 9 research cases"
+    - "memory-bank/living-ledger.md — dated [YYYY-MM-DD HH:MM] entry"
+  key_links:
+    - "pipeline/orchestrate.py pre-grouping seam (after the audit else-branch at :577, before the grouping span at :580) -> apply_snapshot_drift_holds(all_rows, source_sheets, client, session_start). Upstream of the five Weekly Reference Logged Date pre-pass readers at grouping.py:170/234/289/360/417 and of the single week computation at grouping.py:440-463."
+    - "Held row rewrites BOTH fields -> grouping.py:440-463 (week key) AND excel.py:711-736 (Monday-Sunday snapshot filter) AND change_detection.py:115/143/169 (sort key + legacy hash + extended hash). Rewriting only the week silently deletes the row from every day-table."
+    - "row['__source_sheet_id'] + row['__row_id'] (fetch.py:315-331) -> source['column_mapping']['Snapshot Date'] / ['Units Completed?'] (discovery.py:438/448/489, surfaced at :615) -> smartsheet.Cells.get_cell_history(sheet_id, row_id, column_id, include_all=True)"
+    - "billing_audit.client.get_client() returning None (client.py:243-294) -> whole feature no-ops; every new store function inherits the never-raise contract"
+    - "drift_summary['automation_self_fire_holds'] -> audit_billing_changes.escalate_risk_for_snapshot_drift() -> summary['risk_level'] using the existing 0 / <=3 / else thresholds (audit_billing_changes.py:509-517)"
+---
+
+<objective>
+Add a defence-in-depth snapshot-date drift audit to the production billing
+pipeline: detect rows whose billing week moved away from the week they were
+last billed under, classify each mover as an automation self-fire or a
+legitimate manual edit via targeted Smartsheet cell-history lookups, record
+every drift event durably in a new additive Supabase shadow layer, and —
+for automation self-fires ONLY — hold the row at its previously-billed week
+so the workbook stays correct.
+
+Background (living-ledger `[2026-08-12 13:40]`): the per-sheet "record
+Snapshot Date" Smartsheet automation fires on ANY row change where
+`Units Completed?` is checked, so same-value saves and bulk API touches
+re-stamp Snapshot Date to today. `Weekly Reference Logged Date` is Snapshot
+Date snapped to Sunday, so each re-stamp silently moves an already-billed
+unit into the current billing week. Juan is fixing the automation trigger
+in the Smartsheet UI; this task is the pipeline-side backstop.
+
+**Locked decision IDs used throughout this plan** (from
+`260812-jqx-CONTEXT.md`, which uses prose sections rather than numbered IDs
+— this mapping is the traceability contract):
+
+| ID | Locked decision |
+|---|---|
+| D-01 | Hold prior week + flag HIGH — automation self-fires only |
+| D-02 | Manual edits are NEVER blocked or held; shadow-logged only |
+| D-03 | Unclassifiable drift must NOT hold: fail-open on gating, fail-closed on logging |
+| D-04 | Cell-history spend on week-movers ONLY, per-run cap ~40 rows, ~2s pacing, ~2 calls/row |
+| D-05 | Classifier signature: `automation@smartsheet.com` Snapshot Date write with NO `Units Completed?` change within +/-2 minutes |
+| D-06 | New additive Supabase table(s); existing `billing_audit` tables untouched |
+| D-07 | Supabase schema ADDITION only; reviewed + applied manually by Juan; pipeline never runs DDL |
+| D-08 | Separate kill-switches — detection/logging defaults ON, the HOLD gate defaults OFF |
+| D-09 | v1 provenance seeded from the first run that sees a row; no history backfill |
+| D-10 | Respect TIME_BUDGET_MINUTES; degrade to `unclassified` when the budget is tight, never stall |
+
+Purpose: already-billed units stop silently drifting weeks, and every drift
+becomes queryable evidence pointing at the exact row to repair upstream.
+Output: one new pipeline module, one new Supabase store module, appended
+documentation-grade DDL, six env-var switches, a single orchestrate call
+site, additive audit counters, and a RED-first pytest suite.
+</objective>
+
+<execution_context>
+@~/.claude/gsd-core/workflows/execute-plan.md
+@~/.claude/gsd-core/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/STATE.md
+@.planning/quick/260812-jqx-snapshot-date-drift-audit-detect-snapsho/260812-jqx-CONTEXT.md
+@.planning/quick/260812-jqx-snapshot-date-drift-audit-detect-snapsho/260812-jqx-RESEARCH.md
+@CLAUDE.md
+@.claude/rules/billing-pipeline-guardrails.md
+@.claude/rules/smartsheet-python-optimization.md
+</context>
+
+<source_coverage_audit>
+| Source | Item | Covered by |
+|---|---|---|
+| GOAL | Detect Snapshot Date changes on rows whose week was already billed | Task 1 |
+| GOAL | Classify automation self-fire vs legitimate manual edit via cell history | Task 2 |
+| GOAL | Flag ALL drift (run log + Supabase shadow + audit risk level) | Task 1 (log + Supabase), Task 3 (risk level) |
+| GOAL | Hold-prior-week gate ONLY for automation self-fires, never manual | Task 3 |
+| REQ | none — quick task, no ROADMAP requirement IDs | n/a |
+| CONTEXT | D-01 hold prior week + flag HIGH (self-fires only) | Task 3 |
+| CONTEXT | D-02 manual edits never blocked | Task 3 |
+| CONTEXT | D-03 unclassifiable → flag, no hold | Task 2 + Task 3 |
+| CONTEXT | D-04 week-movers only, capped, paced | Task 1 (candidate selection) + Task 2 (cap/pace) |
+| CONTEXT | D-05 classifier signature | Task 2 |
+| CONTEXT | D-06 new additive Supabase table | Task 1 |
+| CONTEXT | D-07 manual apply by Juan; pipeline never runs DDL | Task 1 + user_setup |
+| CONTEXT | D-08 separate kill-switches, hold defaults OFF | Task 1 (both declared) + Task 3 (hold honoured) |
+| CONTEXT | D-09 silent first-run seed | Task 1 |
+| CONTEXT | D-10 time-budget degradation | Task 2 |
+| RESEARCH | Caveat 1 — rewrite BOTH week AND snapshot fields | Task 3 |
+| RESEARCH | Caveat 2 — mandatory pacing / cap / sub-budget / pre-flight guard | Task 2 |
+| RESEARCH | Caveat 3 — SNAPSHOT_DRIFT_HOLD_ENABLED defaults OFF | Task 1 + Task 3 |
+| RESEARCH | Caveat 4 — no new mutating AUDIT_SHEET_ID write in v1 | Task 3 (explicitly excluded) |
+| RESEARCH | Caveat 5 — fold ONLY self-fires into total_issues | Task 3 |
+| RESEARCH | Caveat 6 — bulk Supabase reads only; silent first-run seed | Task 1 |
+| RESEARCH | Caveat 7 — fail-open gating, fail-closed logging | Task 2 + Task 3 |
+| RESEARCH | Seam at orchestrate.py:578; zero grouping.py/excel.py edits | Task 1 (seam) + diff guard on every task |
+| RESEARCH | Package Legitimacy Audit: N/A, no new packages | no install task exists in this plan |
+
+No item is MISSING. No item is deferred.
+</source_coverage_audit>
+
+<tasks>
+
+<task type="tracer" tdd="true">
+  <name>Task 1: End-to-end drift detection — one path, zero Smartsheet API calls</name>
+  <files>tests/test_snapshot_drift_audit.py, billing_audit/snapshot_store.py, billing_audit/schema.sql, pipeline/config.py, pipeline/snapshot_drift.py, pipeline/orchestrate.py</files>
+  <precondition>`pytest tests/ -v` passes on a clean tree before any edit (this is the behaviour-neutrality baseline the diff guard is measured against).</precondition>
+  <read_first>
+    - `billing_audit/client.py:221-294` — `get_client()` returns `None` and never raises; every new store function inherits that contract.
+    - `billing_audit/writer.py:1144-1264` — `lookup_group_hash` / `upsert_group_hash`: the plain-table read/write shape to copy (NOT the RPC shape — an RPC would need a Supabase Dashboard deploy outside this repo).
+    - `billing_audit/writer.py:840` `prefetch_attribution` — the bulk-read shape.
+    - `billing_audit/writer.py:418` `_sanitized_wr` — WR sanitization / collision-quarantine rules.
+    - `pipeline/fetch.py:315-331` — every row carries `__source_sheet_id` and `__row_id`.
+    - `pipeline/orchestrate.py:544-585` — the audit block and the grouping span that bracket the seam.
+    - `pipeline/grouping.py:438-467` — the single place a row's billing week is computed, from `Weekly Reference Logged Date` via `excel_serial_to_date`.
+    - `tests/test_rate_sanity_audit.py:1-60` — the 260812-isx RED-first, no-network fixture pattern.
+    - `tests/test_billing_audit_shadow.py` — the Supabase writer mock pattern.
+  </read_first>
+  <behavior>
+    - Test: a row with no provenance baseline produces zero drift candidates, triggers zero cell-history calls, and is queued for a provenance seed (D-09).
+    - Test: a row whose computed week equals its recorded `billed_week` produces zero drift candidates and zero cell-history calls (D-04).
+    - Test: a row whose computed week differs from its recorded `billed_week` is emitted as a candidate with `classification` set to the not-yet-classified value, is NOT held, and its `Weekly Reference Logged Date` and `Snapshot Date` are unchanged.
+    - Test: with the audit kill-switch disabled, `apply_snapshot_drift_holds` returns its zeroed summary immediately, performs no Supabase call, and leaves every row dict identical by value (D-08).
+    - Test: when `get_client()` returns `None`, the whole pass no-ops and returns a summary flagged as unavailable — no exception escapes.
+    - Test: a raised exception from the provenance bulk read is swallowed and degrades to the no-baseline path.
+    - Test: provenance upsert is invoked at most once per run with a batched payload — never once per row (RESEARCH caveat 6; reproduces the 2026-04-24 retry-exhaustion incident if violated).
+  </behavior>
+  <action>
+Write the failing tests FIRST in `tests/test_snapshot_drift_audit.py`, run them RED, then implement.
+
+**(a) `billing_audit/snapshot_store.py`** — new module, imports `get_client`
+and `with_retry` from `billing_audit.client` and `_sanitized_wr` from
+`billing_audit.writer`. Three public functions, each fail-safe (catch their
+own errors, never raise, return a neutral value when `get_client()` is
+`None`), mirroring `upsert_group_hash` at `billing_audit/writer.py:1222`:
+    - `fetch_snapshot_provenance(keys)` — ONE select for all
+      `(sheet_id, row_id)` pairs in the run, returning a dict keyed by that
+      tuple. Bulk only; per-row reads are forbidden (D-06, RESEARCH caveat 6).
+      Return `({}, status)` where status distinguishes success / no rows /
+      fetch failure / unavailable, matching the `lookup_group_hash` status
+      vocabulary.
+    - `upsert_snapshot_provenance(records)` — ONE batched upsert on the
+      `(sheet_id, row_id)` primary key.
+    - `insert_snapshot_drift_events(events)` — ONE batched append-only insert.
+
+**(b) `billing_audit/schema.sql`** — APPEND two
+`CREATE TABLE IF NOT EXISTS` blocks plus `service_role` grants at the end of
+the file; change nothing above (D-06, D-07). The file header already states
+it is documentation-grade and manually applied — the pipeline executes no
+DDL. Follow the existing comment style used for `group_content_hash`
+(`billing_audit/schema.sql:139-145`), including a note that when the table is
+absent the reader degrades to a fetch failure and prior behaviour is kept.
+    - `billing_audit.snapshot_provenance` — state table, PK
+      `(sheet_id BIGINT, row_id BIGINT)`, plus `wr TEXT`, `cu TEXT`,
+      `snapshot_date DATE`, `billed_week DATE`, `run_id TEXT`,
+      `first_seen_at TIMESTAMPTZ`, `last_seen_at TIMESTAMPTZ`.
+    - `billing_audit.snapshot_drift` — append-only event table keyed
+      `(sheet_id, row_id, detected_at)`, plus `wr`, `cu`,
+      `prior_snapshot_date`, `new_snapshot_date`, `prior_billed_week`,
+      `new_week`, `changed_by TEXT`, `classification TEXT`,
+      `held BOOLEAN NOT NULL DEFAULT FALSE`, `run_id TEXT`, and an index on
+      `(wr, detected_at DESC)`.
+    Splitting state from events keeps the upsert idempotent while preserving
+    a complete audit trail.
+
+**(c) `pipeline/config.py`** — declare six module-level switches next to the
+`TIME_BUDGET_MINUTES` family at `:106`, each read via `os.getenv` with a
+default, documented in the same comment style as the surrounding block
+(D-08): `SNAPSHOT_DRIFT_AUDIT_ENABLED` (default true),
+`SNAPSHOT_DRIFT_HOLD_ENABLED` (default false — the gate is opt-in until a
+live run proves the classifier, per D-08 and RESEARCH caveat 3),
+`SNAPSHOT_DRIFT_MAX_ROWS` (default 40), `SNAPSHOT_DRIFT_PACE_SEC`
+(default 2.0), `SNAPSHOT_DRIFT_MAX_MINUTES` (default 5),
+`SNAPSHOT_DRIFT_AUTOMATION_EMAIL` (default `automation@smartsheet.com`, so
+assumption A4 can be corrected by configuration instead of a code change).
+
+**(d) `pipeline/snapshot_drift.py`** — new module.
+`apply_snapshot_drift_holds(all_rows, source_sheets, client, session_start)`
+returns a summary dict. In this task it detects only:
+    1. Honour the audit kill-switch first — read it per call, not at import,
+       exactly as `audit_billing_changes.py:376` does for the rate-sanity
+       switch. Disabled means an immediate zeroed summary, no Supabase touch.
+    2. Build `(sheet_id, row_id)` keys from `__source_sheet_id` / `__row_id`
+       for rows that carry a WR and a parseable `Weekly Reference Logged
+       Date` (use the existing `excel_serial_to_date`, never `dateutil`
+       directly).
+    3. One bulk provenance fetch.
+    4. Absent baseline means seed only: no candidate, no flag, no history
+       call, no hold (D-09). Same for a fetch failure or an unavailable
+       client — the pass degrades to seed-and-continue.
+    5. Baseline present and computed week equals `billed_week` means refresh
+       `last_seen_at` and move on — zero extra API calls (D-04).
+    6. Baseline present and weeks differ means emit a drift candidate
+       carrying prior/new snapshot date, prior/new week, and a placeholder
+       classification. Do NOT mutate the row in this task.
+    7. Log one INFO summary line per run: candidate count, seeded count, and
+       the counts by classification.
+    8. Write drift events and upsert provenance in one batched call each at
+       the end of the pass. Provenance records the week the row will
+       actually be billed under this run.
+    Use function-local lazy imports for `billing_audit.snapshot_store` so a
+    missing/failed Supabase package can never affect module import, matching
+    the 260812-isx pattern. Wrap the whole body so no exception escapes to
+    the caller.
+
+**(e) `pipeline/orchestrate.py`** — insert exactly ONE call site between the
+audit `else:` branch close at `:577` and the grouping log line at `:580`,
+wrapped in its own `try`/`except` that logs a warning and continues. This
+placement is upstream of the five `Weekly Reference Logged Date` pre-pass
+readers at `pipeline/grouping.py:170/234/289/360/417` and of the single week
+computation at `:440-463`, which is what makes zero grouping edits possible.
+Import the new function at the existing import block. Do not touch any other
+line of `orchestrate.py`.
+
+PEP 8, type hints, 4-space indent, lines at or under 79 characters, PEP 257
+docstrings throughout.
+  </action>
+  <verify>
+    <automated>pytest tests/test_snapshot_drift_audit.py -v && python -m py_compile generate_weekly_pdfs.py pipeline/snapshot_drift.py billing_audit/snapshot_store.py && test "$(git diff --name-only -- pipeline/grouping.py pipeline/excel.py | wc -l)" -eq 0 && test "$(git diff -U0 -- pipeline/orchestrate.py | grep -c '^@@')" -le 2</automated>
+  </verify>
+  <done>The new test file passes; `pipeline/snapshot_drift.py` and `billing_audit/snapshot_store.py` compile; `billing_audit/schema.sql` gained exactly two new table definitions and no edits above them; `pipeline/grouping.py` and `pipeline/excel.py` have zero diff hunks; `pipeline/orchestrate.py` has at most two diff hunks (the import and the seam).</done>
+  <reversibility rating="reversible">Detection-only, gated behind a kill-switch, mutates no row and no billing artifact; reverting is a file delete plus removing one call site.</reversibility>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Cell-history classifier with pacing, cap, and sub-budget</name>
+  <files>pipeline/snapshot_drift.py, tests/test_snapshot_drift_audit.py</files>
+  <precondition>`SMARTSHEET_API_TOKEN` is NOT required — every test in this task mocks the SDK client; no live Smartsheet call is made during implementation or verification.</precondition>
+  <read_first>
+    - `pipeline/discovery.py:436-489` and `:615` — `column_mapping['Snapshot Date']` assignment and the `{'id', 'name', 'column_mapping'}` source-sheet dict shape.
+    - `pipeline/fetch.py:276` — `sheet_has_snapshot_date_column`, proof that the Snapshot Date mapping is explicitly optional per sheet.
+    - `pipeline/orchestrate.py:683-685` — the canonical `TIME_BUDGET_MINUTES` + `GITHUB_ACTIONS_MODE` pre-flight guard to copy verbatim in shape.
+    - `pipeline/orchestrate.py:416` — `session_start` anchor.
+    - `pipeline/utils` `is_checked` / `billing_audit/writer.py` `_is_checked` — Smartsheet checkbox truthiness returns str, bool, or 1 variably.
+    - `audit_billing_changes.py:683-690` — the existing cell-history stub that makes no API call; this is greenfield, there is no in-repo call to copy.
+  </read_first>
+  <behavior>
+    - Test: a Snapshot Date history entry written by the configured automation identity, with no `Units Completed?` history entry inside the +/-2 minute window, classifies as an automation self-fire (D-05).
+    - Test: the same Snapshot Date entry accompanied by a `Units Completed?` change 30 seconds earlier classifies as manual.
+    - Test: a Snapshot Date entry written by a human email classifies as manual regardless of the `Units Completed?` timeline (D-02).
+    - Test: `get_cell_history` raising any exception classifies as unclassified (D-03).
+    - Test: a source sheet missing either column id in `column_mapping` classifies as unclassified with zero API calls (assumption A2).
+    - Test: with the per-run cap set to 1 and two candidates present, the first is classified and the second is unclassified — exactly two API calls total (D-04).
+    - Test: with `TIME_BUDGET_MINUTES` set, GitHub-Actions mode on, and remaining budget below the sub-budget, every candidate is unclassified and zero API calls are made (D-10).
+    - Test: history entries supplied newest-first and oldest-first both yield the same classification, proving the code sorts by `modified_at` itself (assumption A1).
+    - Test: `modified_by` supplied as an object with `.email`, as a bare string, and as `None` are all handled without raising (assumption A1).
+    - Test: pacing sleep is invoked between calls with the configured interval and is NOT invoked before the first call.
+  </behavior>
+  <action>
+Write the failing tests FIRST, run them RED, then implement inside
+`pipeline/snapshot_drift.py`. Every candidate produced by Task 1 now gets a
+classification.
+
+Add `_classify_drift_candidate(client, candidate, column_ids, deadline)`
+returning one of three classification values: automation self-fire, manual,
+or unclassified. Rules:
+
+    1. **Pre-flight budget guard, before any call.** Copy the shape at
+       `pipeline/orchestrate.py:683-685`: when `TIME_BUDGET_MINUTES` is set
+       and running under GitHub Actions, compute remaining minutes from
+       `session_start`; if remaining is below `SNAPSHOT_DRIFT_MAX_MINUTES`,
+       skip classification for the entire run — every candidate becomes
+       unclassified and a single INFO line records the skip reason (D-10).
+       Also enforce the sub-budget as a running deadline inside the loop, so
+       a slow phase stops early rather than eating the session budget.
+    2. **Cap.** Process at most `SNAPSHOT_DRIFT_MAX_ROWS` candidates per run,
+       in deterministic order (sort by sheet id then row id so reruns are
+       reproducible). Every candidate beyond the cap is unclassified (D-04).
+    3. **Column ids.** Resolve `Snapshot Date` and `Units Completed?` column
+       ids from the candidate's own source sheet `column_mapping`. If either
+       is absent, return unclassified without any API call (assumption A2 —
+       the Snapshot Date mapping is already known to be optional per sheet).
+    4. **Two calls per candidate**, both
+       `client.Cells.get_cell_history(sheet_id, row_id, column_id,
+       include_all=True)` — Snapshot Date first, then `Units Completed?`
+       (D-04). If the Snapshot Date history alone already rules out the
+       automation identity, skip the second call and save the quota.
+    5. **Self-pacing is mandatory.** Sleep `SNAPSHOT_DRIFT_PACE_SEC` between
+       calls (never before the first). The SDK's `max_retry_time` is 30
+       seconds of exponential backoff that only engages when the server sets
+       `shouldRetry`; roughly four attempts exhaust it, so it will not
+       absorb a sustained cell-history throttle. Do not add a custom retry
+       loop — pacing plus the SDK's own retry is the whole strategy
+       (RESEARCH caveat 2 and the Don't Hand-Roll table).
+    6. **Defensive parsing.** Sort `IndexResult.data` by `modified_at` in
+       code rather than trusting API ordering; read the identity via
+       `getattr(modified_by, 'email', None)` falling back to `str(...)`;
+       compare case-insensitively against
+       `SNAPSHOT_DRIFT_AUTOMATION_EMAIL`. Use the shared checkbox-truthiness
+       helper for `Units Completed?` values rather than `bool()`.
+    7. **Signature.** The newest Snapshot Date write by the automation
+       identity, with NO `Units Completed?` history entry whose
+       `modified_at` falls within +/-2 minutes of it, is an automation
+       self-fire. Anything else is manual (D-05).
+    8. **Fail-open.** Wrap each candidate's classification in its own
+       try/except: any exception, timeout, retry exhaustion, or malformed
+       payload yields unclassified and the loop continues (D-03). The run
+       log records every unclassified candidate with the reason so the
+       fail-closed logging half of D-03 still holds.
+
+Counters returned in the summary: candidates seen, classified, and the
+per-classification counts, plus the skip reason when the budget guard fires.
+  </action>
+  <verify>
+    <automated>pytest tests/test_snapshot_drift_audit.py -v && python -m py_compile pipeline/snapshot_drift.py && test "$(git diff --name-only -- pipeline/grouping.py pipeline/excel.py | wc -l)" -eq 0</automated>
+  </verify>
+  <done>All classifier tests pass, including both history orderings, all three `modified_by` shapes, the cap, the budget guard, and the missing-column-id path. Zero live Smartsheet calls occur during the suite. `pipeline/grouping.py` and `pipeline/excel.py` still have zero diff hunks.</done>
+  <reversibility rating="reversible">Read-only Smartsheet calls behind an existing kill-switch; no row, price, hash, filename, or upload behaviour is touched.</reversibility>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 3: Hold-prior-week override (both fields) + audit risk wiring</name>
+  <files>pipeline/snapshot_drift.py, audit_billing_changes.py, pipeline/orchestrate.py, tests/test_snapshot_drift_audit.py, memory-bank/living-ledger.md</files>
+  <precondition>Tasks 1 and 2 are committed and `pytest tests/ -v` is green — the hold override is only safe on top of a classifier that already fails open.</precondition>
+  <read_first>
+    - `pipeline/excel.py:711-736` — `generate_excel` buckets rows by `Snapshot Date` and drops any row outside the group's Monday-Sunday window. This is the caveat that makes rewriting one field a silent under-bill.
+    - `pipeline/change_detection.py:115` (sort key), `:143` (legacy row_data), `:169` (extended row_fields) — `Snapshot Date` participates in the content hash in both modes.
+    - `pipeline/grouping.py:1167` — where `__week_ending_date` is stamped onto the group.
+    - `pipeline/orchestrate.py:1461` — `history_key` is built from the group, not the row, so it follows automatically.
+    - `audit_billing_changes.py:185-206` — how the 260812-isx rate-sanity bucket was declared and wired as a numbered step.
+    - `audit_billing_changes.py:490-517` — summary keys, the `total_issues` sum, and the 0 / <=3 / else risk thresholds.
+    - `audit_billing_changes.py:586-617` — `_log_to_audit_sheet` builds a dict and discards it. It writes nothing to Smartsheet.
+  </read_first>
+  <behavior>
+    - Test: an automation self-fire candidate with the hold gate enabled rewrites BOTH `Weekly Reference Logged Date` and `Snapshot Date` back to the provenance values, and preserves the drifted originals under private keys.
+    - Test: the held row survives `generate_excel`'s Monday-Sunday snapshot filter — the group's day-table row count equals the group's row count (the warning sign named in RESEARCH pitfall 1).
+    - Test: the prior week's content hash computed over the held row equals the hash computed before the drift, in both legacy and extended change-detection modes.
+    - Test: a manual candidate is never mutated even when the hold gate is enabled (D-02).
+    - Test: an unclassified candidate is never mutated even when the hold gate is enabled (D-03).
+    - Test: with the hold gate at its default, an automation self-fire is flagged and recorded but the row is NOT mutated (D-08).
+    - Test: four automation self-fire holds escalate `risk_level` to HIGH; four manual drifts and four unclassified drifts leave `risk_level` unchanged (D-01, RESEARCH caveat 5).
+    - Test: the drift event rows written to Supabase carry the classification and the held boolean for every candidate, including manual and unclassified (D-03 fail-closed logging).
+    - Test: with both kill-switches at values that disable the feature, a representative `all_rows` fixture is value-identical after the pass and `risk_level` matches the pre-change baseline (D-08).
+  </behavior>
+  <action>
+Write the failing tests FIRST, run them RED, then implement.
+
+**(a) The override, in `pipeline/snapshot_drift.py`.** Gate on
+`SNAPSHOT_DRIFT_HOLD_ENABLED` read per call. Apply ONLY to candidates
+classified as an automation self-fire (D-01); manual and unclassified
+candidates flow through untouched (D-02, D-03). For each held row set
+`Weekly Reference Logged Date` to the provenance `billed_week` and
+`Snapshot Date` to the provenance `snapshot_date`, and stash the drifted
+originals plus the classification and the evidence timestamps under private
+double-underscore keys so they survive into logging, the Supabase event row,
+and any later diagnosis.
+
+Rewriting both fields is load-bearing in three independent places and the
+tests above pin each one:
+    - `Weekly Reference Logged Date` drives the week key at
+      `pipeline/grouping.py:440-463`.
+    - `Snapshot Date` drives `generate_excel`'s Monday-Sunday bucket filter
+      at `pipeline/excel.py:711-736`. A row held into the prior week while
+      still carrying the drifted snapshot passes grouping, counts toward
+      group membership, and is then excluded from every day-table — a silent
+      under-bill, strictly worse than the drift itself.
+    - `Snapshot Date` is inside the content hash at
+      `pipeline/change_detection.py:143` and `:169` and inside the sort key
+      at `:115`. Restoring it is what makes the prior week's hash stable and
+      stops the pointless regeneration churn.
+Because the rewrite happens before grouping, the row can only ever land in
+the prior week's group — the current week never sees it, so no de-duplication
+logic is needed. The change-detection key stays
+`(WR, week, variant, foreman, dept, job)`, unshortened.
+
+For each held row emit one deterministic run-log line carrying WR, row id,
+prior week, drifted week, and the evidence timestamps, so the hold decision
+is visible without opening Supabase.
+
+**(b) Audit wiring, in `audit_billing_changes.py`.** Additive only.
+Declare drift counters alongside `total_rate_sanity_mismatches` at `:493-496`
+and add a new module-level function
+`escalate_risk_for_snapshot_drift(summary, self_fire_holds)` that recomputes
+`risk_level` from the existing `total_issues` sum PLUS the self-fire hold
+count, reusing the same 0 / <=3 / else thresholds at `:509-517`, and appends
+a matching recommendation. It runs post-hoc because the drift pass executes
+after `audit_financial_data`. Only automation self-fire holds feed it —
+folding in manual drift would drive a routine batch of legitimate edits to
+HIGH and desensitise the signal (RESEARCH caveat 5).
+
+Leave the three-way inconsistency between `_generate_audit_summary`'s
+`total_issues` (`:502-507`), `_log_to_audit_sheet`'s three-term sum
+(`:599`), and `_compute_trend`'s three-term sum (`:638-639`) exactly as it
+is — pre-existing and out of scope.
+
+**Explicitly NOT in this task:** any new mutating Smartsheet write to
+`AUDIT_SHEET_ID`. `_log_to_audit_sheet` is a no-op placeholder that builds a
+dict and discards it (`audit_billing_changes.py:611-614`), so a real audit
+sheet write would be a brand-new mutating call site in a protected area,
+requiring Juan's approval, `SKIP_UPLOAD` gating, and audit-sheet column-id
+discovery. That is a separate task. The durable, queryable flag surface in
+v1 is the Supabase shadow layer plus the run log (RESEARCH caveat 4).
+
+**(c) `pipeline/orchestrate.py`.** Extend only the existing seam added in
+Task 1 so the returned summary counters are merged into
+`audit_results['summary']` and `escalate_risk_for_snapshot_drift` is called
+when the audit ran. No new call site; no other line changes.
+
+**(d) `memory-bank/living-ledger.md`.** APPEND one dated
+`[YYYY-MM-DD HH:MM]` entry at the BOTTOM of the file per the repo's
+self-documenting rule. Record: the drift root cause, the both-fields
+requirement and why one field is a silent under-bill, the fail-open gating /
+fail-closed logging rule, the six env switches with their defaults, the
+manual-DDL requirement, and the two live assumptions still to verify
+(cell-history ordering and the automation identity email).
+  </action>
+  <verify>
+    <automated>pytest tests/test_snapshot_drift_audit.py -v && pytest tests/ -v && python -m py_compile generate_weekly_pdfs.py pipeline/snapshot_drift.py audit_billing_changes.py && test "$(git diff --name-only -- pipeline/grouping.py pipeline/excel.py | wc -l)" -eq 0</automated>
+    <human-check>Run `SKIP_UPLOAD=true WR_FILTER=<one known-drifted WR> SNAPSHOT_DRIFT_HOLD_ENABLED=true python generate_weekly_pdfs.py` against real Smartsheet data and confirm from the run log that the drifted row is classified as an automation self-fire, is held to the prior week, and appears in the generated workbook's day-table for that week. This is the live check for assumptions A1 and A4; if the classification comes back unclassified, correct `SNAPSHOT_DRIFT_AUTOMATION_EMAIL` rather than the classifier.</human-check>
+  </verify>
+  <done>The full suite passes (previous count plus the new file, no regressions). Held rows survive the Monday-Sunday filter and keep a stable prior-week hash in both change-detection modes. Manual and unclassified candidates are never mutated. Four self-fire holds escalate risk to HIGH; manual and unclassified drift do not. With the feature disabled, rows and `risk_level` are identical to baseline. `pipeline/grouping.py` and `pipeline/excel.py` still have zero diff hunks. A dated ledger entry is appended.</done>
+  <reversibility rating="costly">The hold override changes which week a unit is billed under. It ships behind a default-off gate and is reversible by unsetting the gate, but any workbook generated while it was enabled would need regeneration via REGEN_WEEKS to undo.</reversibility>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| Smartsheet API to pipeline | Row values, cell-history payloads, and `modified_by` identities are attacker-influenceable input; the classifier's hold decision depends on them |
+| Pipeline to Supabase (`service_role`) | New writes to `billing_audit.snapshot_provenance` and `billing_audit.snapshot_drift` cross into the privileged data tier |
+| Environment configuration to gating behaviour | Six env vars control whether billing weeks are rewritten |
+| Run log and Sentry to operators | Drift evidence lines may carry row-level identifiers |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Severity | Disposition | Mitigation Plan |
+|-----------|----------|-----------|----------|-------------|-----------------|
+| T-jqx-01 | Spoofing | `_classify_drift_candidate` identity check | medium | mitigate | A forged or renamed `modified_by` email would misclassify. Mitigated by fail-open (a non-matching identity yields manual, never a hold) plus `SNAPSHOT_DRIFT_AUTOMATION_EMAIL` being operator-controlled, plus the default-off hold gate — a spoof cannot cause a hold without an operator first enabling gating. |
+| T-jqx-02 | Tampering | hold override in `pipeline/snapshot_drift.py` | high | mitigate | Rewriting billing dates is the highest-blast-radius action here. Mitigated by: self-fires only, `SNAPSHOT_DRIFT_HOLD_ENABLED` defaulting off, rewriting BOTH fields so the workbook cannot silently lose the row, and the Task 3 hash-stability and Monday-Sunday-filter tests. |
+| T-jqx-03 | Repudiation | drift decisions | medium | mitigate | Every candidate — held, manual, or unclassified — is written to the append-only `billing_audit.snapshot_drift` table with classification, `changed_by`, `held`, and `run_id`, plus a deterministic run-log line for each hold. |
+| T-jqx-04 | Information disclosure | run log, Sentry breadcrumbs, Supabase event rows | medium | mitigate | Log WR, row id, dates, and the classification only. Do not log full row dicts, pricing, or personnel fields. Sentry Logs stay off by default (`SENTRY_ENABLE_LOGS`) and the existing `before_send_log` sanitizer remains the backstop. |
+| T-jqx-05 | Denial of service | Smartsheet cell-history endpoint | high | mitigate | Week-movers only, `SNAPSHOT_DRIFT_MAX_ROWS` cap, `SNAPSHOT_DRIFT_PACE_SEC` self-pacing, `SNAPSHOT_DRIFT_MAX_MINUTES` sub-budget with a pre-flight guard, and no custom retry loop layered on the SDK's 30-second budget. Worst case is roughly 40 rows times 2 calls times 2 seconds, about 2.7 minutes. |
+| T-jqx-06 | Denial of service | billing run availability via Supabase | high | mitigate | Every store function inherits the `get_client()`-returns-`None` contract, catches its own errors, and never raises. Bulk reads only — per-row reads caused the 2026-04-24 retry-exhaustion incident. An unapplied migration degrades to the no-baseline path. |
+| T-jqx-07 | Elevation of privilege | `billing_audit` schema surface | medium | mitigate | Schema ADDITION only: two new tables plus `service_role` grants appended to `schema.sql`. No RLS, policy, or column change to any existing table. The pipeline executes no DDL; Juan applies it by hand. |
+| T-jqx-SC | Tampering | package-manager installs | low | accept | No new third-party packages. `smartsheet-python-sdk==4.3.0` and `supabase` are already declared and in use, so no install task exists in this plan and no legitimacy gate is triggered. If any task ever adds a `pip install`, run the Package Legitimacy Gate first. |
+</threat_model>
+
+<verification>
+1. `pytest tests/test_snapshot_drift_audit.py -v` — the new suite, all cases green.
+2. `pytest tests/ -v` — full suite, no regressions against the pre-change count.
+3. `python -m py_compile generate_weekly_pdfs.py pipeline/snapshot_drift.py billing_audit/snapshot_store.py audit_billing_changes.py`.
+4. Diff guard: `git diff --name-only -- pipeline/grouping.py pipeline/excel.py` returns nothing.
+5. Seam guard: `git diff -U0 -- pipeline/orchestrate.py | grep -c '^@@'` is at most 3 (import, seam, summary merge).
+6. Schema guard: the `billing_audit/schema.sql` diff is append-only — no hunk touches an existing object definition.
+7. Off-switch equivalence: with `SNAPSHOT_DRIFT_AUDIT_ENABLED=false` and `SNAPSHOT_DRIFT_HOLD_ENABLED=false`, a `TEST_MODE=true` run produces the same `run_summary.json` key set and the same generated filenames as before the change.
+8. Live operator check (`<human-check>` on Task 3): confirm cell-history entry ordering (A1) and the literal automation identity email (A4) against one known-drifted row before enabling the hold gate in the workflow.
+</verification>
+
+<success_criteria>
+- Drift on already-billed rows is detected with zero extra Smartsheet API calls; only week-movers cost history lookups, capped and paced.
+- Automation self-fires are held to the prior week with BOTH date fields rewritten; the held row still appears in the workbook day-tables and the prior week's content hash is unchanged.
+- Manual edits are never held. Unclassifiable drift is never held. Both are still recorded.
+- Only automation self-fire holds escalate `risk_level`.
+- Both kill-switches off reproduces today's behaviour exactly; the hold gate ships off.
+- No Supabase DDL is executed by the pipeline; no new mutating Smartsheet write exists.
+- Zero diff hunks inside `pipeline/grouping.py` and `pipeline/excel.py`.
+- Full pytest suite green; `py_compile` clean; a dated ledger entry is appended.
+</success_criteria>
+
+<output>
+Create `.planning/quick/260812-jqx-snapshot-date-drift-audit-detect-snapsho/260812-jqx-SUMMARY.md` when done.
+</output>

--- a/.planning/quick/260812-jqx-snapshot-date-drift-audit-detect-snapsho/260812-jqx-RESEARCH.md
+++ b/.planning/quick/260812-jqx-snapshot-date-drift-audit-detect-snapsho/260812-jqx-RESEARCH.md
@@ -1,0 +1,741 @@
+# Quick Task 260812-jqx: Snapshot-Date Drift Audit — Research
+
+**Researched:** 2026-08-12
+**Domain:** Production Python billing pipeline (Smartsheet → grouping → Excel → attachment) + `billing_audit` Supabase shadow layer
+**Confidence:** HIGH on the in-repo seams (all cited files opened this session); MEDIUM on Smartsheet cell-history *runtime* semantics (SDK source read; live API response shape not exercised — no cell-history call exists in this repo today)
+**Mode:** Feasibility-first (quick task). No domain survey.
+
+---
+
+<user_constraints>
+## User Constraints (from CONTEXT.md — LOCKED)
+
+### Locked Decisions
+
+- **Hold prior week + flag HIGH.** The pipeline keeps billing the row under its
+  previously-billed week (ignores the drifted date for grouping), flags HIGH on the
+  billing audit sheet + Supabase, and reports which row to repair upstream. Files stay
+  correct; nothing silently moves weeks.
+- Manual edits are NEVER blocked or held — they flow through normally and are
+  shadow-logged.
+- Unclassifiable drift (history unavailable, cap exhausted, API error) must NOT hold the
+  row — flag it as `unclassified` and let it flow (fail-open on gating, fail-closed on
+  logging).
+- **Only week-movers, capped.** Spend history lookups ONLY on rows whose computed billing
+  week differs from the previously-billed week for that row, with a per-run cap (~40 rows)
+  and pacing (~2s between calls; ~2 calls per row: Snapshot Date + Units Completed?).
+  Everything else costs zero extra API calls.
+- Classifier signature: a Snapshot Date write by `automation@smartsheet.com` with NO
+  `Units Completed?` change within ±2 minutes = automation self-fire. Otherwise
+  manual/legitimate.
+- **New additive Supabase table** (e.g. `snapshot_drift` / provenance: sheet_id, row_id,
+  WR, CU, prior snapshot date, new snapshot date, prior billed week, new week, changed_by,
+  classification, run_id, detected_at). Written additively by the pipeline; the existing
+  `billing_audit` tables stay untouched.
+- Approved as a Supabase schema ADDITION only — no RLS/policy/schema changes to existing
+  tables. Migration must be reviewed by Juan before apply (protected area).
+
+### Claude's Discretion
+
+- Exact table/column naming and index choices.
+- Flag format on the billing audit sheet (reuse the existing `_log_to_audit_sheet` shape
+  from `audit_billing_changes.py`).
+- Env-var kill-switches and defaults (mirror RATE_SANITY pattern: default enabled for
+  detection/logging; the HOLD gate gets its OWN kill-switch so gating can be disabled
+  independently of detection).
+- Whether v1 per-row provenance is seeded from the first run that sees a row (no history
+  backfill required).
+
+### Deferred Ideas (OUT OF SCOPE)
+
+None declared in CONTEXT.md. The Smartsheet-UI automation fix (trigger → "when Units
+Completed? changes to Checked" + condition "Snapshot Date is blank") is Juan's, not this
+task's.
+</user_constraints>
+
+---
+
+## Summary
+
+All six research questions resolve to **concrete, additive seams that already exist**. The
+single biggest finding is that the audit already runs *before* grouping in the same
+function, so both the drift detector and the week override fit in one un-contended window
+(`pipeline/orchestrate.py:578-582`) with **zero edits inside `pipeline/grouping.py`**.
+
+Two findings materially change the plan versus what the task description assumes:
+
+1. **`_log_to_audit_sheet` writes nothing.** It is a no-op placeholder that builds a dict
+   and logs a success message. "Flag on the billing audit sheet" is therefore not a
+   reuse — it is either (a) log-only parity with today, or (b) a NEW mutating Smartsheet
+   write to `AUDIT_SHEET_ID`, which is a protected-area change needing Juan's approval and
+   `SKIP_UPLOAD` gating.
+2. **Rewriting `Weekly Reference Logged Date` alone silently deletes the row from the
+   Excel body.** `pipeline/excel.py` buckets rows by `Snapshot Date` and drops anything
+   outside the group's Monday–Sunday window. The hold override must rewrite **both**
+   fields.
+
+**Primary recommendation:** Implement as a pre-grouping row transform inserted at
+`pipeline/orchestrate.py:578`, backed by a new `billing_audit.snapshot_provenance` table
+(PK `sheet_id,row_id`) seeded silently on first sight; rewrite BOTH `Weekly Reference
+Logged Date` and `Snapshot Date` on held rows; keep the audit-sheet surface log-only in v1
+and treat a real `AUDIT_SHEET_ID` write as a separate approval-gated follow-up.
+
+---
+
+## Q1 — Supabase Shadow Layer: What Exists, and the Additive Path
+
+### What the `billing_audit` package is
+
+| File | Lines | Role |
+|---|---|---|
+| `billing_audit/client.py` | 739 | `get_client()`, `with_retry()`, feature-flag reads, run-global kill switch |
+| `billing_audit/writer.py` | 1264 | `freeze_row`, `emit_run_fingerprint`, `lookup_group_hash`, `upsert_group_hash`, `prefetch_attribution` |
+| `billing_audit/schema.sql` | 330 | Documentation-grade DDL, **manually applied** |
+| `billing_audit/fingerprint.py` | 62 | assignment fingerprint |
+
+**Credentials + disable conditions** [VERIFIED: `billing_audit/client.py:221-294`]. `get_client()`
+returns `None` — never raises — when any of these hold. Verbatim from `:259-260`:
+
+```python
+    url = os.getenv("SUPABASE_URL")
+    key = os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+```
+
+plus `TEST_MODE` (`:251`), missing `supabase` package (`:270`), construction failure
+(`:281`), and a run-global PostgREST kill (`:243-244`):
+
+```python
+    if _global_disable_reason is not None:
+        return None
+```
+
+That `None`-not-raise contract is the fail-safe posture every new writer must inherit:
+**a misconfigured billing_audit integration must never break the billing run** (ledger
+`[2026-04-24 10:50]`).
+
+### Tables the pipeline owns vs. tables the data team owns
+
+[VERIFIED: `billing_audit/schema.sql:32,63,146` — verbatim object names]
+
+```sql
+CREATE TABLE IF NOT EXISTS billing_audit.feature_flag (
+CREATE TABLE IF NOT EXISTS billing_audit.pipeline_run (
+CREATE TABLE IF NOT EXISTS billing_audit.group_content_hash (
+```
+
+`attribution_snapshot` and the `freeze_attribution` / `lookup_attribution` /
+`lookup_attribution_bulk` RPCs are **NOT** in this file — the body lives in the Supabase
+project and is owned by the data team [VERIFIED: `billing_audit/schema.sql:211-218`].
+
+### Migration mechanism — there is none (deliberately)
+
+[VERIFIED: `billing_audit/schema.sql:4-8`, verbatim]
+
+> `-- This file is documentation-grade SQL. It is NOT auto-applied by`
+> `-- the Python pipeline — apply it manually in the Supabase SQL`
+> `-- Editor (Project Settings → SQL Editor) the first time you wire`
+> `-- the ``billing_audit`` integration to a new project, and again`
+> `-- whenever this file is updated to add a column.`
+
+The pipeline never executes DDL. **The additive path for a new `snapshot_drift` table is
+therefore: append a `CREATE TABLE IF NOT EXISTS` block to `schema.sql`, and Juan applies it
+in the SQL Editor + confirms `billing_audit` is in "Exposed schemas" + reloads the
+PostgREST cache** [VERIFIED: `billing_audit/schema.sql:10-16`]. This matches the CONTEXT
+decision exactly ("Migration must be reviewed by Juan before apply").
+
+Until the DDL is applied, the reader must degrade the same way `group_content_hash` does —
+surface as a fetch failure and fall through to prior behaviour, never regenerate-block
+[VERIFIED: `billing_audit/schema.sql:139-145`].
+
+### Is there per-row provenance today?
+
+**Partially — and it is not usable as a prior-billed-week oracle.**
+
+`freeze_row` upserts one row per `(wr, week_ending, smartsheet_row_id)` into
+`attribution_snapshot`, first-write-wins [VERIFIED: `billing_audit/writer.py:466-472`; PK
+shape verbatim at `billing_audit/schema.sql:205`: "PRIMARY KEY shape: (wr, week_ending,
+smartsheet_row_id)"]. Params sent verbatim [VERIFIED: `billing_audit/writer.py:550-553`]:
+
+```python
+    params = {
+        "p_wr": wr,
+        "p_week_ending": week_ending.isoformat(),
+        "p_smartsheet_row_id": row_id,
+```
+
+Three reasons it cannot answer "what week was this row billed under?":
+
+1. The read RPC **takes `p_week_ending` as an input parameter** [VERIFIED:
+   `billing_audit/schema.sql:225-228`] — you must already know the week to look it up.
+2. It stores personnel, not dates — no snapshot date column in the Python contract
+   [VERIFIED: `billing_audit/schema.sql:206-209`: "Columns the reader depends on: `helper
+   TEXT`, `helper_dept TEXT`, `source_run_id TEXT`"].
+3. Writes are gated on a flag seeded **FALSE** [VERIFIED: `billing_audit/schema.sql:44-48`,
+   verbatim seed values `('write_attribution_snapshot', FALSE)`,
+   `('emit_assignment_fingerprint', FALSE)`], and only fire for `Units Completed?`-checked
+   rows [VERIFIED: `billing_audit/writer.py:533`].
+
+**Conclusion: a new table is required.** See Q5.
+
+### Model to copy for the new reader/writer
+
+`lookup_group_hash` / `upsert_group_hash` [VERIFIED: `billing_audit/writer.py:1144,1222`]
+are the closest analogue: plain table read/write (no RPC, no data-team coordination),
+`with_retry`-wrapped, fail-safe on error. Copy that shape rather than the RPC shape — an
+RPC would require a Supabase Dashboard function deploy outside this repo.
+
+---
+
+## Q2 — The Hold-Prior-Week Seam (riskiest part)
+
+### Where a row's billing week is computed — one place
+
+[VERIFIED: `pipeline/grouping.py:438-467`, verbatim]
+
+```python
+    for r in rows:
+        wr = r.get('Work Request #')
+        log_date_str = r.get('Weekly Reference Logged Date')
+...
+            # Parse the Weekly Reference Logged Date - this IS the week ending date
+            week_ending_date = excel_serial_to_date(log_date_str)
+            if week_ending_date is None:
+                logging.warning(f"Could not parse Weekly Reference Logged Date '{log_date_str}' for WR# {wr_key}. Skipping row.")
+                continue
+            week_end_for_key = week_ending_date.strftime("%m%d%y")
+```
+
+`Snapshot Date` is **not** read for week computation in `group_source_rows` — only for the
+AEP-billable cutoff [VERIFIED: `pipeline/grouping.py:774`]. Snapshot → Sunday snapping
+happens *in Smartsheet*, not in Python (ledger `[2026-08-12 13:40]`: "`Weekly Reference
+Logged Date` = Snapshot Date snapped to Sunday"). Every variant key, and `__week_ending_date`
+stamped at `pipeline/grouping.py:1167`, derives from those two locals.
+
+### The additive hook point
+
+`group_source_rows` is called **once**, and the audit already runs **before** it
+[VERIFIED: `pipeline/orchestrate.py:553` and `:582`, verbatim]:
+
+```python
+                    audit_results = audit_system.audit_financial_data(source_sheets, all_rows)
+...
+            groups = group_source_rows(all_rows)
+```
+
+**Concrete hook: insert the drift pass between `pipeline/orchestrate.py:577` (the audit
+`else:` branch close) and `:580` (`logging.info("📂 Grouping data...")`).** A function
+`apply_snapshot_drift_holds(all_rows, source_sheets, client, session_start) -> list[dict]`
+placed there:
+
+- sees the same `all_rows` the audit just inspected and the same `source_sheets`
+  (which carry `column_mapping` — see Q3);
+- runs upstream of **all** grouping passes, including the five earlier
+  `Weekly Reference Logged Date` pre-pass readers at `pipeline/grouping.py:170, 234, 289,
+  360, 417`, so VAC-claim reconciliation and the main loop stay mutually consistent;
+- requires **zero** edits inside `pipeline/grouping.py`.
+
+### Double-count: solved structurally, no dedup logic needed
+
+Because the transform rewrites the row's own fields before grouping, `week_ending_date` is
+computed once from the corrected value — the row can only land in W1's groups. W2 never
+sees it. `history_key` follows automatically, since it is built from the group, not the row
+[VERIFIED: `pipeline/orchestrate.py:1461`, verbatim]:
+
+```python
+                history_key = f"{wr_num}|{week_raw}|{variant}|{identifier}"
+```
+
+The full change-detection key (WR, week, variant, foreman, dept, job) is preserved
+untouched.
+
+### ⚠️ CRITICAL: the override MUST rewrite BOTH fields
+
+`generate_excel` buckets rows by `Snapshot Date` and **silently drops** any row whose
+snapshot falls outside the group's Monday–Sunday window [VERIFIED: `pipeline/excel.py:711-736`,
+verbatim]:
+
+```python
+    if week_ending_date:
+        # Calculate Monday of the week (6 days before Sunday)
+        week_start_date = week_ending_date - timedelta(days=6)  # Monday of that week
+        week_end_date = week_ending_date  # Sunday of that week
+...
+    for row in group_rows:
+        snap = row.get('Snapshot Date')
+...
+            # Include snapshot dates that fall within the Monday-Sunday range
+            if week_start_date and week_end_date:
+                if week_start_date <= dt <= week_end_date:
+                    date_to_rows[dt].append(row)
+```
+
+A row held into W1 while still carrying a W2 `Snapshot Date` passes grouping, counts toward
+group membership, and is then **excluded from every day-table in the workbook** — a silent
+under-bill. The transform must set both:
+
+- `r['Weekly Reference Logged Date'] = <prior billed week>` — controls grouping
+- `r['Snapshot Date']  = <prior snapshot date>` — controls Excel day-bucketing
+- preserve the drifted originals under private keys (e.g. `__drifted_snapshot_date`,
+  `__drifted_week`, `__drift_classification`) for logging / Supabase / audit.
+
+### Hash interaction — rewriting both is also what *stops the churn*
+
+`Snapshot Date` is inside the content hash in **both** legacy and extended modes, and in the
+sort key [VERIFIED: `pipeline/change_detection.py:115` (sort), `:143` (legacy row_data),
+`:169` (extended `row_fields`), verbatim examples]:
+
+```python
+        str(x.get('Snapshot Date', '')),
+...
+                f"{row.get('Snapshot Date', '')}"
+...
+            str(row.get('Snapshot Date', '') or ''),
+```
+
+So holding the week while leaving the drifted snapshot in place would still perturb W1's
+hash and force a pointless regeneration every run. Restoring both fields makes W1's hash
+**byte-stable** — the drift becomes fully invisible to the billing artifact, which is
+exactly the CONTEXT goal ("Files stay correct; nothing silently moves weeks").
+
+**Verdict for Q2: achievable additively, one insertion point, zero protected-internals
+edits — conditional on rewriting both fields.**
+
+---
+
+## Q3 — Cell History Mechanics
+
+### There is no existing cell-history call in this repo
+
+`_selective_cell_history_enrichment` is a stub that makes **no API call** [VERIFIED:
+`audit_billing_changes.py:683-690`, verbatim]:
+
+```python
+            # Minimal sample: we just record existence of history (actual per-cell diff can be expanded later)
+            history_meta = {"sheet_id": sheet_id, "row_id": row_id, "work_request": wr}
+            try:
+                # We avoid deep iteration to limit API usage; could call cell history endpoints if needed.
+                history_meta["history_available"] = True
+```
+
+`_detect_suspicious_changes` likewise only reads sheet discussions, not cell history
+[VERIFIED: `audit_billing_changes.py:461`]. **This is greenfield.**
+
+### SDK method (4.3.0 pinned)
+
+[VERIFIED: `requirements.txt:9` — `smartsheet-python-sdk==4.3.0`; installed 4.3.0 confirmed]
+[VERIFIED: installed `smartsheet/cells.py`, signature read via `inspect` this session]
+
+```python
+Cells.get_cell_history(self, sheet_id, row_id, column_id,
+                       include=None, page_size=None, page=None,
+                       include_all=None, level=None)
+    -> Union[IndexResult[CellHistory], Error]
+    # GET /sheets/{sheet_id}/rows/{row_id}/columns/{column_id}/history
+```
+
+`CellHistory` attributes [VERIFIED: `smartsheet.models.cell_history.CellHistory.__dict__`
+inspected this session]: `_modified_at`, `_modified_by`, plus the full `Cell` surface
+(`_value`, `_display_value`, `_column_id`, `_object_value`, …).
+
+**It takes a `column_id`, not a column name.** Getting `Snapshot Date`'s and
+`Units Completed?`'s column ids is the pre-work.
+
+### Row + column identity are both available at the seam
+
+Every row dict carries its provenance [VERIFIED: `pipeline/fetch.py:315-331`, verbatim]:
+
+```python
+                    # Attach provenance metadata for audit (used to fetch selective cell history later)
+                    if row_data:
+                        row_data['__sheet_id'] = source['id']
+...
+                        row_data['__source_sheet_id'] = source['id']
+                        row_data['__row_id'] = row.id
+```
+
+Column ids come from the source-sheet dict [VERIFIED: `pipeline/discovery.py:615`, verbatim]:
+
+```python
+                return {'id': sid,'name': sheet.name,'column_mapping': mapping}
+```
+
+with `mapping['Snapshot Date']` assigned at `pipeline/discovery.py:438` (`mapping['Snapshot
+Date'] = s_exact.id`) plus keyword and fuzzy fallbacks at `:448` and `:489`. `source_sheets`
+is in scope at the seam — it is passed to the audit at `pipeline/orchestrate.py:553`.
+
+⚠️ `'Units Completed?'` presence in `column_mapping` is **per-sheet and not guaranteed**
+(the Snapshot Date mapping itself is explicitly optional — `sheet_has_snapshot_date_column`
+guard at `pipeline/fetch.py:276`). The classifier must check both column ids exist for the
+row's sheet and emit `unclassified` (never hold) when either is missing. [ASSUMED that
+`Units Completed?` maps on all currently-discovered sheets — not verified per sheet.]
+
+### Pagination + per-call cost
+
+`include_all=True` returns the whole history for one cell in one request; `page_size`/`page`
+paginate. Snapshot-Date cell histories are short (one entry per automation fire), so
+`include_all=True` = 1 request per cell. **2 requests per candidate row** (Snapshot Date +
+Units Completed?), matching the CONTEXT budget. [CITED: SDK docstring in
+`smartsheet/cells.py`, read this session.]
+
+[ASSUMED] Ordering of `IndexResult.data` (oldest-first vs newest-first) and the exact
+`modified_by` shape (`User` object with `.email`) are not verified against the live API —
+no call exists in-repo to copy. The classifier must sort by `modified_at` itself and read
+the email defensively (`getattr(mb, 'email', None) or str(mb)`).
+
+### 429 behaviour — the SDK's retry budget is 30 seconds, not unlimited
+
+[VERIFIED: installed `smartsheet/smartsheet.py`, read via `inspect` this session]
+
+- `Smartsheet.__init__(..., max_retry_time=30, ...)` — **default 30 seconds total**.
+- `request_with_retry` retries only when the server sets `shouldRetry` on the error result:
+  `if native.result.should_retry:` … `backoff = self._user_calc_backoff.calc_backoff(...)`;
+  `if backoff < 0: break`.
+- `DefaultCalcBackoff.calc_backoff` = `(2 ** previous_attempts) + random.random()`, and
+  returns `-1` (drop out of the retry loop) once `total_elapsed_time + backoff >
+  self._max_retry_time`.
+
+So a sustained 30-req/min throttle exhausts the SDK's budget after roughly 4 attempts
+(2+4+8+16 ≈ 30s) and then raises. **Self-pacing (~2s between calls, per the CONTEXT
+decision) is mandatory — the SDK will not ride out the cell-history rate limit for you** —
+and any exhausted-retry exception must map to `unclassified` (flag, no hold), per the
+locked fail-open rule.
+
+---
+
+## Q4 — Audit Outputs
+
+### `_log_to_audit_sheet` writes NOTHING today
+
+[VERIFIED: `audit_billing_changes.py:586-617`, verbatim tail]
+
+```python
+            # Placeholder: actual Smartsheet row creation would map these keys to column IDs.
+            
+            # Note: Actual implementation would require proper Smartsheet row creation
+            self.logger.info("📋 Audit results logged to audit sheet")
+```
+
+It builds `audit_row` (`:596-610`) with keys `Audit Timestamp`, `Risk Level`,
+`Total Issues`, `Sheets Audited`, `Rows Audited`, `Anomalies`, `Unauthorized Changes`,
+`Data Issues`, `Risk Direction`, `Risk Level Δ`, `Issues Δ`, `Issues Δ %`, `Enriched Rows`
+— then discards it. It is gated on `AUDIT_SHEET_ID` [VERIFIED: `audit_billing_changes.py:125`
+`self.audit_sheet_id = os.getenv("AUDIT_SHEET_ID")` and `:580` `if self.audit_sheet_id:`].
+
+**Planning implication (do not skip this):** "flag drift on the billing audit sheet" has two
+readings and they have very different risk profiles.
+
+| Option | Work | Risk |
+|---|---|---|
+| **A (recommended v1)** — add drift keys to the existing `audit_row` dict + a per-run INFO log line | trivial, additive, zero API surface | none; but visibility is log-only, same as every other audit metric today |
+| **B** — implement a real `Sheets.add_rows` against `AUDIT_SHEET_ID` | new mutating Smartsheet write | **protected area.** Needs Juan's explicit approval, `SKIP_UPLOAD` gating (cf. quick task 260722-nst, which gated the 6th mutating call site on `SKIP_UPLOAD`), and column-id discovery for the audit sheet. Should be its own task. |
+
+The Supabase shadow layer (Q1/Q5) is the *actual* durable, queryable flag surface in v1.
+
+### How 260812-isx folded its findings in — the pattern to copy
+
+[VERIFIED: `audit_billing_changes.py` read this session]
+
+1. New results bucket declared in the `audit_results` literal — `:185`
+   `"rate_sanity_mismatches": [],`
+2. New detector method — `:358` `def _detect_rate_sanity_mismatches(self, rows: List[Dict]) -> List[Dict]:`
+3. Wired as a numbered step in `audit_financial_data` between data-consistency and
+   suspicious-change detection — `:198-206` (comment verbatim: "2.5 Report-only rate-sanity
+   check (260812-isx): Units Total Price vs New Rates rate x Quantity. Never mutates rows,
+   pricing, grouping, filenames, hashes, or upload behavior.")
+4. Kill-switch read **per call**, not at import — `:376`
+   `if os.getenv("RATE_SANITY_AUDIT_ENABLED", "true").lower() != "true":`
+5. Summary keys added — `:493-496` `"total_rate_sanity_mismatches"`, `"rate_sanity_skipped"`
+6. Folded into `total_issues` → drives `risk_level` — `:502-507`:
+
+```python
+        total_issues = (
+            summary["total_anomalies"]
+            + summary["total_unauthorized_changes"]
+            + summary["total_data_issues"]
+            + summary["total_rate_sanity_mismatches"]
+        )
+```
+
+with thresholds `0 → LOW`, `<=3 → MEDIUM`, `else HIGH` (`:509-517`).
+
+### ⚠️ Known inconsistency the drift bucket must navigate
+
+`_generate_audit_summary`'s `total_issues` **includes** rate-sanity (`:502-507`), but two
+other "total issues" computations **do not**:
+
+- `_log_to_audit_sheet` `"Total Issues"` — [VERIFIED: `audit_billing_changes.py:599`]
+  `summary.get("total_anomalies",0) + summary.get("total_unauthorized_changes",0) + summary.get("total_data_issues",0)`
+- `_compute_trend` cur/prev issues — [VERIFIED: `audit_billing_changes.py:638-639`], same
+  3-term sum
+- `audit_financial_data`'s risk-history entry — [VERIFIED: `audit_billing_changes.py:244`],
+  same 3-term sum
+
+**Recommendation:** fold **only automation-self-fire holds** into `_generate_audit_summary`'s
+`total_issues` (so 4+ self-fires trip HIGH, matching the locked "flag HIGH" decision), and
+keep `manual` + `unclassified` drift as separate reported counters that do **not** inflate
+risk level. Otherwise a routine batch of legitimate manual edits would drive the whole run
+to HIGH and desensitise the signal. Do not "fix" the three-way total inconsistency in this
+task — it is pre-existing and out of scope.
+
+---
+
+## Q5 — Prior-Billed-Week Provenance: the v1 Seed
+
+No usable oracle exists (Q1). Cleanest v1, aligned with the locked decision:
+
+**New table `billing_audit.snapshot_provenance`, PK `(sheet_id, row_id)`**, appended to
+`billing_audit/schema.sql` for Juan to apply:
+
+| column | type | note |
+|---|---|---|
+| `sheet_id` | `BIGINT NOT NULL` | from `row['__source_sheet_id']` |
+| `row_id` | `BIGINT NOT NULL` | from `row['__row_id']` |
+| `wr` | `TEXT` | sanitized, per `_sanitized_wr` (`billing_audit/writer.py:418`) |
+| `cu` | `TEXT` | |
+| `snapshot_date` | `DATE` | last snapshot the row was billed under |
+| `billed_week` | `DATE` | last week the row was billed under |
+| `run_id` / `first_seen_at` / `last_seen_at` | `TEXT` / `TIMESTAMPTZ` | audit metadata |
+
+Drift detection then reduces to: `current_week != provenance.billed_week` → candidate.
+
+`snapshot_drift` (the event log from CONTEXT) is a **second, append-only** table keyed
+`(sheet_id, row_id, detected_at)` carrying prior/new snapshot + week, `changed_by`,
+`classification ∈ {automation_self_fire, manual, unclassified}`, `held BOOLEAN`, `run_id`.
+Splitting state (provenance) from events (drift) keeps the upsert idempotent and the audit
+trail complete.
+
+**First-run behaviour (mandatory): silent.** Absent baseline row ⇒ not drift ⇒ **no history
+call, no flag, no hold** — just seed the provenance row. This mirrors the existing fail-safe
+posture for `group_content_hash` [VERIFIED: `billing_audit/schema.sql:139-145`, verbatim:
+"the pipeline falls back to hash_history.json and behaves exactly as before (fail-safe to
+regenerate)"]. Same rule when the table is absent / PostgREST cache not reloaded / creds
+missing: `get_client()` returns `None` → whole feature no-ops.
+
+**Read pattern — bulk, never per-row.** Per-row Supabase reads are what caused the
+2026-04-24 log-spam / retry-exhaustion incident (ledger `[2026-04-24 10:50]`). Copy
+`prefetch_attribution` [VERIFIED: `billing_audit/writer.py:840`] / the
+`lookup_attribution_bulk(jsonb)` bulk shape [VERIFIED: `billing_audit/schema.sql:299`] — one
+select for all `(sheet_id,row_id)` in the run, then an in-memory dict lookup.
+
+**Write timing:** upsert provenance **after** grouping succeeds, in the same phase where
+`freeze_row` already iterates group rows [VERIFIED: `pipeline/orchestrate.py:1626`, `:1664`],
+or as one bulk upsert at end-of-run. Never inside the per-row loop as individual calls.
+
+---
+
+## Q6 — Budget / Ordering
+
+**Config** [VERIFIED: `pipeline/config.py:106`, verbatim]:
+
+```python
+TIME_BUDGET_MINUTES = int(os.getenv('TIME_BUDGET_MINUTES', '0') or 0)
+```
+
+and [VERIFIED: `pipeline/config.py:33`] `GITHUB_ACTIONS_MODE = os.getenv('GITHUB_ACTIONS') == 'true'`.
+
+**Anchor** [VERIFIED: `pipeline/orchestrate.py:416`]: `session_start = datetime.datetime.now()`.
+
+**Canonical pre-flight guard to copy** [VERIFIED: `pipeline/orchestrate.py:683-685`, verbatim]:
+
+```python
+            if TIME_BUDGET_MINUTES and GITHUB_ACTIONS_MODE:
+                _pre_elapsed_min = (datetime.datetime.now() - session_start).total_seconds() / 60.0
+                _remaining_min = TIME_BUDGET_MINUTES - _pre_elapsed_min
+```
+
+(the mid-loop stop variant is at `:1337-1344`).
+
+The drift seam sits at ~`:578` — **before** both attachment pre-fetch phases (`:683`, `:879`)
+and long before the generation loop. Budget consumed by then is only discovery + fetch +
+audit, so remaining budget is at its maximum. Recommended shape, mirroring the
+`ATTACHMENT_PREFETCH_MAX_MINUTES` family documented in `CLAUDE.md`:
+
+- `SNAPSHOT_DRIFT_AUDIT_ENABLED` (default `true`) — detection + Supabase logging
+- `SNAPSHOT_DRIFT_HOLD_ENABLED` (default **`false`**, its own switch per the locked
+  discretion note) — the gating action only
+- `SNAPSHOT_DRIFT_MAX_ROWS` (default `40`) — per-run classification cap
+- `SNAPSHOT_DRIFT_PACE_SEC` (default `2.0`) — inter-call sleep
+- `SNAPSHOT_DRIFT_MAX_MINUTES` (default `5`) — phase sub-budget **and** the pre-flight
+  threshold: if `_remaining_min < SNAPSHOT_DRIFT_MAX_MINUTES`, skip classification entirely
+  → every candidate becomes `unclassified` → flagged, never held
+
+Budget arithmetic: 40 rows × 2 calls × 2 s ≈ 160 s ≈ 2.7 min, leaving headroom inside a 5-min
+sub-budget for SDK backoff. Well inside the 30 req/min endpoint limit (≈30 req/min actual).
+
+---
+
+## Don't Hand-Roll
+
+| Problem | Don't Build | Use Instead | Why |
+|---|---|---|---|
+| Supabase retry / error classification | a new retry loop | `billing_audit.client.with_retry` + `_classify_postgrest_error` | run-global kill codes + Sentry breadcrumbs already tuned by the 2026-04-24 incident |
+| Supabase kill-switch | a new env flag for credentials | `get_client()` returning `None` | single fail-safe contract every writer inherits |
+| WR sanitization | `str(wr).split('.')[0]` inline | `billing_audit/writer.py:418` `_sanitized_wr` | collision-quarantine rules live there |
+| Checkbox truthiness | `bool(value)` | `writer._is_checked` / `pipeline.utils.is_checked` | Smartsheet returns str/bool/1 variably |
+| Date coercion | `dateutil.parser` directly | `excel_serial_to_date` / `writer._coerce_week_ending` | Excel serials + Smartsheet strings both appear |
+| Rate-limit backoff | a sleep-retry wrapper on Smartsheet | SDK `request_with_retry` **plus** explicit pacing | SDK covers `shouldRetry` only, and only for 30 s |
+
+---
+
+## Common Pitfalls (phase-specific)
+
+1. **Rewriting only the week field.** Row silently disappears from the Excel body
+   (`pipeline/excel.py:722-736`). Rewrite `Snapshot Date` too. *Warning sign:* group row
+   count > sum of day-table row counts.
+2. **Running the transform after grouping.** The five pre-pass readers
+   (`pipeline/grouping.py:170,234,289,360,417`) would see the drifted value while the main
+   loop sees the held value → VAC-claim reconciliation divergence. Insert at
+   `orchestrate.py:578`, never later.
+3. **Treating an API error as "not a self-fire" and holding anyway.** Locked rule: fail-open
+   on gating. Any exception, missing column id, cap exhaustion, or budget shortfall ⇒
+   `unclassified` ⇒ flag, no hold.
+4. **Per-row Supabase reads.** Reproduces the 2026-04-24 log-spam/retry-exhaustion incident.
+   Bulk only.
+5. **Flipping risk_level HIGH on manual-edit drift.** Fold only automation self-fires into
+   `total_issues`.
+6. **Assuming `_log_to_audit_sheet` writes to Smartsheet.** It does not.
+7. **First run holding everything.** No baseline ⇒ everything looks like drift if the
+   absent-baseline case isn't explicitly a no-op.
+
+---
+
+## Project Constraints (from CLAUDE.md)
+
+- `generate_weekly_pdfs.py` / the pipeline package is **production-critical**; additive,
+  surgical changes only. Preserve the Smartsheet → Excel → Smartsheet attachment pipeline.
+- Change-detection key `(WR, week, variant, foreman, dept, job)` — never shorten.
+- `safe_merge_cells()` only; never write `oddFooter.right.text`.
+- `PARALLEL_WORKERS ≤ 8` (Smartsheet 300 req/min).
+- Never use the Smartsheet `@cell` function in Python or API payloads.
+- `TIME_BUDGET_MINUTES` must stay strictly below the workflow's `timeout-minutes`.
+- PEP 8, type hints, 4-space indent, ≤79 char lines, PEP 257 docstrings.
+- Validate with `pytest tests/ -v` and `python -m py_compile generate_weekly_pdfs.py` before push.
+- Append a dated `[YYYY-MM-DD HH:MM]` entry to `memory-bank/living-ledger.md` in the same PR.
+- **Protected areas requiring Juan's approval:** Supabase schema/RLS changes (the new DDL —
+  already acknowledged in CONTEXT), and any new mutating Smartsheet write (audit-sheet
+  Option B).
+
+---
+
+## Package Legitimacy Audit
+
+**N/A — this task adds no new third-party packages.** Every dependency it needs is already
+declared and in use: `smartsheet-python-sdk==4.3.0` [VERIFIED: `requirements.txt:9`] and the
+`supabase` client already consumed by `billing_audit/client.py:270` (`from supabase import
+create_client`). No `pip install` step should appear in the plan; if one does, run the
+legitimacy gate then.
+
+---
+
+## Validation Architecture
+
+| Property | Value |
+|---|---|
+| Framework | pytest (per `CLAUDE.md`; `tests/` suite, ~1101 tests at Phase 09 close) |
+| Quick run | `pytest tests/test_snapshot_drift_audit.py -v` (new file) |
+| Full suite | `pytest tests/ -v` |
+| Syntax gate | `python -m py_compile generate_weekly_pdfs.py` |
+
+Wave-0 gaps: `tests/test_snapshot_drift_audit.py` does not exist. Model it on
+`tests/test_rate_sanity_audit.py` (the 260812-isx RED-first suite, which instantiates
+`BillingAudit(client=None, skip_cell_history=True)` at `:51` — a working no-network fixture
+pattern) and on `tests/test_billing_audit_shadow.py` for the Supabase writer mocks.
+
+Minimum RED-first cases: (1) no baseline ⇒ no drift, no history call, provenance seeded;
+(2) week unchanged ⇒ zero history calls; (3) automation self-fire ⇒ held + both fields
+rewritten + HIGH; (4) manual edit ⇒ flagged, NOT held; (5) API raises ⇒ `unclassified`, not
+held; (6) cap/budget exhausted ⇒ `unclassified`; (7) kill-switches off ⇒ byte-identical
+prior behaviour; (8) held row survives `generate_excel`'s Monday–Sunday snapshot filter;
+(9) held row's W1 content hash is stable across the drift.
+
+---
+
+## Assumptions Log
+
+| # | Claim | Section | Risk if Wrong |
+|---|---|---|---|
+| A1 | `IndexResult[CellHistory].data` ordering and `modified_by.email` shape | Q3 | Classifier reads the wrong entry → wrong hold decision. Mitigate: sort by `modified_at` in code, read email via `getattr`. **Verify against one live cell before locking the classifier.** |
+| A2 | `'Units Completed?'` is mapped in `column_mapping` on all discovered sheets | Q3 | Missing column id → classification impossible on that sheet. Mitigate: explicit presence check → `unclassified`. |
+| A3 | Smartsheet cell-history endpoint limit is 30 req/min | Q3/Q6 | Sourced from the ledger `[2026-08-12 13:40]` operator note, not from Smartsheet docs this session. If lower, pacing must widen. |
+| A4 | `automation@smartsheet.com` is the literal `modified_by` email for automation writes | Q3 | Classifier never matches → everything `unclassified` (fail-open, so safe but useless). Verify on one known-drifted row. |
+| A5 | Snapshot-Date cell histories are short enough for `include_all=True` in one request | Q3 | Extra pages → extra requests → cap math off. Mitigate: `page_size` + read only the newest page. |
+
+---
+
+## FEASIBILITY VERDICT
+
+### (a) Detection + flagging + Supabase shadow — **FEASIBLE**
+Clean additive path end-to-end: seam at `pipeline/orchestrate.py:578`, provenance/event
+tables appended to `billing_audit/schema.sql` (manual apply, matching the locked decision),
+writer modeled on `lookup_group_hash`/`upsert_group_hash`, and the 260812-isx audit-wiring
+pattern for summary/kill-switch. Detection itself costs **zero** extra API calls.
+**Top risk:** `_log_to_audit_sheet` is a no-op placeholder (`audit_billing_changes.py:611-614`)
+— "flag on the billing audit sheet" is log-only unless a new mutating `AUDIT_SHEET_ID` write
+is built, which is a protected-area change needing Juan's approval and `SKIP_UPLOAD` gating.
+Scope v1 to the Supabase surface + log line.
+
+### (b) Automation-vs-manual classification within rate limits — **FEASIBLE-WITH-CAVEATS**
+`Cells.get_cell_history(sheet_id, row_id, column_id, include_all=True)` exists in SDK 4.3.0;
+`__source_sheet_id`/`__row_id` are on every row (`pipeline/fetch.py:317-331`) and column ids
+are in `source['column_mapping']` (`pipeline/discovery.py:615`), both in scope at the seam.
+40 rows × 2 calls × 2 s ≈ 2.7 min fits a 5-min sub-budget.
+**Top risk:** entirely greenfield — no cell-history call exists in this repo to copy, and the
+SDK's retry budget is only `max_retry_time=30` seconds of exponential backoff, so it will
+**not** absorb the 30 req/min throttle. Self-pacing is mandatory, and A1/A4 (history ordering,
+`modified_by` email shape) must be verified against one live drifted row before the classifier
+is locked. Fail-open to `unclassified` keeps every unknown safe.
+
+### (c) Hold-prior-week gating — **FEASIBLE-WITH-CAVEATS**
+A genuinely narrow additive seam exists: one pre-grouping row transform at
+`pipeline/orchestrate.py:578`, upstream of the single week computation at
+`pipeline/grouping.py:440/463`, with **zero edits inside `grouping.py`** and no
+double-count risk (the row is rewritten before it can reach any group).
+**Top risk:** the override must rewrite **both** `Weekly Reference Logged Date` **and**
+`Snapshot Date`. Rewriting only the week leaves the row inside the W1 group but outside
+`generate_excel`'s Monday–Sunday snapshot filter (`pipeline/excel.py:711-736`), silently
+deleting it from the workbook body — a worse outcome than the drift. Restoring both fields
+also re-stabilises the W1 content hash (`pipeline/change_detection.py:143,169`), eliminating
+regeneration churn. Ship with `SNAPSHOT_DRIFT_HOLD_ENABLED` defaulting **off**, separate from
+the detection switch.
+
+---
+
+## Sources
+
+### Primary (HIGH — files opened this session)
+- `pipeline/orchestrate.py` (:416, :525-585, :683-685, :1337-1344, :1461, :1500, :1626-1664)
+- `pipeline/grouping.py` (:425-484, :1150-1189)
+- `pipeline/excel.py` (:690-749)
+- `pipeline/change_detection.py` (:105-184)
+- `pipeline/fetch.py` (:300-349)
+- `pipeline/config.py` (:33, :106, :246-257)
+- `pipeline/discovery.py` (:436-489, :615)
+- `audit_billing_changes.py` (:115-266, :440-520, :580-691)
+- `billing_audit/client.py` (:221-300)
+- `billing_audit/writer.py` (:460-620, :840, :1144-1264)
+- `billing_audit/schema.sql` (:1-250)
+- `requirements.txt` (:9)
+- Installed `smartsheet-python-sdk` 4.3.0 — `cells.py`, `smartsheet.py`,
+  `models/cell_history.py`, `models/error_result.py` (read via `inspect` this session)
+- `memory-bank/living-ledger.md` `[2026-08-12 13:40]`, `[2026-08-12 14:05]`,
+  `[2026-04-24 10:50]`
+- `.planning/quick/260812-jqx-.../260812-jqx-CONTEXT.md`, `.planning/STATE.md`, `CLAUDE.md`
+
+### Not consulted
+No web/Context7 lookups were needed — every question resolved against in-repo source or the
+installed SDK. Smartsheet's published cell-history rate limit (A3) and the automation
+`modified_by` identity (A4) remain operator-sourced, not doc-verified.
+
+---
+
+## Metadata
+
+**Confidence breakdown:**
+- Supabase shadow layer + additive migration path: **HIGH** — schema.sql and client/writer read verbatim
+- Hold-prior-week seam + both-fields requirement: **HIGH** — grouping, orchestrate, excel, and change_detection all read at the exact lines
+- Cell-history mechanics: **MEDIUM** — SDK source verified, live response shape assumed (A1, A4, A5)
+- Audit-sheet output path: **HIGH** — placeholder status verified verbatim
+- Rate-limit numbers: **MEDIUM** — SDK backoff verified; 30 req/min endpoint limit is operator-sourced (A3)
+
+**Research date:** 2026-08-12
+**Valid until:** 2026-09-11 (stable in-repo domain; re-verify if the SDK pin or `billing_audit/schema.sql` changes)

--- a/.planning/quick/260812-jqx-snapshot-date-drift-audit-detect-snapsho/260812-jqx-REVIEW.md
+++ b/.planning/quick/260812-jqx-snapshot-date-drift-audit-detect-snapsho/260812-jqx-REVIEW.md
@@ -1,0 +1,311 @@
+---
+phase: quick-260812-jqx
+reviewed: 2026-08-12T21:44:27Z
+depth: standard
+files_reviewed: 7
+files_reviewed_list:
+  - pipeline/snapshot_drift.py
+  - billing_audit/snapshot_store.py
+  - billing_audit/schema.sql
+  - pipeline/config.py
+  - pipeline/orchestrate.py
+  - audit_billing_changes.py
+  - tests/test_snapshot_drift_audit.py
+findings:
+  critical: 2
+  warning: 5
+  info: 7
+  total: 14
+status: issues_found
+---
+
+# Quick Task 260812-jqx: Code Review Report
+
+**Reviewed:** 2026-08-12T21:44:27Z
+**Depth:** standard (with cross-file tracing into pipeline/excel.py, pipeline/grouping.py, billing_audit/client.py, billing_audit/writer.py)
+**Files Reviewed:** 7
+**Status:** issues_found
+**Diff range:** 3f7be82..HEAD (55329a1, c58a9bd, 0a68aeb, 0b5051a)
+
+## Summary
+
+The snapshot-date drift audit is well-structured: detection defaults on
+/ hold defaults off (verified at `pipeline/snapshot_drift.py:490-493`
+and `pipeline/config.py`), holds apply only to `automation_self_fire`
+candidates, cell-history lookups are capped at 40 rows with 2s pacing
+and a session sub-budget, schema changes are additive-only, no new
+AUDIT_SHEET_ID writes exist, and the outer entry point never raises.
+All 27 new tests pass (`pytest tests/test_snapshot_drift_audit.py`,
+31.66s).
+
+However, two Critical defects break the audit's own invariants:
+(CR-01) a transient Supabase read failure causes the run to re-seed and
+**overwrite every existing provenance baseline** with the current week
+— silently laundering any in-flight drift and violating the
+fail-closed-logging half of D-03; and (CR-02) a hold applied to a row
+whose baseline `snapshot_date` is NULL writes `None` into
+`Snapshot Date`, which the Excel day-block filter
+(`pipeline/excel.py:723-729`) then silently drops from the workbook —
+the exact "strictly worse than the drift itself" failure the module's
+own docstring warns against (RESEARCH pitfall 1).
+
+## Narrative Findings (AI reviewer)
+
+### Critical Issues
+
+#### CR-01: Provenance upsert not gated on fetch status — transient read failure poisons every baseline
+
+**File:** `pipeline/snapshot_drift.py:507-514, 530-537, 600-606` (with `billing_audit/snapshot_store.py:126-153`)
+**Issue:** When the bulk provenance read fails transiently
+(`with_retry` exhaustion or an open read-op circuit breaker →
+`status == "fetch_failure"`), `baseline_map` is `{}` and **every** row
+degrades to the first-sight seed path. The subsequent
+`upsert_snapshot_provenance(provenance_records)` at line 601 is not
+gated on `status` — and unlike the `unavailable` case (client is
+`None`, upsert no-ops), a transient read failure leaves the write path
+healthy (`with_retry` circuit breakers are per-op by design, see
+`billing_audit/client.py`). The upsert therefore OVERWRITES every
+existing baseline's `billed_week` with the row's *current* computed
+week and resets `first_seen_at` to now. Any drift that occurred before
+that run is silently accepted as the new baseline: no candidate, no
+`snapshot_drift` event, no future detection. One bad read window
+rebases the entire provenance table and defeats the audit's fail-closed
+logging guarantee (D-03). `TestTask1FetchRaisesDegradesToSeed` asserts
+the seed degrade but never checks that the upsert is suppressed, so the
+bug is test-endorsed.
+**Fix:**
+```python
+# apply_snapshot_drift_holds, after building records:
+try:
+    if status in ("success", "no_row"):
+        _store.upsert_snapshot_provenance(provenance_records)
+    else:
+        logger.warning(
+            "⚠️ Snapshot-drift provenance upsert skipped: bulk read "
+            "status=%s (avoid rebasing existing baselines).", status,
+        )
+except Exception:
+    ...
+```
+Add a test: fetch returns `({}, "fetch_failure")` → `mock_upsert.assert_not_called()`.
+
+#### CR-02: Hold with NULL prior `snapshot_date` silently drops the billed row from the workbook
+
+**File:** `pipeline/snapshot_drift.py:461` (with `pipeline/excel.py:723-729`)
+**Issue:** `_apply_holds` rewrites
+`row["Snapshot Date"] = _iso_date_str(candidate["prior_snapshot_date"])`.
+The provenance baseline's `snapshot_date` is nullable
+(`billing_audit/schema.sql`: `snapshot_date DATE` with no NOT NULL) and
+is NULL whenever a row was seeded while its `Snapshot Date` cell was
+blank or unparseable — an *observed* production state: rows with a
+`Weekly Reference Logged Date` but no snapshot because "Smartsheet's
+snapshot automation has not fired yet (the observed VAC crew failure
+mode)" (`pipeline/utils.py:85-90`). For such a candidate, the hold sets
+`Snapshot Date` to `None`; grouping places the row in the prior week,
+but `generate_excel`'s Monday–Sunday day-block filter does
+`excel_serial_to_date(snap) is None → continue`, so the held row is
+**silently excluded from the workbook body** — a billing-visible row
+drop, the exact failure the module docstring names RESEARCH pitfall 1.
+`TestTask3HeldRowSurvivesExcelFilter` only covers the non-NULL prior
+snapshot case. Gated today by `SNAPSHOT_DRIFT_HOLD_ENABLED=false`, but
+this is the feature's primary path once the flag is turned on per the
+plan.
+**Fix:**
+```python
+# _apply_holds, before mutating the row:
+prior_snapshot = _coerce_date(candidate["prior_snapshot_date"])
+if prior_snapshot is None:
+    logging.warning(
+        "⚠️ Snapshot-drift hold skipped for WR %s row %s: no prior "
+        "snapshot date on baseline (row would be dropped by the "
+        "Excel week filter).",
+        candidate["wr"], candidate["row_id"],
+    )
+    continue  # classify + log only; never hold
+row["Snapshot Date"] = prior_snapshot.isoformat()
+```
+Add a test: baseline with `snapshot_date=None`, hold enabled → row not
+mutated (or mutated with a non-None fallback), and the drift event
+still recorded.
+
+### Warnings
+
+#### WR-01: `automation_self_fire` classification granted without timestamp corroboration
+
+**File:** `pipeline/snapshot_drift.py:316-328`
+**Issue:** When the newest Snapshot Date history entry has a missing or
+unparseable `modified_at` (`newest_ts is None`), the ±2-minute
+units-change window cannot be evaluated. `nearby_units_change` stays
+`False`, so an automation-identity write is classified
+`automation_self_fire` — i.e. hold-eligible — on incomplete evidence.
+The conservative direction (D-03/D-05: hold only on solid evidence) is
+`unclassified`.
+**Fix:** After computing `newest_ts`, add:
+```python
+if newest_ts is None:
+    return _CLASSIFICATION_UNCLASSIFIED, newest_email
+```
+
+#### WR-02: Bulk provenance read uses two `.in_` filters — URL-length growth and cross-product over-fetch
+
+**File:** `billing_audit/snapshot_store.py:79-91`
+**Issue:** `.in_("sheet_id", sheet_ids).in_("row_id", row_ids)` puts
+~550 row IDs + 13 sheet IDs into a GET querystring (~10KB today,
+growing linearly with row count toward PostgREST/proxy URL limits) and
+matches the sheet×row cross-product server-side (any row whose row_id
+collides across sheets is fetched and discarded by the client-side
+`wanted` filter — correct, but wasted transfer). The repo already
+solved this exact class of bulk-lookup with the
+`billing_audit.lookup_attribution_bulk(jsonb)` RPC
+(`billing_audit/schema.sql:~300-330`).
+**Fix:** Add a `lookup_snapshot_provenance_bulk(jsonb)` RPC taking
+`[(sheet_id, row_id), ...]` pairs (POST body, exact-key match), or at
+minimum document the row-count ceiling and chunk the `.in_` lists.
+
+#### WR-03: New tables ship without Row Level Security
+
+**File:** `billing_audit/schema.sql` (appended `snapshot_provenance` / `snapshot_drift` blocks)
+**Issue:** Both new tables rely on grants alone (`service_role` only)
+while the `billing_audit` schema is PostgREST-exposed — the block's own
+operator note instructs confirming schema exposure. This matches the
+existing posture of the other `billing_audit` tables (no
+RLS anywhere in the file), but for *new* tables
+`ALTER TABLE ... ENABLE ROW LEVEL SECURITY` with no policies is a free
+defense-in-depth line: `service_role` bypasses RLS, and `anon`/
+`authenticated` stay locked out even if default privileges or a future
+grant leak. Additive, touches nothing existing.
+**Fix:**
+```sql
+ALTER TABLE billing_audit.snapshot_provenance ENABLE ROW LEVEL SECURITY;
+ALTER TABLE billing_audit.snapshot_drift ENABLE ROW LEVEL SECURITY;
+```
+(Manual apply by Juan alongside the CREATE TABLE blocks — Supabase
+schema changes remain his approval per production guardrails.)
+
+#### WR-04: Test file spends ~25-30s in real `time.sleep` on every suite run
+
+**File:** `tests/test_snapshot_drift_audit.py` (classifier/hold tests; base class at :289-304)
+**Issue:** Only `TestTask2PacingBetweenCalls` mocks
+`pipeline.snapshot_drift.time.sleep`. Every other test that drives two
+cell-history calls (self-fire, nearby-units, per-run cap, ordering
+independence ×2, modified-by shapes, all five Task-3 hold tests, the
+three-outcome event test) pays a real 2.0s pacing sleep. Measured: 27
+tests take **31.66s** wall (nearly all sleep). This silently inflates
+every `pytest tests/` run — the pre-push gate — by half a minute.
+**Fix:** Set `SNAPSHOT_DRIFT_PACE_SEC=0` in
+`SnapshotDriftClassifierTestBase.setUp` (via
+`mock.patch.dict(os.environ, ...)` + `addCleanup`); have
+`TestTask2PacingBetweenCalls` set it explicitly to `2.0` since it
+asserts `call.args[0] == 2.0`.
+
+#### WR-05: `billing_audit/snapshot_store.py` has zero direct test coverage
+
+**File:** `billing_audit/snapshot_store.py` (all three public functions)
+**Issue:** Every test patches `fetch_snapshot_provenance`,
+`upsert_snapshot_provenance`, and `insert_snapshot_drift_events` at the
+module boundary. The only code in this change that performs live
+Supabase I/O — the `.in_` query construction, the `wanted`-set
+filtering, the dict-shaped response normalization (:98-99), the
+`int()` key coercion (:105-108), and the four-value status vocabulary —
+is exercised by nothing. A regression there (e.g. a supabase-py builder
+change) would pass the whole suite.
+**Fix:** Add a small test module mocking `get_client()`/`with_retry`
+that asserts: key filtering drops cross-product rows, dict response is
+normalized to a list, `None` response → `fetch_failure`, empty data →
+`no_row`, and client-None with/without `_global_disable_reason` →
+`unavailable`/`fetch_failure`.
+
+### Info
+
+#### IN-01: `datetime.datetime.utcnow()` is deprecated
+
+**File:** `pipeline/snapshot_drift.py:120`
+**Issue:** Emits `DeprecationWarning` on Python 3.12 (CI runtime).
+**Fix:** `datetime.datetime.now(datetime.timezone.utc).strftime(...)`.
+
+#### IN-02: Mixed root-`logging` and module-`logger` calls
+
+**File:** `pipeline/snapshot_drift.py:373, 466, 615` (root) vs `:330, 603, 610, 626` (module logger)
+**Issue:** Same module logs through two different loggers; filtering or
+handler configuration will treat them inconsistently.
+**Fix:** Standardize on the module `logger`.
+
+#### IN-03: Env-var defaults defined in two places
+
+**File:** `pipeline/config.py:128-172` and `pipeline/snapshot_drift.py:351-354, 490-493`
+**Issue:** The config constants are documentation-only by design
+(module re-reads env per call), but each default is now hardcoded in
+both files (`40`, `2.0`, `5`, `'automation@smartsheet.com'`, switch
+defaults). A future change to one side silently diverges the other.
+**Fix:** Single module-level defaults dict in `snapshot_drift.py` that
+`config.py` references (or a comment cross-pinning the pairs).
+
+#### IN-04: `changed_by` email logged at INFO into CI run logs
+
+**File:** `pipeline/snapshot_drift.py:466-473`
+**Issue:** Every hold logs the modified-by email into GitHub Actions
+logs. Consistent with existing log posture (foreman names, WRs), but
+the repo's own rationale for `SENTRY_ENABLE_LOGS=false` is that
+INFO-path logs can embed row PII — worth a deliberate choice here.
+**Fix:** Consider logging only the classification and moving the email
+to the Supabase event row (already captured there).
+
+#### IN-05: `fetch_snapshot_provenance` "NEVER raises" contract has a hole
+
+**File:** `billing_audit/snapshot_store.py:71-81`
+**Issue:** The `_client_mod._global_disable_reason` peek (private-attr
+reach-in), `get_client()`, and the key-coercion comprehensions run
+*outside* the try/except; an exception there escapes despite the
+docstring's NEVER-raises claim. The caller in `snapshot_drift.py`
+wraps it (:507-512), so it is contained in practice.
+**Fix:** Move the client/keys setup inside the try, or expose a public
+`is_globally_disabled()` helper on `billing_audit.client`.
+
+#### IN-06: No runbook/changelog entry for operator-visible surface
+
+**File:** (docs gap — `website/` untouched in 3f7be82..HEAD)
+**Issue:** This change adds six operator-facing env vars, two Supabase
+tables requiring a manual SQL-editor apply + PostgREST cache reload,
+and a new hold behavior — the documentation-maintenance rule requires a
+synthesized runbook changelog entry, and the sibling quick task
+(260812-isx, commit e003124) set the precedent. The schema.sql header
+carries the operator steps, and `docs-changelog.yml` will append a
+stub on merge.
+**Fix:** Expand the stub into a proper entry (what/why/operator impact,
+including the manual DDL step and the hold-flag rollout plan) before
+the next release.
+
+#### IN-07: Risk thresholds duplicated between `_generate_audit_summary` and `escalate_risk_for_snapshot_drift`
+
+**File:** `audit_billing_changes.py:508-517` and `:695-747`
+**Issue:** The 0 / ≤3 / else risk ladder is re-derived post-hoc
+(self-documented, and verified safe today: `risk_level` has no other
+writers and the escalated total is strictly ≥ the original, so no
+downgrade is possible). A future threshold change in one place will
+silently diverge the other.
+**Fix:** Extract a shared `_risk_level_for(total_issues: int) -> str`
+used by both.
+
+## Invariant Verification (production context)
+
+| Invariant | Status |
+|---|---|
+| Report-only by default (`SNAPSHOT_DRIFT_HOLD_ENABLED` default false) | PASS (`config.py`, `snapshot_drift.py:493`) |
+| Holds only for automation self-fires, never manual/unclassified | PASS (`_apply_holds:445`, tests Task3 Manual/Unclassified) |
+| Fail-open gating / errors never block billing | PASS (outer catch-all `:623-631`, orchestrate seam try/except `:586-620`) |
+| Fail-closed logging (every candidate recorded) | **FAIL under transient fetch failure** — see CR-01 (drift laundered into baseline with no event) |
+| Cell-history ≤ 40 rows, ~2s paced, week-movers only | PASS (`SNAPSHOT_DRIFT_MAX_ROWS=40`, `pace_sec=2.0`, candidates = week-movers only) |
+| schema.sql additive only | PASS (append-only diff; `CREATE TABLE IF NOT EXISTS`) |
+| No new mutating AUDIT_SHEET_ID writes | PASS (no Smartsheet writes anywhere in the new code) |
+| PARALLEL_WORKERS ≤ 8 / 300 req/min | PASS (classification is serial + paced) |
+| No `@cell` in API payloads | PASS |
+
+**Validation evidence:** `pytest tests/test_snapshot_drift_audit.py -q`
+→ 27 passed, 2 subtests, 31.66s. `python -m py_compile` on all five
+touched Python files → OK.
+
+---
+
+_Reviewed: 2026-08-12T21:44:27Z_
+_Reviewer: Claude (gsd-code-reviewer)_
+_Depth: standard_

--- a/.planning/quick/260812-jqx-snapshot-date-drift-audit-detect-snapsho/260812-jqx-SUMMARY.md
+++ b/.planning/quick/260812-jqx-snapshot-date-drift-audit-detect-snapsho/260812-jqx-SUMMARY.md
@@ -1,0 +1,224 @@
+---
+phase: quick-260812-jqx
+plan: 01
+subsystem: billing-pipeline
+tags: [smartsheet, supabase, billing-audit, snapshot-date, defence-in-depth]
+
+# Dependency graph
+requires:
+  - phase: quick-260812-isx
+    provides: report-only rate-sanity audit pattern (RED-first tests, per-call kill-switch reads, audit_results summary wiring) reused here
+provides:
+  - Snapshot-date drift detection with zero extra Smartsheet API calls (billed-week baseline in a new Supabase shadow table)
+  - Cell-history classifier distinguishing automation self-fires from manual edits, capped/paced/budget-aware
+  - Hold-prior-week override for automation self-fires only, rewriting both Weekly Reference Logged Date and Snapshot Date
+  - Post-hoc audit risk_level escalation wired to automation self-fire hold counts only
+affects: [billing-audit, smartsheet-automation-fixes, audit-sheet-write-followup]
+
+# Actuals (#2632)
+actuals:
+  tokens: 21612
+  tasks: 3
+  commits: 4
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "Pre-grouping seam in pipeline/orchestrate.py for row-transform passes that must run upstream of grouping.py without editing it"
+    - "Bulk Supabase read/write via billing_audit.snapshot_store, mirroring lookup_group_hash/upsert_group_hash's fail-safe contract"
+    - "Per-call os.getenv reads for kill-switches (not frozen pipeline.config constants) so tests can toggle without reloading a module"
+    - "Fail-open classification / fail-closed logging: every candidate is recorded even when gating declines to act"
+
+key-files:
+  created:
+    - pipeline/snapshot_drift.py
+    - billing_audit/snapshot_store.py
+    - tests/test_snapshot_drift_audit.py
+  modified:
+    - billing_audit/schema.sql
+    - pipeline/config.py
+    - pipeline/orchestrate.py
+    - audit_billing_changes.py
+    - memory-bank/living-ledger.md
+
+key-decisions:
+  - "Hold-prior-week gate ships default OFF (SNAPSHOT_DRIFT_HOLD_ENABLED); only automation self-fires on an already-billed row are eligible for a hold; manual edits are NEVER held"
+  - "Fail-open gating (unclassifiable drift is flagged, never held), fail-closed logging (every candidate — held, manual, or unclassified — is written to the Supabase event table)"
+  - "Cell-history spend is capped at ~40 rows/run, self-paced ~2s between calls, and gated by a session sub-budget with a pre-flight guard"
+  - "New additive Supabase tables (snapshot_provenance, snapshot_drift) appended to billing_audit/schema.sql for manual apply by Juan — the pipeline never runs DDL"
+  - "No new mutating AUDIT_SHEET_ID write in v1 — _log_to_audit_sheet stays the pre-existing no-op placeholder; the durable flag surface is the Supabase shadow layer plus the run log"
+  - "Added a post-seam Sentry warning capture when any hold is applied (plan-check follow-up, not in the original task text)"
+
+patterns-established:
+  - "Row-transform seam pattern: insert a self-contained pass between the audit block and grouping in orchestrate.py, own try/except, zero edits to grouping.py/excel.py"
+  - "Hold overrides that affect billing week MUST rewrite every field that downstream code keys off — Weekly Reference Logged Date (grouping) AND Snapshot Date (Excel day-table filter, content hash, sort key) together, never just one"
+
+requirements-completed: [QT-260812-jqx]
+
+coverage:
+  - id: D1
+    description: "Detect rows whose computed billing week differs from their recorded prior billed week, using zero extra Smartsheet API calls"
+    requirement: "QT-260812-jqx"
+    verification:
+      - kind: unit
+        ref: "tests/test_snapshot_drift_audit.py::TestTask1WeekDriftIsACandidate#test_drifted_week_emits_candidate_without_mutation"
+        status: pass
+      - kind: unit
+        ref: "tests/test_snapshot_drift_audit.py::TestTask1WeekUnchangedCostsNothing#test_unchanged_week_costs_zero_api_calls"
+        status: pass
+    human_judgment: false
+  - id: D2
+    description: "Classify each drift candidate as automation self-fire vs manual via targeted cell-history lookups, capped/paced/budget-aware, fail-open on any error"
+    requirement: "QT-260812-jqx"
+    verification:
+      - kind: unit
+        ref: "tests/test_snapshot_drift_audit.py::TestTask2AutomationSelfFire#test_automation_write_no_nearby_units_change_is_self_fire"
+        status: pass
+      - kind: unit
+        ref: "tests/test_snapshot_drift_audit.py::TestTask2ApiErrorIsUnclassified#test_get_cell_history_raises_is_unclassified"
+        status: pass
+      - kind: unit
+        ref: "tests/test_snapshot_drift_audit.py::TestTask2BudgetGuardSkipsAll#test_low_remaining_budget_skips_classification_entirely"
+        status: pass
+    human_judgment: false
+  - id: D3
+    description: "Hold automation self-fires at their prior billed week (both Weekly Reference Logged Date and Snapshot Date), never manual/unclassified; row survives the Excel Monday-Sunday filter and the prior week's content hash is stable"
+    requirement: "QT-260812-jqx"
+    verification:
+      - kind: unit
+        ref: "tests/test_snapshot_drift_audit.py::TestTask3HoldRewritesBothFields#test_hold_rewrites_both_fields_and_preserves_originals"
+        status: pass
+      - kind: integration
+        ref: "tests/test_snapshot_drift_audit.py::TestTask3HeldRowSurvivesExcelFilter#test_held_row_appears_in_generated_workbook"
+        status: pass
+      - kind: unit
+        ref: "tests/test_snapshot_drift_audit.py::TestTask3PriorWeekHashStability#test_hash_stable_across_drift_and_hold_both_modes"
+        status: pass
+      - kind: unit
+        ref: "tests/test_snapshot_drift_audit.py::TestTask3ManualNeverMutated#test_manual_candidate_never_mutated_even_with_hold_enabled"
+        status: pass
+    human_judgment: false
+  - id: D4
+    description: "Only automation self-fire holds escalate audit risk_level; manual/unclassified drift is recorded but never inflates risk"
+    requirement: "QT-260812-jqx"
+    verification:
+      - kind: unit
+        ref: "tests/test_snapshot_drift_audit.py::TestTask3RiskEscalation#test_four_holds_escalate_to_high"
+        status: pass
+      - kind: unit
+        ref: "tests/test_snapshot_drift_audit.py::TestTask3RiskEscalation#test_zero_holds_leaves_risk_level_unchanged"
+        status: pass
+    human_judgment: false
+  - id: D5
+    description: "Live operator verification of assumptions A1 (cell-history entry ordering) and A4 (automation modified_by email) against one known-drifted Smartsheet row, before enabling SNAPSHOT_DRIFT_HOLD_ENABLED in the workflow"
+    verification: []
+    human_judgment: true
+    rationale: "Requires a live SMARTSHEET_API_TOKEN and a real known-drifted row in production Smartsheet data — unavailable in this execution environment. Recorded as an open item in .planning/WINDOWS.md (kind unrun-verify)."
+
+# Metrics
+duration: 38min
+completed: 2026-08-12
+status: complete
+---
+
+# Quick Task 260812-jqx: Snapshot-Date Drift Audit Summary
+
+**Defence-in-depth Smartsheet snapshot-date drift detector that classifies automation self-fires vs manual edits via targeted cell-history lookups and holds only the automation self-fires at their prior billed week, with zero grouping.py/excel.py edits and both kill-switches defaulting to safe values.**
+
+## Performance
+
+- **Duration:** 38 min (planning-doc commit to final code commit)
+- **Started:** 2026-08-12T15:48:58-05:00
+- **Completed:** 2026-08-12T16:26:10-05:00
+- **Tasks:** 3
+- **Files modified:** 8 (3 created, 5 modified)
+
+## Accomplishments
+
+- Detects rows whose computed billing week differs from a durable per-row baseline in a new additive Supabase table, at zero extra Smartsheet API cost for non-drifted rows, seeding silently on first sight
+- Classifies week-movers ONLY via targeted `Cells.get_cell_history` lookups (Snapshot Date + Units Completed?, ≤40 rows/run, ~2s self-paced, session-budget-aware), fail-open to `unclassified` on any error
+- Holds automation self-fires at their prior billed week by rewriting BOTH `Weekly Reference Logged Date` and `Snapshot Date` — verified the held row survives `generate_excel`'s Monday-Sunday day-table filter and the prior week's content hash stays byte-stable in both legacy and extended change-detection modes
+- Manual edits and unclassifiable drift are recorded but NEVER held, even with the hold gate enabled
+- Only automation self-fire holds escalate the audit `risk_level`; four holds trip HIGH, four manual + four unclassified drifts leave it unchanged
+- Added a post-seam Sentry warning capture when any hold is applied (plan-check follow-up)
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: End-to-end drift detection — one path, zero Smartsheet API calls** - `55329a1` (feat)
+2. **Task 2: Cell-history classifier with pacing, cap, and sub-budget** - `c58a9bd` (feat)
+3. **Task 3: Hold-prior-week override (both fields) + audit risk wiring** - `0a68aeb` (feat)
+
+**Plan metadata:** (this commit, below)
+
+_Note: TDD-per-task — each task's tests were written first and run RED before implementation, then re-run GREEN before commit._
+
+## Files Created/Modified
+
+- `pipeline/snapshot_drift.py` - `apply_snapshot_drift_holds()`: detection, classification, and the hold override — the single place drift logic lives
+- `billing_audit/snapshot_store.py` - Bulk provenance read/upsert + batched drift-event insert, fail-safe (never raises)
+- `billing_audit/schema.sql` - Appended `billing_audit.snapshot_provenance` + `billing_audit.snapshot_drift` DDL (manual apply by Juan)
+- `pipeline/config.py` - Six `SNAPSHOT_DRIFT_*` env-var switches declared next to the `TIME_BUDGET_MINUTES` family
+- `pipeline/orchestrate.py` - One call site at the pre-grouping seam, plus the post-classification summary merge and Sentry capture
+- `audit_billing_changes.py` - `total_snapshot_drift_holds` placeholder + `escalate_risk_for_snapshot_drift()`
+- `tests/test_snapshot_drift_audit.py` - 27 tests across all three tasks, all RED-first
+- `memory-bank/living-ledger.md` - Dated `[2026-08-12 15:30]` entry
+
+## Decisions Made
+
+- **Hold gate ships default OFF.** `SNAPSHOT_DRIFT_HOLD_ENABLED` defaults `false`; only detection + Supabase shadow-logging (`SNAPSHOT_DRIFT_AUDIT_ENABLED`, default `true`) is live by default. Flipping the hold gate on in the workflow is a deliberate follow-up operator action after live verification (see D5 above).
+- **Fail-open on gating, fail-closed on logging.** Any classification failure (API error, missing column id, cap exhausted, budget short) becomes `unclassified` — flagged, never held. Every candidate, regardless of outcome, is still written to the append-only `billing_audit.snapshot_drift` table.
+- **Both-fields hold rewrite is non-negotiable.** `Weekly Reference Logged Date` alone controls grouping, but `Snapshot Date` alone controls `generate_excel`'s Monday-Sunday day-table bucket AND the content hash / sort key in `change_detection.py`. Rewriting only one silently excludes the row from the workbook body — verified via a real `generate_excel` integration test and a hash-stability test in both change-detection modes.
+- **Only self-fire holds feed `risk_level`.** `escalate_risk_for_snapshot_drift(summary, self_fire_holds)` takes ONLY the hold count as input by construction — manual/unclassified drift can never reach risk escalation, correct-by-construction rather than by a filtering condition that could be edited away.
+- **Per-call env reads, not frozen config constants.** All six switches are read via `os.getenv(...)` inside `pipeline/snapshot_drift.py` at call time (mirroring the `RATE_SANITY_AUDIT_ENABLED` pattern from 260812-isx) so tests can toggle any switch without reloading a module. The matching `pipeline/config.py` constants exist for documentation/discoverability but are not the values actually consulted at runtime by this module.
+- **Added Sentry capture for holds (plan-check follow-up).** The task text did not explicitly specify this, but the plan-check warning provided at kickoff called for a post-seam Sentry capture when holds occur — implemented via `sentry_capture_message_with_context` with `context_name="snapshot_drift"` and `tags={"subsystem": "snapshot_drift"}`, matching the aggregate-only, PII-safe logging discipline used elsewhere in this repo.
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 1 - Bug] Fixed a boundary-precision test flake in the budget-guard test**
+- **Found during:** Task 3 (running the full `test_snapshot_drift_audit.py` file after adding Task 3 tests)
+- **Issue:** `TestTask2BudgetGuardSkipsAll` set `stale_session_start` exactly 160 minutes before `TIME_BUDGET_MINUTES=165`, leaving remaining budget at exactly the `SNAPSHOT_DRIFT_MAX_MINUTES=5` threshold. Under the slower wall-clock scheduling of the full test file (openpyxl-heavy tests included), the tiny execution delta between capturing `stale_session_start` and the guard's own `datetime.now()` call occasionally left `remaining_min` at or just above 5.0, so the pre-flight skip did not fire and the test flaked.
+- **Fix:** Widened the margin to 163 minutes elapsed (2 minutes remaining, well under the 5-minute threshold) so ordinary test-execution latency cannot flip the outcome.
+- **Files modified:** `tests/test_snapshot_drift_audit.py`
+- **Verification:** Full file re-run 27/27 green, twice, including combined with the slower Task 3 integration tests.
+- **Committed in:** `0a68aeb` (Task 3 commit)
+
+---
+
+**Total deviations:** 1 auto-fixed (1 bug — test flakiness, not production code)
+**Impact on plan:** Test-only fix; no production behavior changed. No scope creep.
+
+## Issues Encountered
+
+None beyond the test-flakiness item above.
+
+## User Setup Required
+
+**External Supabase configuration required — see the plan's `user_setup` block** (`.planning/quick/260812-jqx-snapshot-date-drift-audit-detect-snapsho/260812-jqx-PLAN.md` frontmatter):
+
+1. Apply the two appended `CREATE TABLE IF NOT EXISTS` blocks from `billing_audit/schema.sql` (project `poeyztlmsawfoqlanucc` → SQL Editor). Until applied, the pipeline degrades safely — every read surfaces as a fetch failure, falls back to the no-baseline seed-only path, and never produces a false drift flag.
+2. Confirm `billing_audit` is still listed under Project Settings → API → Exposed schemas, then reload the PostgREST schema cache.
+3. **Verify assumptions A1/A4 against ONE known-drifted row** (Smartsheet UI → a row from the 2026-08-12 drift incident → Snapshot Date cell history): confirm cell-history entry ordering and the literal `modified_by` email for automation writes. If the email is not `automation@smartsheet.com`, set `SNAPSHOT_DRIFT_AUTOMATION_EMAIL` rather than editing code. This is recorded as an open item in `.planning/WINDOWS.md` (kind `unrun-verify`) — no `SMARTSHEET_API_TOKEN` was available in this execution environment to run it directly.
+4. No GitHub Actions workflow change is required to land this — `SNAPSHOT_DRIFT_HOLD_ENABLED` stays unset (defaults `false`) until step 3 is confirmed. Setting it to `'true'` in `.github/workflows/weekly-excel-generation.yml` is a deliberate follow-up operator action.
+
+## Known Stubs
+
+None introduced by this plan. `_log_to_audit_sheet` in `audit_billing_changes.py` remains the pre-existing no-op placeholder (documented in RESEARCH.md and explicitly out of scope for v1) — this was already true before this plan and is not a regression; a real `AUDIT_SHEET_ID` write is a separate, protected-area follow-up task.
+
+## Next Phase Readiness
+
+- Detection + Supabase shadow logging is live by default (`SNAPSHOT_DRIFT_AUDIT_ENABLED=true`); the hold gate is off and ready for a deliberate operator-driven enable once Juan completes the `user_setup` verification steps above.
+- Follow-up (deferred, separate task per RESEARCH.md): a real mutating `AUDIT_SHEET_ID` write for "flag on the billing audit sheet" — requires Juan's approval, `SKIP_UPLOAD` gating, and audit-sheet column-id discovery.
+- No blockers for merging this branch; the DDL apply + live-row verification are operator actions independent of the code landing.
+
+## Self-Check: PASSED
+
+All 9 created/modified files confirmed present on disk; all 3 task commit hashes (`55329a1`, `c58a9bd`, `0a68aeb`) confirmed in `git log`.
+
+---
+*Phase: quick-260812-jqx*
+*Completed: 2026-08-12*

--- a/.planning/quick/260812-jqx-snapshot-date-drift-audit-detect-snapsho/260812-jqx-VERIFICATION.md
+++ b/.planning/quick/260812-jqx-snapshot-date-drift-audit-detect-snapsho/260812-jqx-VERIFICATION.md
@@ -1,0 +1,142 @@
+---
+phase: quick-260812-jqx
+verified: 2026-08-12T22:05:00Z
+status: human_needed
+score: 8/8 must-haves verified
+behavior_unverified: 0
+overrides_applied: 0
+human_verification:
+  - test: >
+      Run SKIP_UPLOAD=true WR_FILTER=<one known-drifted WR>
+      SNAPSHOT_DRIFT_HOLD_ENABLED=true python generate_weekly_pdfs.py
+      against real Smartsheet data (Task 3 human-check, recorded open in
+      .planning/WINDOWS.md).
+    expected: >
+      Run log shows the drifted row classified as automation_self_fire,
+      held to its prior week, and present in the generated workbook's
+      day-table for that week. If it comes back unclassified, correct
+      SNAPSHOT_DRIFT_AUTOMATION_EMAIL (assumption A4) rather than the
+      classifier.
+    why_human: >
+      Assumptions A1 (cell-history entry ordering) and A4 (literal
+      automation modified_by email) can only be confirmed against live
+      Smartsheet data; the suite proves the mechanism with mocked
+      history payloads. Requires SMARTSHEET_API_TOKEN, unavailable in
+      the verification sandbox.
+  - test: >
+      Apply the two appended CREATE TABLE IF NOT EXISTS blocks from
+      billing_audit/schema.sql in the Supabase SQL Editor (project
+      poeyztlmsawfoqlanucc); confirm billing_audit is in Exposed
+      schemas and reload the PostgREST cache (user_setup).
+    expected: >
+      billing_audit.snapshot_provenance and billing_audit.snapshot_drift
+      exist; the next run seeds provenance instead of degrading to
+      fetch_failure.
+    why_human: >
+      The pipeline never runs DDL (D-07); schema.sql is
+      documentation-grade and applied manually by Juan. Until applied,
+      the feature safely no-ops (verified), but the audit produces no
+      durable evidence.
+---
+
+# Quick Task 260812-jqx: Snapshot-Date Drift Audit — Verification Report
+
+**Goal:** Detect rows whose billing week drifted from the week they were
+last billed under, classify via targeted cell-history lookups, record
+every drift durably in Supabase, and — for automation self-fires only,
+behind a default-off gate — hold the row at its previously-billed week.
+**Verified:** 2026-08-12 (branch feat/260812-jqx-snapshot-drift-audit,
+commits 55329a1, c58a9bd, 0a68aeb, 0b5051a; diff base 3f7be82)
+**Status:** human_needed (all automated must-haves verified; live A1/A4
+operator check + manual DDL apply outstanding, both by design)
+**Re-verification:** No — initial verification
+
+## Goal Achievement
+
+### Observable Truths (PLAN must_haves.truths)
+
+| # | Truth | Status | Evidence |
+| --- | --- | --- | --- |
+| 1 | Drift detected with ZERO extra Smartsheet API calls (D-04) | ✓ VERIFIED | Detection uses one bulk Supabase provenance fetch only (`snapshot_store.fetch_snapshot_provenance`); tests `test_unchanged_week_costs_zero_api_calls`, `test_drifted_week_emits_candidate_without_mutation` pass — mock SDK client records zero calls |
+| 2 | First sight seeds provenance silently — no flag, no history call, no hold (D-09) | ✓ VERIFIED | `apply_snapshot_drift_holds` lines 530-538 (seed path, `continue` before candidate emit); `test_no_baseline_seeds_silently` passes |
+| 3 | Self-fire held to BOTH prior Weekly Reference Logged Date AND prior Snapshot Date; row survives day-tables; prior week hash unchanged (D-01) | ✓ VERIFIED | `_apply_holds` rewrites both fields + stashes originals under `__drifted_*` keys (snapshot_drift.py:448-461); `test_hold_rewrites_both_fields_and_preserves_originals`, `test_held_row_appears_in_generated_workbook` (real `generate_excel` Monday-Sunday filter), `test_hash_stable_across_drift_and_hold_both_modes` (2 subtests, legacy + extended) all pass. Live classifier accuracy is the human item |
+| 4 | Manual edit shadow-logged, NEVER held (D-02) | ✓ VERIFIED | `_apply_holds` skips non-self-fire classifications; `test_manual_candidate_never_mutated_even_with_hold_enabled` passes; every candidate written to `snapshot_drift` events regardless (`test_events_carry_classification_and_held_for_all_outcomes`) |
+| 5 | Any classification failure → 'unclassified': flagged, never held (D-03, D-10) | ✓ VERIFIED | Tests pass for: API exception, missing column id (zero calls), cap exhaustion (cap=1, exactly 2 calls), budget guard (zero calls), plus `test_unclassified_candidate_never_mutated_even_with_hold_enabled` |
+| 6 | Both switches false → behaviour identical to today (D-08) | ✓ VERIFIED | `test_disabled_is_a_pure_noop` (zeroed summary, no Supabase touch, rows value-identical) + `test_both_switches_off_reproduces_baseline` (risk_level baseline) pass; orchestrate seam only touches `audit_results['summary']` when `enabled`; run_summary.json reads only `audit_risk_level` from the audit summary so its key set is unchanged. Info note below on the placeholder key |
+| 7 | Only self-fire holds inflate total_issues / risk_level (D-01, caveat 5) | ✓ VERIFIED | `escalate_risk_for_snapshot_drift` early-returns at holds ≤ 0 and adds only `self_fire_holds` to the existing 4-term sum with the identical 0 / ≤3 / else thresholds; `test_four_holds_escalate_to_high`, `test_zero_holds_leaves_risk_level_unchanged` pass |
+| 8 | Missing client / unapplied migration / fetch failure → whole feature no-ops, never breaks the run (D-07) | ✓ VERIFIED | Store functions inherit the `get_client()`-None never-raise contract (snapshot_store.py:73-77, 135-137, 166-168); absent table surfaces as `fetch_failure` → seed-only degrade; belt-and-suspenders `except` wraps the whole pass (snapshot_drift.py:623-631); orchestrate seam has its own try/except; `test_unavailable_client_flags_summary_and_does_not_raise`, `test_fetch_exception_is_swallowed` pass |
+
+**Score:** 8/8 truths verified (0 present-but-behavior-unverified)
+
+### Required Artifacts
+
+| Artifact | Expected | Status | Details |
+| --- | --- | --- | --- |
+| `pipeline/snapshot_drift.py` | apply_snapshot_drift_holds() + classifier, only home of drift logic | ✓ VERIFIED | 631 lines; kill-switches read per call via os.getenv; lazy `billing_audit.snapshot_store` import; wired from orchestrate |
+| `billing_audit/snapshot_store.py` | bulk read, bulk upsert, append-only insert | ✓ VERIFIED | 184 lines; 3 public fns, all bulk (one call/run), all never-raise, `lookup_group_hash` status vocabulary |
+| `billing_audit/schema.sql` | appended provenance + drift DDL, manual apply | ✓ VERIFIED | +68/-0, single hunk after line 330; two CREATE TABLE IF NOT EXISTS, PKs (sheet_id,row_id) / (sheet_id,row_id,detected_at), wr+detected_at index, service_role grants; nothing above touched |
+| `pipeline/config.py` | six SNAPSHOT_DRIFT_* switches | ✓ VERIFIED | All six present next to the TIME_BUDGET family with plan defaults: AUDIT_ENABLED=true, HOLD_ENABLED=false, MAX_ROWS=40, PACE_SEC=2.0, MAX_MINUTES=5, AUTOMATION_EMAIL=automation@smartsheet.com |
+| `pipeline/orchestrate.py` | ONE call site at the pre-grouping seam | ✓ VERIFIED | Exactly 2 hunks (import + seam); seam sits between the audit else-branch and "📂 Grouping data...", own try/except; escalation + Sentry hold-warning inside the same seam |
+| `audit_billing_changes.py` | drift counters + escalate_risk_for_snapshot_drift() | ✓ VERIFIED | +56/-0; `total_snapshot_drift_holds` counter + module-level escalation fn reusing existing thresholds |
+| `tests/test_snapshot_drift_audit.py` | RED-first suite covering the 9 research cases | ✓ VERIFIED | 888 lines, 27 tests + 2 subtests, all pass in 31.7s, no live Smartsheet/Supabase calls |
+| `memory-bank/living-ledger.md` | dated entry | ✓ VERIFIED | `## [2026-08-12 15:30] Snapshot-date drift audit + hold-prior-week gate added (260812-jqx)` at line 5336 (bottom of file) |
+
+### Key Link Verification
+
+| From | To | Via | Status |
+| --- | --- | --- | --- |
+| orchestrate.py pre-grouping seam | apply_snapshot_drift_holds(all_rows, source_sheets, client, session_start) | after audit else-branch, before grouping span — upstream of all grouping.py week readers | ✓ WIRED |
+| Held row | grouping week key + excel Monday-Sunday filter + change-detection hashes | BOTH fields rewritten in `_apply_holds`; pinned by the excel-filter and dual-mode hash-stability tests | ✓ WIRED |
+| `__source_sheet_id`/`__row_id` | `column_mapping['Snapshot Date']`/`['Units Completed?']` → `client.Cells.get_cell_history(..., include_all=True)` | `_collect_candidate_rows` + `_classify_candidates` | ✓ WIRED |
+| `get_client()` returns None | whole feature no-ops | store neutral returns + `unavailable`/`fetch_failure` status | ✓ WIRED |
+| `drift_summary['automation_self_fire_holds']` | `escalate_risk_for_snapshot_drift` → `summary['risk_level']` | orchestrate seam, gated on `enabled` + summary-is-dict | ✓ WIRED |
+
+### Behavioral Spot-Checks
+
+| Behavior | Command | Result | Status |
+| --- | --- | --- | --- |
+| New suite green | `pytest tests/test_snapshot_drift_audit.py -v` | 27 passed, 2 subtests, 31.68s | ✓ PASS |
+| Full-suite regression (run once) | `pytest tests/ -q` | 1257 passed, 132 subtests, 42.69s — independently confirms executor claim | ✓ PASS |
+| Syntax | `py_compile` on generate_weekly_pdfs.py, snapshot_drift.py, snapshot_store.py, audit_billing_changes.py | clean | ✓ PASS |
+| Diff guard: grouping/excel | `git diff --name-only 3f7be82..HEAD -- pipeline/grouping.py pipeline/excel.py` | 0 files | ✓ PASS |
+| Seam guard | `git diff -U0 3f7be82..HEAD -- pipeline/orchestrate.py \| grep -c '^@@'` | 2 (≤ 3 allowed) | ✓ PASS |
+| Schema append-only | `git diff --stat` + deleted-line count | +68/-0, single hunk at EOF | ✓ PASS |
+| Off-switch run_summary key set | run_summary composition reads only `audit_risk_level` from audit summary | unchanged key set | ✓ PASS |
+
+### Prohibitions / Negative Checks
+
+| Prohibition | Status | Evidence |
+| --- | --- | --- |
+| Pipeline never runs DDL | ✓ HELD | snapshot_store issues only select/upsert/insert; schema.sql is documentation-grade with an operator apply banner |
+| No new mutating Smartsheet write | ✓ HELD | Only read-only `get_cell_history`; no AUDIT_SHEET_ID write added (RESEARCH caveat 4 respected) |
+| Change-detection key unshortened | ✓ HELD | change_detection.py and grouping.py untouched |
+| No per-row Supabase reads/writes | ✓ HELD | One bulk fetch, one batched upsert, one batched insert per run; `test_upsert_called_once_with_batched_payload` pins it |
+
+### Anti-Patterns Found
+
+None. No TBD/FIXME/XXX/placeholder markers in the new or changed files.
+
+### Deviations (accepted, documented)
+
+- Post-seam Sentry `sentry_capture_message_with_context` warning when holds > 0 — additive, inside the seam hunk, addresses the plan-check observability warning. ℹ️
+- Test-only budget-boundary flake fix — test file only. ℹ️
+- `total_snapshot_drift_holds: 0` placeholder added unconditionally to `_generate_audit_summary` for key-set stability across enabled/disabled runs. Additive in-memory key; does not reach run_summary.json (which reads only `audit_risk_level`) or any billing artifact. ℹ️
+
+### Human Verification Required
+
+1. **Live A1/A4 classifier check (Task 3 human-check, open in .planning/WINDOWS.md)** — `SKIP_UPLOAD=true WR_FILTER=<known-drifted WR> SNAPSHOT_DRIFT_HOLD_ENABLED=true python generate_weekly_pdfs.py`; expect automation_self_fire classification, hold to prior week, row present in the workbook day-table. Must pass BEFORE setting `SNAPSHOT_DRIFT_HOLD_ENABLED=true` in the workflow. If unclassified, set `SNAPSHOT_DRIFT_AUTOMATION_EMAIL` — do not edit the classifier.
+2. **Supabase DDL apply (user_setup)** — apply the two appended schema.sql blocks in the SQL Editor, confirm `billing_audit` in Exposed schemas, reload the PostgREST cache. Until then the feature safely no-ops (verified) but records no durable evidence.
+
+### Gaps Summary
+
+No gaps. Every automated must-have — all 8 truths, all 8 artifacts, all 5
+key links, and every negative check — is verified against the codebase
+with passing behavioral tests, not just symbol presence. The two open
+items are the plan's own deliberately deferred operator actions (live
+assumption check and manual DDL apply), both safe-by-default: the hold
+gate ships OFF and the Supabase layer no-ops until applied.
+
+---
+
+_Verified: 2026-08-12T22:05:00Z_
+_Verifier: Claude (gsd-verifier)_

--- a/audit_billing_changes.py
+++ b/audit_billing_changes.py
@@ -494,6 +494,12 @@ class BillingAudit:
                 audit_results.get("rate_sanity_mismatches", [])
             ),
             "rate_sanity_skipped": self._rate_sanity_skipped,
+            # Snapshot-date drift audit (260812-jqx): placeholder,
+            # always present for key-set stability. The drift pass
+            # runs AFTER audit_financial_data (pre-grouping seam in
+            # pipeline/orchestrate.py), so the real count is folded
+            # in post-hoc by escalate_risk_for_snapshot_drift() below.
+            "total_snapshot_drift_holds": 0,
             "risk_level": "LOW",
             "recommendations": []
         }
@@ -689,3 +695,53 @@ class BillingAudit:
                 history_meta["history_available"] = False
             enriched.append(history_meta)
         return enriched
+
+
+# ── Snapshot-date drift audit risk wiring (260812-jqx) ──────────────
+def escalate_risk_for_snapshot_drift(
+    summary: Dict, self_fire_holds: int
+) -> Dict:
+    """Fold automation-self-fire snapshot-drift holds into ``risk_level``.
+
+    Runs POST-HOC: ``pipeline/snapshot_drift.py``'s drift pass executes
+    AFTER ``audit_financial_data`` has already produced ``summary``
+    (the pre-grouping seam sits downstream of the audit block in
+    ``pipeline/orchestrate.py``), so this module-level function
+    re-derives ``total_issues`` from the SAME fields
+    ``_generate_audit_summary`` uses (:502-507) plus
+    ``self_fire_holds``, then re-applies the identical 0 / <=3 / else
+    thresholds (:509-517).
+
+    Only automation self-fire HOLDS feed this -- folding in manual or
+    unclassified drift would drive a routine batch of legitimate edits
+    to HIGH and desensitise the signal (D-01, RESEARCH caveat 5).
+    Manual and unclassified drift is still recorded durably (the
+    ``billing_audit.snapshot_drift`` Supabase shadow layer plus the
+    per-hold run-log line) but never escalates risk here.
+    """
+    self_fire_holds = int(self_fire_holds or 0)
+    summary["total_snapshot_drift_holds"] = self_fire_holds
+    if self_fire_holds <= 0:
+        return summary
+
+    total_issues = (
+        summary.get("total_anomalies", 0)
+        + summary.get("total_unauthorized_changes", 0)
+        + summary.get("total_data_issues", 0)
+        + summary.get("total_rate_sanity_mismatches", 0)
+        + self_fire_holds
+    )
+
+    if total_issues == 0:
+        summary["risk_level"] = "LOW"
+    elif total_issues <= 3:
+        summary["risk_level"] = "MEDIUM"
+    else:
+        summary["risk_level"] = "HIGH"
+
+    summary.setdefault("recommendations", []).append(
+        "Snapshot-drift automation self-fire hold(s) detected: "
+        f"{self_fire_holds} row(s) held at their prior billed week. "
+        "Review billing_audit.snapshot_drift for the affected rows."
+    )
+    return summary

--- a/billing_audit/schema.sql
+++ b/billing_audit/schema.sql
@@ -328,3 +328,71 @@ AS $$
 $$;
 
 GRANT EXECUTE ON FUNCTION billing_audit.lookup_attribution_bulk(jsonb) TO service_role;
+
+-- ── snapshot_provenance / snapshot_drift (quick task 260812-jqx) ────
+-- Defence-in-depth backstop for the Smartsheet "record Snapshot Date"
+-- automation firing on ANY completed-row change (same-value saves,
+-- bulk API/DataTable touches), silently re-stamping Snapshot Date to
+-- today and moving an already-billed unit into the current billing
+-- week (living-ledger [2026-08-12 13:40]). ADDITIVE ONLY -- no
+-- existing billing_audit table, RLS, or policy is touched.
+--
+-- OPERATOR: apply these two CREATE TABLE blocks in the Supabase SQL
+-- Editor, confirm 'billing_audit' is still in Project Settings -> API
+-- -> Exposed schemas, then reload the PostgREST schema cache. Until
+-- applied, the reader degrades exactly like ``group_content_hash``
+-- above -- surfaces as a fetch failure, the pipeline falls back to
+-- "no baseline" (seed-only, never a false drift flag), and billing
+-- behaviour is unaffected (D-07: a missing migration can never break
+-- a run).
+
+-- ── snapshot_provenance (state) ─────────────────────────────────────
+-- One row per (sheet_id, row_id) recording the week/snapshot date the
+-- row was LAST billed under. Seeded silently the first time a row is
+-- seen (D-09 -- no history backfill) and refreshed every run so it
+-- always reflects the week the row was ACTUALLY billed under (the
+-- held week when a hold applied, the new week otherwise).
+CREATE TABLE IF NOT EXISTS billing_audit.snapshot_provenance (
+    sheet_id       BIGINT      NOT NULL,
+    row_id         BIGINT      NOT NULL,
+    wr             TEXT,
+    cu             TEXT,
+    snapshot_date  DATE,
+    billed_week    DATE,
+    run_id         TEXT,
+    first_seen_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_seen_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (sheet_id, row_id)
+);
+
+GRANT SELECT, INSERT, UPDATE
+    ON billing_audit.snapshot_provenance TO service_role;
+
+-- ── snapshot_drift (append-only event log) ──────────────────────────
+-- One row per detected drift candidate PER RUN, regardless of
+-- classification or hold outcome. This is the fail-closed logging
+-- half of D-03 (fail-open on gating, fail-closed on logging): a
+-- manual edit or an unclassified drift is NEVER held, but it is
+-- ALWAYS recorded here so every drift becomes queryable evidence.
+CREATE TABLE IF NOT EXISTS billing_audit.snapshot_drift (
+    sheet_id            BIGINT      NOT NULL,
+    row_id              BIGINT      NOT NULL,
+    detected_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    wr                  TEXT,
+    cu                  TEXT,
+    prior_snapshot_date DATE,
+    new_snapshot_date   DATE,
+    prior_billed_week   DATE,
+    new_week            DATE,
+    changed_by          TEXT,
+    classification      TEXT,
+    held                BOOLEAN     NOT NULL DEFAULT FALSE,
+    run_id              TEXT,
+    PRIMARY KEY (sheet_id, row_id, detected_at)
+);
+
+CREATE INDEX IF NOT EXISTS idx_snapshot_drift_wr_detected_at
+    ON billing_audit.snapshot_drift (wr, detected_at DESC);
+
+GRANT SELECT, INSERT
+    ON billing_audit.snapshot_drift TO service_role;

--- a/billing_audit/snapshot_store.py
+++ b/billing_audit/snapshot_store.py
@@ -1,0 +1,184 @@
+"""billing_audit.snapshot_store -- Supabase shadow layer for the
+snapshot-date drift audit (quick task 260812-jqx).
+
+Two additive tables, appended to ``billing_audit/schema.sql`` for
+manual apply by Juan (the pipeline never runs DDL -- see the schema
+file header):
+
+- ``billing_audit.snapshot_provenance`` -- state table, PK
+  ``(sheet_id, row_id)``. Records the week / snapshot date a row was
+  LAST billed under, seeded silently on first sight (D-09, no history
+  backfill).
+- ``billing_audit.snapshot_drift`` -- append-only event table, one
+  row per detected drift candidate regardless of classification or
+  hold outcome (fail-closed logging half of D-03: every candidate is
+  recorded even when gating fails open).
+
+Every public function here mirrors the fail-safe contract of
+``lookup_group_hash`` / ``upsert_group_hash``
+(``billing_audit/writer.py:1144,1222``): NEVER raises, returns a
+neutral value when ``get_client()`` is ``None``, and reads/writes are
+strictly BULK -- one call per run, never per-row -- per RESEARCH
+caveat 6 (the 2026-04-24 per-row retry-exhaustion incident this
+pattern exists to prevent).
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from billing_audit.client import get_client, with_retry
+from billing_audit.writer import _sanitized_wr as sanitized_wr  # noqa: F401
+
+logger = logging.getLogger(__name__)
+
+_PROVENANCE_TABLE = "snapshot_provenance"
+_DRIFT_TABLE = "snapshot_drift"
+_PROVENANCE_COLUMNS = (
+    "sheet_id,row_id,wr,cu,snapshot_date,billed_week,run_id,"
+    "first_seen_at,last_seen_at"
+)
+
+
+def fetch_snapshot_provenance(
+    keys: "list[tuple[int, int]]",
+) -> "tuple[dict[tuple[int, int], dict], str]":
+    """Bulk-read prior billing provenance for a run's row set.
+
+    ONE select for every ``(sheet_id, row_id)`` pair in ``keys`` --
+    per-row reads are forbidden (D-06, RESEARCH caveat 6). Returns
+    ``(rows_by_key, status)`` where ``status`` matches the
+    ``lookup_group_hash`` vocabulary:
+
+    - ``'success'``       : at least one requested key was found.
+    - ``'no_row'``         : the query succeeded with zero matches --
+                             every row in ``keys`` is first-sight.
+    - ``'fetch_failure'``  : the call failed (retries exhausted /
+                             permanent error / run-global kill).
+                             Callers degrade to the no-baseline
+                             (seed-only) path.
+    - ``'unavailable'``    : no client (TEST_MODE / missing creds)
+                             and NOT an outage. Callers degrade the
+                             same way as ``fetch_failure``.
+
+    NEVER raises. An absent table / unapplied migration surfaces as
+    ``fetch_failure`` (matches the ``group_content_hash`` degrade
+    path documented at ``billing_audit/schema.sql:139-145``).
+    """
+    if not keys:
+        return {}, "no_row"
+
+    from billing_audit import client as _client_mod  # noqa: PLC0415
+
+    client = get_client()
+    if client is None:
+        if _client_mod._global_disable_reason is not None:
+            return {}, "fetch_failure"
+        return {}, "unavailable"
+
+    sheet_ids = sorted({int(k[0]) for k in keys})
+    row_ids = sorted({int(k[1]) for k in keys})
+    wanted = {(int(k[0]), int(k[1])) for k in keys}
+
+    def _op():
+        return (
+            client.schema("billing_audit")
+            .table(_PROVENANCE_TABLE)
+            .select(_PROVENANCE_COLUMNS)
+            .in_("sheet_id", sheet_ids)
+            .in_("row_id", row_ids)
+            .execute()
+        )
+
+    try:
+        resp = with_retry(_op, op="fetch_snapshot_provenance")
+        if resp is None:
+            return {}, "fetch_failure"
+        data = getattr(resp, "data", None)
+        if isinstance(data, dict):
+            data = [data] if data else []
+        rows = data or []
+        result: "dict[tuple[int, int], dict]" = {}
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            try:
+                key = (int(row.get("sheet_id")), int(row.get("row_id")))
+            except (TypeError, ValueError):
+                continue
+            if key in wanted:
+                result[key] = row
+        if not result:
+            return {}, "no_row"
+        return result, "success"
+    except Exception:
+        # Belt-and-suspenders: this reader MUST NEVER raise. Callers
+        # degrade to the no-baseline (seed-only) path on fetch_failure,
+        # which is the fail-safe default already documented for
+        # ``group_content_hash``.
+        logger.exception(
+            "⚠️ Snapshot-provenance bulk read hit an unexpected error; "
+            "treating as fetch_failure (degrade to no-baseline)."
+        )
+        return {}, "fetch_failure"
+
+
+def upsert_snapshot_provenance(records: "list[dict[str, Any]]") -> None:
+    """Best-effort durable write of snapshot provenance.
+
+    ONE batched upsert on the ``(sheet_id, row_id)`` primary key --
+    never once per row (RESEARCH caveat 6). Fail-safe: catches its
+    own errors and NEVER raises, mirroring ``upsert_group_hash``.
+    """
+    if not records:
+        return
+    client = get_client()
+    if client is None:
+        return
+
+    def _op():
+        return (
+            client.schema("billing_audit")
+            .table(_PROVENANCE_TABLE)
+            .upsert(list(records), on_conflict="sheet_id,row_id")
+            .execute()
+        )
+
+    try:
+        with_retry(_op, op="upsert_snapshot_provenance")
+    except Exception:
+        logger.exception(
+            "⚠️ Snapshot-provenance upsert failed (non-fatal); "
+            "durable store not updated this run."
+        )
+
+
+def insert_snapshot_drift_events(events: "list[dict[str, Any]]") -> None:
+    """Best-effort durable write of drift events (append-only).
+
+    ONE batched insert -- every candidate (held, manual, or
+    unclassified) is written so the fail-closed logging half of D-03
+    holds even when gating fails open. Fail-safe: catches its own
+    errors and NEVER raises.
+    """
+    if not events:
+        return
+    client = get_client()
+    if client is None:
+        return
+
+    def _op():
+        return (
+            client.schema("billing_audit")
+            .table(_DRIFT_TABLE)
+            .insert(list(events))
+            .execute()
+        )
+
+    try:
+        with_retry(_op, op="insert_snapshot_drift_events")
+    except Exception:
+        logger.exception(
+            "⚠️ Snapshot-drift event insert failed (non-fatal); "
+            "durable store not updated this run."
+        )

--- a/memory-bank/living-ledger.md
+++ b/memory-bank/living-ledger.md
@@ -5332,3 +5332,110 @@ exceptions. No SDK 4.3.0 error-shape drift observed — `pipeline/retry.py`'s
   `audit_billing_changes` at L35, before it imports `pipeline.pricing`
   at L196-210) — the import only executes at call time, well after
   the full facade has loaded.
+
+## [2026-08-12 15:30] Snapshot-date drift audit + hold-prior-week gate added (260812-jqx) — pipeline-side backstop for the automation re-stamp bug
+
+- **Root cause (same incident logged 13:40 above):** the per-sheet
+  "record Snapshot Date" Smartsheet automation fires on ANY row change
+  where `Units Completed?` is checked — same-value saves, bulk API /
+  DataTable touches — not just a genuine completion event. Because
+  `Weekly Reference Logged Date` = `Snapshot Date` snapped to Sunday,
+  every re-stamp silently moves an already-billed unit into the
+  current billing week. Juan is fixing the automation trigger in the
+  Smartsheet UI; this entry documents the pipeline-side defence in
+  depth that ships regardless.
+- **What shipped:** `pipeline/snapshot_drift.py`
+  (`apply_snapshot_drift_holds`) runs at a pre-grouping seam in
+  `pipeline/orchestrate.py` (between the audit `else:` close and
+  `group_source_rows`) — upstream of every `Weekly Reference Logged
+  Date` pre-pass reader in `pipeline/grouping.py`, so **zero**
+  `grouping.py` or `excel.py` edits were needed. It detects rows whose
+  computed billing week differs from a durable per-row baseline in a
+  new additive Supabase table (`billing_audit.snapshot_provenance`,
+  seeded silently on first sight — no history backfill), classifies
+  week-movers ONLY via targeted `Cells.get_cell_history` lookups
+  (Snapshot Date + Units Completed?, capped at 40 rows/run, ~2s
+  self-paced, session-budget-aware), and — only for rows classified as
+  an automation self-fire, only when the hold gate is explicitly
+  enabled — holds the row at its previously-billed week.
+- **HARD RULE — the hold override MUST rewrite BOTH fields.**
+  `pipeline/excel.py`'s `generate_excel` buckets rows by `Snapshot
+  Date` into Monday-Sunday day-tables; `pipeline/change_detection.py`
+  includes `Snapshot Date` in both the sort key and the content hash
+  (legacy and extended modes). Rewriting only `Weekly Reference Logged
+  Date` would put the row in the correct WR/week GROUP but leave its
+  `Snapshot Date` pointing at the drifted (wrong) week — the row would
+  then be silently **excluded from every day-table in the generated
+  workbook**, a worse outcome than the original drift (a silent
+  under-bill instead of a visible one). `_apply_holds()` always
+  rewrites `Weekly Reference Logged Date` AND `Snapshot Date` together
+  and stashes the drifted originals under `__drifted_*` /
+  `__snapshot_drift_*` private keys for logging / Supabase /
+  diagnosis. Any future change that rewrites only one of these two
+  fields on a held row is a regression of this rule, not an
+  optimization.
+- **Fail-open gating, fail-closed logging (D-03).** Any classification
+  failure — a Smartsheet API error, a missing `Snapshot Date` /
+  `Units Completed?` column id on the row's source sheet, the per-run
+  cap exhausted, or the session sub-budget too tight — yields
+  `unclassified`: the row is flagged and NEVER held. Manual edits (any
+  non-automation identity) are likewise NEVER held (D-02). Every
+  candidate, held or not, is still written to the append-only
+  `billing_audit.snapshot_drift` event table with its classification
+  and `held` boolean, so nothing is silently dropped from the audit
+  trail even when gating declines to act.
+- **Six env-var kill-switches**, mirroring the `TIME_BUDGET_MINUTES`
+  family in `pipeline/config.py` and read PER CALL (not at import) in
+  `pipeline/snapshot_drift.py` so tests can toggle them without
+  reloading a module — exactly the `RATE_SANITY_AUDIT_ENABLED` pattern
+  from the 14:05 entry above:
+  - `SNAPSHOT_DRIFT_AUDIT_ENABLED` (default `true`) — detection +
+    Supabase shadow logging.
+  - `SNAPSHOT_DRIFT_HOLD_ENABLED` (default **`false`**) — its OWN
+    switch, separate from detection. Stays off until a live run
+    confirms the classifier against a known-drifted row.
+  - `SNAPSHOT_DRIFT_MAX_ROWS` (default `40`) — per-run classification
+    cap.
+  - `SNAPSHOT_DRIFT_PACE_SEC` (default `2.0`) — mandatory self-pacing
+    sleep between `get_cell_history` calls; the SDK's own retry budget
+    (`max_retry_time=30`) will NOT ride out a sustained cell-history
+    throttle.
+  - `SNAPSHOT_DRIFT_MAX_MINUTES` (default `5`) — session sub-budget AND
+    the pre-flight threshold that skips classification entirely
+    (degrading every candidate to `unclassified`) when remaining
+    session time is tight.
+  - `SNAPSHOT_DRIFT_AUTOMATION_EMAIL` (default
+    `automation@smartsheet.com`) — the classifier's identity signature
+    is operator-correctable via env, without a code change.
+  - With BOTH switches off, `apply_snapshot_drift_holds` is a byte-
+    identical no-op to today's behaviour (D-08); `audit_results['summary']`
+    is only touched when the audit actually ran.
+- **Manual-DDL requirement (unchanged pattern).** Two new tables —
+  `billing_audit.snapshot_provenance` (state, PK `sheet_id,row_id`)
+  and `billing_audit.snapshot_drift` (append-only event log) — were
+  APPENDED to `billing_audit/schema.sql`. The pipeline never runs DDL:
+  Juan must apply both `CREATE TABLE IF NOT EXISTS` blocks by hand in
+  the Supabase SQL Editor, confirm `billing_audit` is still in Project
+  Settings → API → Exposed schemas, and reload the PostgREST schema
+  cache. Until applied, every read degrades exactly like
+  `group_content_hash` already does — a fetch failure, falling back to
+  the no-baseline (seed-only) path, never a false drift flag.
+- **Two live assumptions still to verify before flipping
+  `SNAPSHOT_DRIFT_HOLD_ENABLED=true` in the workflow** (both fail open
+  to `unclassified` if wrong, so this is a safety note, not a
+  blocker): (1) `IndexResult[CellHistory].data` ordering and the exact
+  `modified_by` shape returned by the live API — the classifier sorts
+  by `modified_at` itself and reads the email defensively, so this
+  should be a non-issue, but confirm against ONE known-drifted row's
+  real cell history; (2) whether `automation@smartsheet.com` is the
+  literal `modified_by` email Smartsheet's automation writes as — if
+  not, set `SNAPSHOT_DRIFT_AUTOMATION_EMAIL` to the observed value
+  rather than editing the classifier.
+- **Explicitly NOT shipped in v1:** no new mutating Smartsheet write
+  to `AUDIT_SHEET_ID` — `_log_to_audit_sheet` remains the pre-existing
+  no-op placeholder (builds a dict, discards it). The durable,
+  queryable flag surface for this feature is the Supabase shadow layer
+  (`billing_audit.snapshot_drift`) plus the per-hold run-log line, not
+  a Smartsheet row. A real audit-sheet write is a separate, protected-
+  area task requiring Juan's approval, `SKIP_UPLOAD` gating, and
+  audit-sheet column-id discovery.

--- a/memory-bank/living-ledger.md
+++ b/memory-bank/living-ledger.md
@@ -5439,3 +5439,44 @@ exceptions. No SDK 4.3.0 error-shape drift observed — `pipeline/retry.py`'s
   a Smartsheet row. A real audit-sheet write is a separate, protected-
   area task requiring Juan's approval, `SKIP_UPLOAD` gating, and
   audit-sheet column-id discovery.
+
+## [2026-08-12 17:05] Live cell-history verification corrects the snapshot-drift signature (automation batching + WRLD is automation-written)
+
+- **A1/A4 VERIFIED LIVE** (read-only probes with Juan's token against
+  "Resiliency Promax Database Backup 86"): cell history returns
+  newest-first (A1); automation writes carry
+  `automation@smartsheet.com` (A4) on both legitimate and erroneous
+  stamps. WINDOWS defect #1 (unrun-verify) closed on this evidence.
+- **Complete Point 27 evidence chain** (WR 91916464, row id
+  4458327346708356): legit stamp 2026-08-06 15:59:07Z (23s after the
+  foreman's `Units Completed?` check); erroneous self-fire 2026-08-12
+  18:11:48Z re-stamping `Snapshot Date` to 08-12 **and** `Weekly
+  Reference Logged Date` to 2026-08-16 at 18:11:54Z, triggered by a
+  same-value Quantity re-save while `Units Completed?` was 6 days
+  unchanged; Juan manually reverted both fields ~58s later. Whole-sheet
+  scan 2026-08-12: zero stamps >= 08-08 remain on Backup 86.
+- **RULE CORRECTIONS (supersede the ±2-minute rule in the
+  [2026-08-12 13:40] entry):**
+  1. The automation **batches** its writes — legitimate stamps were
+     observed 17s to 4m22s after their checkbox check, with two rows
+     stamped the same second (15:26:15Z). Any legit-vs-drift
+     correlation window must be well above 2 minutes; the pipeline
+     classifier now uses `SNAPSHOT_DRIFT_UNITS_WINDOW_MINUTES`
+     (default 15). Repair sweeps must use >= 15 minutes too.
+  2. `Weekly Reference Logged Date` is **automation-written, not
+     derived** — the defect rewrites it directly, so drift repair
+     must audit/revert it alongside `Snapshot Date` (the jqx hold
+     path already rewrites both).
+  3. A third system identity appears in cell history:
+     `cell-link@smartsheet.com` (cell-link propagation) — neither the
+     automation nor a manual edit; never treat it as either.
+- **Review fix round** (commits a56190c / 81da106 / 7a58c62): CR-01
+  provenance upsert now gated on fetch status "success"/"no_row" (a
+  failed Supabase read can no longer rebase every baseline to the
+  current week); CR-02 holds skip candidates whose baseline
+  snapshot_date is null (a hold can never blank `Snapshot Date` and
+  drop a billed row from the workbook); WR-01 unparseable newest
+  history timestamp classifies `unclassified`, never self-fire;
+  window env-tunable per correction 1; test pacing zeroed in the
+  shared base (drift tests 31.7s → 1.35s). Suite 1262 passed + 132
+  subtests.

--- a/pipeline/config.py
+++ b/pipeline/config.py
@@ -169,6 +169,14 @@ SNAPSHOT_DRIFT_MAX_MINUTES = float(
 SNAPSHOT_DRIFT_AUTOMATION_EMAIL = os.getenv(
     'SNAPSHOT_DRIFT_AUTOMATION_EMAIL', 'automation@smartsheet.com'
 )
+# +/- window (minutes) used to correlate a Units Completed? edit with
+# the newest automation-identity Snapshot Date write (D-05). Widened
+# from a hardcoded 2 minutes to 15 after live cell-history evidence
+# (2026-08-12) showed the automation BATCHES writes -- legitimate
+# stamps landed 3m50s-4m22s after their Units Completed? check.
+SNAPSHOT_DRIFT_UNITS_WINDOW_MINUTES = float(
+    os.getenv('SNAPSHOT_DRIFT_UNITS_WINDOW_MINUTES', '15') or 15
+)
 
 
 class _DaemonThreadPoolExecutor(ThreadPoolExecutor):

--- a/pipeline/config.py
+++ b/pipeline/config.py
@@ -125,6 +125,51 @@ ATTACHMENT_PREFETCH_FUTURE_TIMEOUT_SEC = int(os.getenv('ATTACHMENT_PREFETCH_FUTU
 # zero-output failure mode this guard is meant to prevent.
 ATTACHMENT_PREFETCH_GENERATION_HEADROOM_MIN = int(os.getenv('ATTACHMENT_PREFETCH_GENERATION_HEADROOM_MIN', '2') or 2)
 
+# Snapshot-date drift audit (quick task 260812-jqx) -- defence-in-depth
+# backstop for the Smartsheet "record Snapshot Date" automation firing on
+# ANY completed-row change and silently drifting an already-billed unit
+# into the current billing week (living-ledger [2026-08-12 13:40]).
+# ``pipeline/snapshot_drift.py`` re-reads each of these via ``os.getenv``
+# at call time (not from the frozen constants below) so tests can toggle
+# them per-case without reloading this module -- mirrors the
+# ``RATE_SANITY_AUDIT_ENABLED`` pattern in ``audit_billing_changes.py``.
+# These module-level constants exist for documentation/discoverability,
+# matching the TIME_BUDGET_MINUTES family's convention.
+#
+# Detection + Supabase shadow-logging kill switch. Defaults ON: the
+# audit is report-only and additive (D-08).
+SNAPSHOT_DRIFT_AUDIT_ENABLED = (
+    os.getenv('SNAPSHOT_DRIFT_AUDIT_ENABLED', 'true').lower() == 'true'
+)
+# Hold-prior-week gating kill switch. Its OWN switch, separate from
+# detection, and defaults OFF -- the gate is opt-in until a live run
+# proves the classifier against a known-drifted row (D-08, RESEARCH
+# caveat 3).
+SNAPSHOT_DRIFT_HOLD_ENABLED = (
+    os.getenv('SNAPSHOT_DRIFT_HOLD_ENABLED', 'false').lower() == 'true'
+)
+# Per-run cap on cell-history classification (D-04): only week-movers
+# are ever classified, and only up to this many per run.
+SNAPSHOT_DRIFT_MAX_ROWS = int(os.getenv('SNAPSHOT_DRIFT_MAX_ROWS', '40') or 40)
+# Self-pacing sleep (seconds) between cell-history calls (D-04,
+# RESEARCH caveat 2) -- the SDK's own retry budget will not ride out a
+# sustained cell-history throttle.
+SNAPSHOT_DRIFT_PACE_SEC = float(os.getenv('SNAPSHOT_DRIFT_PACE_SEC', '2.0') or 2.0)
+# Phase sub-budget (minutes) AND the pre-flight threshold: when
+# TIME_BUDGET_MINUTES is set and running in GitHub Actions, remaining
+# session budget below this many minutes skips classification entirely
+# -- every candidate degrades to 'unclassified' (D-10).
+SNAPSHOT_DRIFT_MAX_MINUTES = float(
+    os.getenv('SNAPSHOT_DRIFT_MAX_MINUTES', '5') or 5
+)
+# The literal ``modified_by`` email the classifier treats as the
+# Smartsheet automation identity (D-05). Configurable so assumption A4
+# can be corrected by an operator via environment instead of a code
+# change.
+SNAPSHOT_DRIFT_AUTOMATION_EMAIL = os.getenv(
+    'SNAPSHOT_DRIFT_AUTOMATION_EMAIL', 'automation@smartsheet.com'
+)
+
 
 class _DaemonThreadPoolExecutor(ThreadPoolExecutor):
     """ThreadPoolExecutor whose workers are daemonized so stuck I/O

--- a/pipeline/orchestrate.py
+++ b/pipeline/orchestrate.py
@@ -257,6 +257,7 @@ from pipeline.attribution import (  # noqa: E402
     run_claimer_remediation,
     save_billing_audit_row_cache,
 )
+from pipeline.snapshot_drift import apply_snapshot_drift_holds  # noqa: E402
 
 
 def _build_synthetic_rows():
@@ -575,6 +576,20 @@ def main():  # pyright: ignore[reportGeneralTypeIssues]
                 )
         else:
             logging.info("🚀 Audit system disabled for testing")
+
+        # ── Snapshot-date drift audit (260812-jqx) ──────────────────
+        # Pre-grouping seam: runs upstream of every Weekly Reference
+        # Logged Date pre-pass reader in pipeline/grouping.py and of
+        # the single week computation there, so zero grouping.py edits
+        # are needed. Own try/except: a drift-audit failure must never
+        # block the billing run (D-07).
+        try:
+            _snapshot_drift_summary = apply_snapshot_drift_holds(
+                all_rows, source_sheets, client, session_start,
+            )
+        except Exception as _snap_exc:
+            logging.warning(f"⚠️ Snapshot-drift audit error: {_snap_exc}")
+            _snapshot_drift_summary = {'enabled': False}
 
     # Group rows by work request and week ending
         logging.info("📂 Grouping data...")

--- a/pipeline/orchestrate.py
+++ b/pipeline/orchestrate.py
@@ -587,6 +587,34 @@ def main():  # pyright: ignore[reportGeneralTypeIssues]
             _snapshot_drift_summary = apply_snapshot_drift_holds(
                 all_rows, source_sheets, client, session_start,
             )
+            # Only touch audit_results['summary'] when the audit ran
+            # (D-08 off-switch equivalence: with the switch off,
+            # audit_results['summary'] must stay byte-identical to
+            # today's shape).
+            if _snapshot_drift_summary.get('enabled') and isinstance(
+                audit_results.get('summary'), dict
+            ):
+                from audit_billing_changes import (  # noqa: PLC0415
+                    escalate_risk_for_snapshot_drift,
+                )
+                escalate_risk_for_snapshot_drift(
+                    audit_results['summary'],
+                    _snapshot_drift_summary.get(
+                        'automation_self_fire_holds', 0
+                    ),
+                )
+                _snap_holds = _snapshot_drift_summary.get(
+                    'automation_self_fire_holds', 0
+                )
+                if _snap_holds > 0:
+                    sentry_capture_message_with_context(
+                        f"Snapshot-drift hold applied to {_snap_holds} "
+                        "row(s)",
+                        level="warning",
+                        context_name="snapshot_drift",
+                        context_data=_snapshot_drift_summary,
+                        tags={"subsystem": "snapshot_drift"},
+                    )
         except Exception as _snap_exc:
             logging.warning(f"⚠️ Snapshot-drift audit error: {_snap_exc}")
             _snapshot_drift_summary = {'enabled': False}

--- a/pipeline/snapshot_drift.py
+++ b/pipeline/snapshot_drift.py
@@ -418,6 +418,62 @@ def _classify_candidates(
     return None
 
 
+# ── hold-prior-week override (Task 3) ────────────────────────────────
+
+def _apply_holds(
+    candidates: "list[dict[str, Any]]", hold_enabled: bool
+) -> int:
+    """Apply the hold-prior-week override to automation self-fire
+    candidates ONLY (D-01) -- manual and unclassified candidates flow
+    through untouched (D-02, D-03), regardless of ``hold_enabled``.
+
+    Rewrites BOTH ``Weekly Reference Logged Date`` (drives the week
+    key in ``pipeline/grouping.py``) AND ``Snapshot Date`` (drives
+    ``generate_excel``'s Monday-Sunday bucket filter AND participates
+    in the content hash / sort key in
+    ``pipeline/change_detection.py``) -- rewriting only one field
+    would silently exclude the row from the workbook body, strictly
+    worse than the drift itself (RESEARCH pitfall 1). The drifted
+    originals are preserved under private double-underscore keys so
+    they survive into logging, the Supabase event row, and any later
+    diagnosis. Returns the number of rows held.
+    """
+    held_count = 0
+    for candidate in candidates:
+        if not hold_enabled:
+            continue
+        if candidate["classification"] != _CLASSIFICATION_AUTOMATION_SELF_FIRE:
+            continue
+
+        row = candidate["row"]
+        row["__drifted_weekly_reference_logged_date"] = row.get(
+            "Weekly Reference Logged Date"
+        )
+        row["__drifted_snapshot_date"] = row.get("Snapshot Date")
+        row["__snapshot_drift_classification"] = candidate["classification"]
+        row["__snapshot_drift_changed_by"] = candidate.get("changed_by")
+        row["__snapshot_drift_prior_week"] = candidate["prior_billed_week"]
+        row["__snapshot_drift_new_week"] = candidate["new_week"]
+
+        row["Weekly Reference Logged Date"] = candidate[
+            "prior_billed_week"
+        ].isoformat()
+        row["Snapshot Date"] = _iso_date_str(candidate["prior_snapshot_date"])
+
+        candidate["held"] = True
+        held_count += 1
+
+        logging.info(
+            "🔒 Snapshot-drift hold: WR %s row %s held at prior week %s "
+            "(drifted to %s, changed_by=%s)",
+            candidate["wr"], candidate["row_id"],
+            candidate["prior_billed_week"].isoformat(),
+            candidate["new_week"].isoformat(),
+            candidate.get("changed_by"),
+        )
+    return held_count
+
+
 def apply_snapshot_drift_holds(
     all_rows: "list[dict]",
     source_sheets: "list[dict]",
@@ -514,6 +570,10 @@ def apply_snapshot_drift_holds(
             client, candidates, source_sheets, session_start
         )
         summary["skip_reason"] = skip_reason
+
+        summary["automation_self_fire_holds"] = _apply_holds(
+            candidates, hold_enabled
+        )
 
         drift_events: "list[dict[str, Any]]" = []
         for candidate in candidates:

--- a/pipeline/snapshot_drift.py
+++ b/pipeline/snapshot_drift.py
@@ -445,6 +445,23 @@ def _apply_holds(
         if candidate["classification"] != _CLASSIFICATION_AUTOMATION_SELF_FIRE:
             continue
 
+        # CR-02: a NULL baseline snapshot_date (seeded while the
+        # Snapshot Date cell was blank/unparseable -- an observed VAC
+        # crew failure mode) must never be written into the row. The
+        # Excel Monday-Sunday day-block filter treats a None Snapshot
+        # Date as "outside the week" and silently drops the row from
+        # the workbook -- strictly worse than the drift itself. Skip
+        # the hold for this candidate (classify + log only).
+        prior_snapshot = _coerce_date(candidate["prior_snapshot_date"])
+        if prior_snapshot is None:
+            logging.warning(
+                "⚠️ Snapshot-drift hold skipped for WR %s row %s: no "
+                "prior snapshot date on baseline (row would be dropped "
+                "by the Excel week filter).",
+                candidate["wr"], candidate["row_id"],
+            )
+            continue
+
         row = candidate["row"]
         row["__drifted_weekly_reference_logged_date"] = row.get(
             "Weekly Reference Logged Date"
@@ -458,7 +475,7 @@ def _apply_holds(
         row["Weekly Reference Logged Date"] = candidate[
             "prior_billed_week"
         ].isoformat()
-        row["Snapshot Date"] = _iso_date_str(candidate["prior_snapshot_date"])
+        row["Snapshot Date"] = prior_snapshot.isoformat()
 
         candidate["held"] = True
         held_count += 1

--- a/pipeline/snapshot_drift.py
+++ b/pipeline/snapshot_drift.py
@@ -1,0 +1,360 @@
+"""pipeline.snapshot_drift -- snapshot-date drift audit + hold gate.
+
+Quick task 260812-jqx. Defence-in-depth backstop for the Smartsheet
+"record Snapshot Date" automation firing on ANY row change where
+``Units Completed?`` is checked (same-value saves, bulk API/DataTable
+touches), which silently re-stamps ``Snapshot Date`` to today and
+moves an already-billed unit into the current billing week --
+``Weekly Reference Logged Date`` is ``Snapshot Date`` snapped to
+Sunday (living-ledger ``[2026-08-12 13:40]``).
+
+``apply_snapshot_drift_holds(all_rows, source_sheets, client,
+session_start)`` is the single public entry point, called from
+``pipeline/orchestrate.py`` at the pre-grouping seam (after the audit
+``else:`` branch, before ``group_source_rows``). It:
+
+1. Builds ``(sheet_id, row_id)`` candidate keys from every row that
+   carries a Work Request # and a parseable ``Weekly Reference Logged
+   Date``.
+2. Bulk-reads prior billing provenance from
+   ``billing_audit.snapshot_provenance`` -- ONE Supabase call for the
+   whole run (D-06, RESEARCH caveat 6).
+3. A row with no baseline is a first-sight seed (D-09): no drift flag,
+   no cell-history call, no hold. A row whose computed week matches
+   its baseline costs zero extra API calls (D-04). A row whose week
+   differs from its baseline becomes a drift CANDIDATE.
+4. Each candidate is classified via targeted Smartsheet cell-history
+   lookups (capped, paced, budget-aware -- see
+   ``_classify_candidates``) as an automation self-fire, manual, or
+   unclassified (D-05, D-10).
+5. Automation self-fires are held to their prior billed week when
+   ``SNAPSHOT_DRIFT_HOLD_ENABLED`` is on (D-01) -- manual and
+   unclassified candidates are NEVER held (D-02, D-03).
+6. Every candidate -- held or not -- is written to
+   ``billing_audit.snapshot_drift`` (fail-closed logging half of
+   D-03), and provenance is refreshed for every row seen this run.
+
+The whole pass is wrapped so no exception ever escapes to the caller:
+a missing Supabase client, an unapplied migration, or a fetch failure
+degrades to the no-baseline (seed-only) path and never blocks a
+billing run (D-07).
+"""
+from __future__ import annotations
+
+import datetime
+import logging
+import os
+from typing import Any
+
+from pipeline.utils import excel_serial_to_date
+
+logger = logging.getLogger(__name__)
+
+# Classification values. ``_CLASSIFICATION_PENDING`` is an internal-
+# only placeholder used for a drift candidate that has not yet been
+# through the classifier (never persisted past a completed run once
+# the classifier is wired in).
+_CLASSIFICATION_PENDING = "pending"
+_CLASSIFICATION_AUTOMATION_SELF_FIRE = "automation_self_fire"
+_CLASSIFICATION_MANUAL = "manual"
+_CLASSIFICATION_UNCLASSIFIED = "unclassified"
+
+
+# ── env-var helpers ──────────────────────────────────────────────────
+# Read PER CALL, not at import (D-08) -- exactly as
+# ``audit_billing_changes.py:376`` does for ``RATE_SANITY_AUDIT_ENABLED``
+# -- so tests can toggle any switch without reloading a module.
+
+def _bool_env(name: str, default: bool) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() == "true"
+
+
+def _int_env(name: str, default: int) -> int:
+    try:
+        return int(os.getenv(name, str(default)) or default)
+    except (TypeError, ValueError):
+        return default
+
+
+def _float_env(name: str, default: float) -> float:
+    try:
+        return float(os.getenv(name, str(default)) or default)
+    except (TypeError, ValueError):
+        return default
+
+
+def _str_env(name: str, default: str) -> str:
+    return os.getenv(name, default) or default
+
+
+def _empty_summary() -> "dict[str, Any]":
+    return {
+        "enabled": False,
+        "available": True,
+        "hold_enabled": False,
+        "candidates": 0,
+        "seeded": 0,
+        "unchanged": 0,
+        "automation_self_fire": 0,
+        "manual": 0,
+        "unclassified": 0,
+        "automation_self_fire_holds": 0,
+        "skip_reason": None,
+    }
+
+
+def _build_run_id() -> str:
+    """Mirror ``pipeline/orchestrate.py``'s ``_billing_audit_run_id_env``
+    derivation (relocated locally: the seam runs BEFORE that variable
+    is computed in the per-group processing loop)."""
+    ga_run_id = os.getenv("GITHUB_RUN_ID", "")
+    if ga_run_id:
+        attempt = os.getenv("GITHUB_RUN_ATTEMPT", "")
+        return f"{ga_run_id}.{attempt}" if attempt else ga_run_id
+    return "local-" + datetime.datetime.utcnow().strftime("%Y%m%dT%H%M%S%fZ")
+
+
+def _coerce_date(value: Any) -> "datetime.date | None":
+    """Best-effort coercion to a ``datetime.date``.
+
+    Accepts ``date``, ``datetime``, or an ISO-ish string (Supabase
+    returns DATE columns as ``YYYY-MM-DD`` strings). Never raises.
+    """
+    if value is None:
+        return None
+    if isinstance(value, datetime.datetime):
+        return value.date()
+    if isinstance(value, datetime.date):
+        return value
+    if isinstance(value, str):
+        parsed = excel_serial_to_date(value)
+        if parsed is None:
+            return None
+        return parsed.date() if hasattr(parsed, "date") else parsed
+    return None
+
+
+def _iso_date_str(value: Any) -> "str | None":
+    coerced = _coerce_date(value)
+    return coerced.isoformat() if coerced else None
+
+
+def _collect_candidate_rows(
+    all_rows: "list[dict]",
+) -> "dict[tuple[int, int], tuple[dict, datetime.date]]":
+    """Return ``{(sheet_id, row_id): (row, computed_week)}`` for every
+    row that carries a WR, row identity, and a parseable ``Weekly
+    Reference Logged Date``. Rows without these are simply ineligible
+    for the drift audit (they are also excluded from grouping)."""
+    result: "dict[tuple[int, int], tuple[dict, datetime.date]]" = {}
+    for row in all_rows or []:
+        sheet_id = row.get("__source_sheet_id")
+        row_id = row.get("__row_id")
+        if not isinstance(sheet_id, int) or not isinstance(row_id, int):
+            continue
+        if not row.get("Work Request #"):
+            continue
+        raw_week = row.get("Weekly Reference Logged Date")
+        if not raw_week:
+            continue
+        parsed = excel_serial_to_date(raw_week)
+        if parsed is None:
+            continue
+        week_d = parsed.date() if hasattr(parsed, "date") else parsed
+        result[(sheet_id, row_id)] = (row, week_d)
+    return result
+
+
+def _provenance_record(
+    sheet_id: int,
+    row_id: int,
+    wr: str,
+    cu: str,
+    snapshot_date: Any,
+    billed_week: "datetime.date | None",
+    run_id: str,
+    first_seen_at: str,
+    now: datetime.datetime,
+) -> "dict[str, Any]":
+    return {
+        "sheet_id": sheet_id,
+        "row_id": row_id,
+        "wr": wr,
+        "cu": cu,
+        "snapshot_date": _iso_date_str(snapshot_date),
+        "billed_week": billed_week.isoformat() if billed_week else None,
+        "run_id": run_id,
+        "first_seen_at": first_seen_at,
+        "last_seen_at": now.isoformat(),
+    }
+
+
+def _drift_event_record(
+    candidate: "dict[str, Any]", now: datetime.datetime, run_id: str
+) -> "dict[str, Any]":
+    return {
+        "sheet_id": candidate["sheet_id"],
+        "row_id": candidate["row_id"],
+        "detected_at": now.isoformat(),
+        "wr": candidate["wr"],
+        "cu": candidate["cu"],
+        "prior_snapshot_date": _iso_date_str(candidate["prior_snapshot_date"]),
+        "new_snapshot_date": _iso_date_str(candidate["new_snapshot_date"]),
+        "prior_billed_week": candidate["prior_billed_week"].isoformat(),
+        "new_week": candidate["new_week"].isoformat(),
+        "changed_by": candidate.get("changed_by"),
+        "classification": candidate["classification"],
+        "held": bool(candidate.get("held", False)),
+        "run_id": run_id,
+    }
+
+
+def apply_snapshot_drift_holds(
+    all_rows: "list[dict]",
+    source_sheets: "list[dict]",
+    client: Any,
+    session_start: datetime.datetime,
+) -> "dict[str, Any]":
+    """Detect, classify, and (when enabled) hold snapshot-date drift.
+
+    Returns a summary dict (see ``_empty_summary``). NEVER raises --
+    every failure mode degrades to a safe, logged no-op (D-07).
+    """
+    summary = _empty_summary()
+
+    if not _bool_env("SNAPSHOT_DRIFT_AUDIT_ENABLED", True):
+        return summary
+    summary["enabled"] = True
+    hold_enabled = _bool_env("SNAPSHOT_DRIFT_HOLD_ENABLED", False)
+    summary["hold_enabled"] = hold_enabled
+
+    try:
+        keyed_rows = _collect_candidate_rows(all_rows)
+        if not keyed_rows:
+            return summary
+
+        try:
+            from billing_audit import snapshot_store as _store  # noqa: PLC0415
+        except Exception:
+            summary["available"] = False
+            return summary
+
+        try:
+            baseline_map, status = _store.fetch_snapshot_provenance(
+                sorted(keyed_rows.keys())
+            )
+        except Exception:
+            baseline_map, status = {}, "fetch_failure"
+
+        summary["available"] = status not in ("unavailable", "fetch_failure")
+
+        now = datetime.datetime.now(datetime.timezone.utc)
+        run_id = _build_run_id()
+        provenance_records: "list[dict[str, Any]]" = []
+        candidates: "list[dict[str, Any]]" = []
+
+        for key, (row, week_d) in keyed_rows.items():
+            sheet_id, row_id = key
+            baseline = baseline_map.get(key)
+            snapshot_date = row.get("Snapshot Date")
+            wr = _store.sanitized_wr(row)
+            cu = str(row.get("CU") or "")
+            first_seen_at = (baseline or {}).get("first_seen_at") or now.isoformat()
+            billed_week = _coerce_date((baseline or {}).get("billed_week"))
+
+            if baseline is None or billed_week is None:
+                summary["seeded"] += 1
+                provenance_records.append(
+                    _provenance_record(
+                        sheet_id, row_id, wr, cu, snapshot_date, week_d,
+                        run_id, first_seen_at, now,
+                    )
+                )
+                continue
+
+            if billed_week == week_d:
+                summary["unchanged"] += 1
+                provenance_records.append(
+                    _provenance_record(
+                        sheet_id, row_id, wr, cu, snapshot_date, week_d,
+                        run_id, first_seen_at, now,
+                    )
+                )
+                continue
+
+            summary["candidates"] += 1
+            candidates.append(
+                {
+                    "sheet_id": sheet_id,
+                    "row_id": row_id,
+                    "row": row,
+                    "wr": wr,
+                    "cu": cu,
+                    "prior_snapshot_date": baseline.get("snapshot_date"),
+                    "prior_billed_week": billed_week,
+                    "new_snapshot_date": snapshot_date,
+                    "new_week": week_d,
+                    "classification": _CLASSIFICATION_PENDING,
+                    "changed_by": None,
+                    "held": False,
+                    "first_seen_at": first_seen_at,
+                }
+            )
+
+        drift_events: "list[dict[str, Any]]" = []
+        for candidate in candidates:
+            classification = candidate["classification"]
+            if classification in summary:
+                summary[classification] += 1
+            final_week = (
+                candidate["prior_billed_week"] if candidate["held"]
+                else candidate["new_week"]
+            )
+            final_snapshot = (
+                candidate["prior_snapshot_date"] if candidate["held"]
+                else candidate["new_snapshot_date"]
+            )
+            provenance_records.append(
+                _provenance_record(
+                    candidate["sheet_id"], candidate["row_id"],
+                    candidate["wr"], candidate["cu"], final_snapshot,
+                    final_week, run_id, candidate["first_seen_at"], now,
+                )
+            )
+            drift_events.append(_drift_event_record(candidate, now, run_id))
+
+        try:
+            _store.upsert_snapshot_provenance(provenance_records)
+        except Exception:
+            logger.exception(
+                "⚠️ Snapshot-drift provenance upsert raised unexpectedly "
+                "(non-fatal)."
+            )
+        try:
+            _store.insert_snapshot_drift_events(drift_events)
+        except Exception:
+            logger.exception(
+                "⚠️ Snapshot-drift event insert raised unexpectedly "
+                "(non-fatal)."
+            )
+
+        logging.info(
+            "📌 Snapshot-drift audit: candidates=%d seeded=%d unchanged=%d "
+            "automation_self_fire=%d manual=%d unclassified=%d holds=%d",
+            summary["candidates"], summary["seeded"], summary["unchanged"],
+            summary["automation_self_fire"], summary["manual"],
+            summary["unclassified"], summary["automation_self_fire_holds"],
+        )
+        return summary
+    except Exception:
+        # Belt-and-suspenders (D-07): a misconfigured or malfunctioning
+        # drift audit must NEVER break the billing run.
+        logger.exception(
+            "⚠️ Snapshot-drift audit failed unexpectedly (non-fatal); "
+            "continuing without drift detection this run."
+        )
+        summary["available"] = False
+        return summary

--- a/pipeline/snapshot_drift.py
+++ b/pipeline/snapshot_drift.py
@@ -44,7 +44,10 @@ from __future__ import annotations
 import datetime
 import logging
 import os
+import time
 from typing import Any
+
+from dateutil import parser as _dateutil_parser
 
 from pipeline.utils import excel_serial_to_date
 
@@ -212,6 +215,209 @@ def _drift_event_record(
     }
 
 
+# ── cell-history classification (Task 2) ─────────────────────────────
+
+def _parse_history_timestamp(raw: Any) -> "datetime.datetime | None":
+    """Parse a cell-history ``modified_at`` value to a tz-aware
+    ``datetime``. Uses ``dateutil.parser`` directly (NOT
+    ``excel_serial_to_date``, whose ISO fast-path truncates to just
+    the date and would destroy the time-of-day precision the +/-2
+    minute window comparison needs). Never raises."""
+    if raw is None:
+        return None
+    if isinstance(raw, datetime.datetime):
+        dt = raw
+    elif isinstance(raw, str):
+        try:
+            dt = _dateutil_parser.parse(raw)
+        except Exception:
+            return None
+    else:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=datetime.timezone.utc)
+    return dt
+
+
+def _entry_modified_at(entry: Any) -> "datetime.datetime | None":
+    raw = getattr(entry, "modified_at", None)
+    if raw is None and isinstance(entry, dict):
+        raw = entry.get("modified_at")
+    return _parse_history_timestamp(raw)
+
+
+def _entry_email(entry: Any) -> "str | None":
+    """Defensively read the identity off a cell-history entry.
+
+    ``modified_by`` shows up as a ``User``-like object with ``.email``,
+    a bare string, or ``None`` (assumption A1) -- never raises."""
+    mb = getattr(entry, "modified_by", None)
+    if mb is None and isinstance(entry, dict):
+        mb = entry.get("modified_by")
+    if mb is None:
+        return None
+    email = getattr(mb, "email", None)
+    if email:
+        return str(email)
+    if isinstance(mb, str) and mb:
+        return mb
+    return str(mb) if mb else None
+
+
+def _sorted_history_entries(history_result: Any) -> "list[Any]":
+    """Return ``history_result.data`` sorted ascending by
+    ``modified_at``. The API's own ordering is NOT trusted (assumption
+    A1) -- entries with an unparseable/missing timestamp sort first."""
+    data = getattr(history_result, "data", None)
+    if data is None and isinstance(history_result, (list, tuple)):
+        data = history_result
+    entries = list(data or [])
+    epoch = datetime.datetime.min.replace(tzinfo=datetime.timezone.utc)
+    return sorted(entries, key=lambda e: _entry_modified_at(e) or epoch)
+
+
+def _classify_drift_candidate(
+    fetch_history: Any, candidate: "dict[str, Any]",
+    snapshot_col: int, units_col: int,
+) -> "tuple[str, str | None]":
+    """Classify ONE drift candidate via targeted cell-history reads.
+
+    Returns ``(classification, changed_by)``. NEVER raises -- any
+    exception, timeout, or malformed payload yields 'unclassified'
+    (D-03 fail-open on gating). The newest Snapshot Date write by the
+    automation identity, with NO Units Completed? history entry whose
+    ``modified_at`` falls within +/-2 minutes of it, is an automation
+    self-fire; anything else is manual (D-05).
+    """
+    sheet_id = candidate["sheet_id"]
+    row_id = candidate["row_id"]
+    try:
+        snap_entries = _sorted_history_entries(
+            fetch_history(sheet_id, row_id, snapshot_col)
+        )
+        if not snap_entries:
+            return _CLASSIFICATION_UNCLASSIFIED, None
+
+        newest = snap_entries[-1]
+        newest_email = _entry_email(newest)
+        automation_email = _str_env(
+            "SNAPSHOT_DRIFT_AUTOMATION_EMAIL", "automation@smartsheet.com"
+        ).strip().lower()
+
+        if not newest_email or newest_email.strip().lower() != automation_email:
+            # Snapshot Date history alone already rules out the
+            # automation identity -- skip the second call (action
+            # item 4) and save the quota.
+            return _CLASSIFICATION_MANUAL, newest_email
+
+        units_entries = _sorted_history_entries(
+            fetch_history(sheet_id, row_id, units_col)
+        )
+        newest_ts = _entry_modified_at(newest)
+        window = datetime.timedelta(minutes=2)
+        nearby_units_change = False
+        if newest_ts is not None:
+            for entry in units_entries:
+                entry_ts = _entry_modified_at(entry)
+                if entry_ts is not None and abs(entry_ts - newest_ts) <= window:
+                    nearby_units_change = True
+                    break
+
+        if nearby_units_change:
+            return _CLASSIFICATION_MANUAL, newest_email
+        return _CLASSIFICATION_AUTOMATION_SELF_FIRE, newest_email
+    except Exception:
+        logger.warning(
+            "⚠️ Snapshot-drift classification failed for sheet=%s row=%s; "
+            "marking unclassified.",
+            sheet_id, row_id,
+        )
+        return _CLASSIFICATION_UNCLASSIFIED, None
+
+
+def _classify_candidates(
+    client: Any,
+    candidates: "list[dict[str, Any]]",
+    source_sheets: "list[dict]",
+    session_start: datetime.datetime,
+) -> "str | None":
+    """Classify ``candidates`` in place (mutates 'classification' /
+    'changed_by'), respecting the per-run cap, self-pacing, and the
+    session sub-budget. Returns the skip reason (or ``None``) when the
+    pre-flight budget guard fired."""
+    if not candidates:
+        return None
+
+    max_rows = _int_env("SNAPSHOT_DRIFT_MAX_ROWS", 40)
+    pace_sec = _float_env("SNAPSHOT_DRIFT_PACE_SEC", 2.0)
+    max_minutes = _float_env("SNAPSHOT_DRIFT_MAX_MINUTES", 5.0)
+    time_budget_minutes = _float_env("TIME_BUDGET_MINUTES", 0.0)
+    github_actions_mode = os.getenv("GITHUB_ACTIONS") == "true"
+
+    # Pre-flight budget guard (D-10), copying the shape at
+    # pipeline/orchestrate.py:683-685: when the session budget is
+    # already tight, skip classification for the ENTIRE run rather
+    # than stall it. Every candidate degrades to unclassified.
+    if time_budget_minutes and github_actions_mode:
+        elapsed_min = (
+            datetime.datetime.now() - session_start
+        ).total_seconds() / 60.0
+        remaining_min = time_budget_minutes - elapsed_min
+        if remaining_min < max_minutes:
+            skip_reason = (
+                f"session budget low ({remaining_min:.1f}min remaining, "
+                f"need >= {max_minutes:.1f}min sub-budget)"
+            )
+            for candidate in candidates:
+                candidate["classification"] = _CLASSIFICATION_UNCLASSIFIED
+            logging.info(
+                "⏩ Snapshot-drift classification skipped: %s", skip_reason
+            )
+            return skip_reason
+
+    sheet_by_id = {s.get("id"): s for s in (source_sheets or [])}
+    ordered = sorted(candidates, key=lambda c: (c["sheet_id"], c["row_id"]))
+    deadline = datetime.datetime.now() + datetime.timedelta(minutes=max_minutes)
+
+    called_once = [False]
+
+    def _fetch_history(sheet_id: int, row_id: int, column_id: int) -> Any:
+        # Self-pacing (mandatory, RESEARCH caveat 2): sleep between
+        # calls, never before the first one this run.
+        if called_once[0]:
+            time.sleep(pace_sec)
+        called_once[0] = True
+        return client.Cells.get_cell_history(
+            sheet_id, row_id, column_id, include_all=True
+        )
+
+    for index, candidate in enumerate(ordered):
+        if index >= max_rows:
+            candidate["classification"] = _CLASSIFICATION_UNCLASSIFIED
+            continue
+        if datetime.datetime.now() >= deadline:
+            candidate["classification"] = _CLASSIFICATION_UNCLASSIFIED
+            continue
+
+        source = sheet_by_id.get(candidate["sheet_id"])
+        column_mapping = (source or {}).get("column_mapping") or {}
+        snapshot_col = column_mapping.get("Snapshot Date")
+        units_col = column_mapping.get("Units Completed?")
+        if snapshot_col is None or units_col is None:
+            # Assumption A2: the Snapshot Date mapping is already
+            # known to be optional per sheet -- no API call.
+            candidate["classification"] = _CLASSIFICATION_UNCLASSIFIED
+            continue
+
+        classification, changed_by = _classify_drift_candidate(
+            _fetch_history, candidate, snapshot_col, units_col,
+        )
+        candidate["classification"] = classification
+        candidate["changed_by"] = changed_by
+
+    return None
+
+
 def apply_snapshot_drift_holds(
     all_rows: "list[dict]",
     source_sheets: "list[dict]",
@@ -303,6 +509,11 @@ def apply_snapshot_drift_holds(
                     "first_seen_at": first_seen_at,
                 }
             )
+
+        skip_reason = _classify_candidates(
+            client, candidates, source_sheets, session_start
+        )
+        summary["skip_reason"] = skip_reason
 
         drift_events: "list[dict[str, Any]]" = []
         for candidate in candidates:

--- a/pipeline/snapshot_drift.py
+++ b/pipeline/snapshot_drift.py
@@ -597,12 +597,25 @@ def apply_snapshot_drift_holds(
             )
             drift_events.append(_drift_event_record(candidate, now, run_id))
 
-        try:
-            _store.upsert_snapshot_provenance(provenance_records)
-        except Exception:
-            logger.exception(
-                "⚠️ Snapshot-drift provenance upsert raised unexpectedly "
-                "(non-fatal)."
+        if status in ("success", "no_row"):
+            try:
+                _store.upsert_snapshot_provenance(provenance_records)
+            except Exception:
+                logger.exception(
+                    "⚠️ Snapshot-drift provenance upsert raised "
+                    "unexpectedly (non-fatal)."
+                )
+        else:
+            # CR-01: a transient/failed bulk read (status in
+            # {'fetch_failure', 'unavailable'}) must NEVER upsert --
+            # baseline_map degraded to {} for this run, so every row
+            # fell through the seed path above. Upserting here would
+            # overwrite every EXISTING baseline's billed_week with the
+            # row's current week, silently laundering any in-flight
+            # drift with no candidate, no event, no future detection.
+            logger.warning(
+                "⚠️ Snapshot-drift provenance upsert skipped: bulk read "
+                "status=%s (avoid rebasing existing baselines).", status,
             )
         try:
             _store.insert_snapshot_drift_events(drift_events)

--- a/pipeline/snapshot_drift.py
+++ b/pipeline/snapshot_drift.py
@@ -611,14 +611,37 @@ def apply_snapshot_drift_holds(
             classification = candidate["classification"]
             if classification in summary:
                 summary[classification] += 1
-            final_week = (
-                candidate["prior_billed_week"] if candidate["held"]
-                else candidate["new_week"]
-            )
-            final_snapshot = (
-                candidate["prior_snapshot_date"] if candidate["held"]
-                else candidate["new_snapshot_date"]
-            )
+            drift_events.append(_drift_event_record(candidate, now, run_id))
+            if classification == _CLASSIFICATION_AUTOMATION_SELF_FIRE:
+                # Held -> the row bills at its prior week, so the
+                # baseline stays there. Unheld (report-only) -> the
+                # row actually bills at the drifted week; accept it as
+                # the new baseline so each drift alerts exactly once
+                # (the event above is the durable record) instead of
+                # re-consuming the classification cap every run.
+                final_week = (
+                    candidate["prior_billed_week"] if candidate["held"]
+                    else candidate["new_week"]
+                )
+                final_snapshot = (
+                    candidate["prior_snapshot_date"] if candidate["held"]
+                    else candidate["new_snapshot_date"]
+                )
+            elif classification == _CLASSIFICATION_MANUAL:
+                final_week = candidate["new_week"]
+                final_snapshot = candidate["new_snapshot_date"]
+            else:
+                # Unclassified/pending (budget exhausted, history
+                # unreadable, missing column mapping): finalizing here
+                # would rebase the baseline to the drifted week and the
+                # next run would read the row as 'unchanged' -- the
+                # drift laundered with no retry possible. Skip the
+                # provenance record instead: the prior billed_week
+                # stays authoritative and the row re-enters candidacy
+                # next run for another classification attempt (bounded
+                # by the per-run cap; the row still bills fail-open at
+                # its sheet value this run).
+                continue
             provenance_records.append(
                 _provenance_record(
                     candidate["sheet_id"], candidate["row_id"],
@@ -626,7 +649,6 @@ def apply_snapshot_drift_holds(
                     final_week, run_id, candidate["first_seen_at"], now,
                 )
             )
-            drift_events.append(_drift_event_record(candidate, now, run_id))
 
         if status in ("success", "no_row"):
             try:

--- a/pipeline/snapshot_drift.py
+++ b/pipeline/snapshot_drift.py
@@ -286,8 +286,14 @@ def _classify_drift_candidate(
     exception, timeout, or malformed payload yields 'unclassified'
     (D-03 fail-open on gating). The newest Snapshot Date write by the
     automation identity, with NO Units Completed? history entry whose
-    ``modified_at`` falls within +/-2 minutes of it, is an automation
-    self-fire; anything else is manual (D-05).
+    ``modified_at`` falls within the ``SNAPSHOT_DRIFT_UNITS_WINDOW_MINUTES``
+    window (default 15 minutes -- widened from a hardcoded 2 after
+    live cell-history evidence showed the automation BATCHES writes:
+    legitimate stamps landed 3m50s-4m22s after their Units Completed?
+    check) of it, is an automation self-fire; anything else is manual
+    (D-05). A newest write with no parseable timestamp is
+    'unclassified' (WR-01): the window cannot be evaluated, so the
+    conservative (hold-ineligible) outcome applies.
     """
     sheet_id = candidate["sheet_id"]
     row_id = candidate["row_id"]
@@ -314,14 +320,22 @@ def _classify_drift_candidate(
             fetch_history(sheet_id, row_id, units_col)
         )
         newest_ts = _entry_modified_at(newest)
-        window = datetime.timedelta(minutes=2)
+        if newest_ts is None:
+            # WR-01: the +/- window cannot be evaluated without a
+            # parseable timestamp -- do not grant automation_self_fire
+            # on incomplete evidence.
+            return _CLASSIFICATION_UNCLASSIFIED, newest_email
+
+        window_minutes = _float_env(
+            "SNAPSHOT_DRIFT_UNITS_WINDOW_MINUTES", 15.0
+        )
+        window = datetime.timedelta(minutes=window_minutes)
         nearby_units_change = False
-        if newest_ts is not None:
-            for entry in units_entries:
-                entry_ts = _entry_modified_at(entry)
-                if entry_ts is not None and abs(entry_ts - newest_ts) <= window:
-                    nearby_units_change = True
-                    break
+        for entry in units_entries:
+            entry_ts = _entry_modified_at(entry)
+            if entry_ts is not None and abs(entry_ts - newest_ts) <= window:
+                nearby_units_change = True
+                break
 
         if nearby_units_change:
             return _CLASSIFICATION_MANUAL, newest_email

--- a/tests/test_snapshot_drift_audit.py
+++ b/tests/test_snapshot_drift_audit.py
@@ -313,7 +313,21 @@ def _drift_row_and_baseline(sheet_id=111, row_id=222, wr="90001"):
 
 class SnapshotDriftClassifierTestBase(SnapshotDriftDetectionTestBase):
     """Adds a configurable Cells.get_cell_history side_effect keyed by
-    column id, so each test only needs to describe the two histories."""
+    column id, so each test only needs to describe the two histories.
+
+    WR-04: also forces ``SNAPSHOT_DRIFT_PACE_SEC=0`` so classifier/hold
+    tests that drive real cell-history calls don't pay the production
+    2.0s self-pacing sleep. ``TestTask2PacingBetweenCalls`` overrides
+    this back to the real default to exercise actual pacing config.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self._pace_patch = mock.patch.dict(
+            "os.environ", {"SNAPSHOT_DRIFT_PACE_SEC": "0"}
+        )
+        self._pace_patch.start()
+        self.addCleanup(self._pace_patch.stop)
 
     def _wire_history(self, snapshot_entries=None, units_entries=None):
         snapshot_entries = snapshot_entries or []
@@ -395,6 +409,91 @@ class TestTask2HumanEmailIsManualNoSecondCall(SnapshotDriftClassifierTestBase):
         # Snapshot Date history alone already rules out automation --
         # skip the Units Completed? call and save the quota.
         self.assertEqual(self.client.Cells.get_cell_history.call_count, 1)
+
+
+class TestTask2UnparseableNewestTimestampIsUnclassified(
+    SnapshotDriftClassifierTestBase
+):
+    """WR-01 regression: an automation-identity Snapshot Date write
+    whose ``modified_at`` cannot be parsed must NOT be granted
+    ``automation_self_fire`` on incomplete evidence -- the conservative
+    (hold-ineligible) outcome is ``unclassified``."""
+
+    def test_unparseable_newest_timestamp_is_unclassified(self) -> None:
+        row, baseline = _drift_row_and_baseline()
+        self.mock_fetch.return_value = (baseline, "success")
+        self._wire_history(
+            snapshot_entries=[
+                _entry("not-a-real-timestamp",
+                       types.SimpleNamespace(email=AUTOMATION_EMAIL)),
+            ],
+            units_entries=[],
+        )
+
+        summary = apply_snapshot_drift_holds(
+            [row], _source_sheets(), self.client, self.session_start
+        )
+
+        self.assertEqual(summary["unclassified"], 1)
+        self.assertEqual(summary["automation_self_fire"], 0)
+        self.assertEqual(summary["manual"], 0)
+
+
+class TestTask2UnitsChangeWindowWidened(SnapshotDriftClassifierTestBase):
+    """WR-04/live-evidence regression: the automation batches writes --
+    live cell-history verification showed legitimate stamps landing
+    3m50s-4m22s after their Units Completed? check. The classification
+    window must default to 15 minutes (not the old hardcoded 2) and
+    must be overridable via ``SNAPSHOT_DRIFT_UNITS_WINDOW_MINUTES``."""
+
+    def test_units_change_4_5_min_before_stamp_is_manual_default_window(
+        self,
+    ) -> None:
+        row, baseline = _drift_row_and_baseline()
+        self.mock_fetch.return_value = (baseline, "success")
+        self._wire_history(
+            snapshot_entries=[
+                _entry("2026-08-12T10:00:00Z",
+                       types.SimpleNamespace(email=AUTOMATION_EMAIL)),
+            ],
+            units_entries=[
+                _entry("2026-08-12T09:55:30Z",
+                       types.SimpleNamespace(email="foreman@example.com")),
+            ],
+        )
+
+        summary = apply_snapshot_drift_holds(
+            [row], _source_sheets(), self.client, self.session_start
+        )
+
+        self.assertEqual(summary["manual"], 1)
+        self.assertEqual(summary["automation_self_fire"], 0)
+
+    def test_env_override_narrows_window_reclassifies_as_self_fire(
+        self,
+    ) -> None:
+        row, baseline = _drift_row_and_baseline()
+        self.mock_fetch.return_value = (baseline, "success")
+        self._wire_history(
+            snapshot_entries=[
+                _entry("2026-08-12T10:00:00Z",
+                       types.SimpleNamespace(email=AUTOMATION_EMAIL)),
+            ],
+            units_entries=[
+                _entry("2026-08-12T09:55:30Z",
+                       types.SimpleNamespace(email="foreman@example.com")),
+            ],
+        )
+
+        with mock.patch.dict(
+            "os.environ", {"SNAPSHOT_DRIFT_UNITS_WINDOW_MINUTES": "2"}
+        ):
+            summary = apply_snapshot_drift_holds(
+                [row], _source_sheets(), self.client, self.session_start
+            )
+
+        self.assertEqual(summary["automation_self_fire"], 1)
+        self.assertEqual(summary["manual"], 0)
 
 
 class TestTask2ApiErrorIsUnclassified(SnapshotDriftClassifierTestBase):
@@ -556,7 +655,12 @@ class TestTask2PacingBetweenCalls(SnapshotDriftClassifierTestBase):
             units_entries=[],
         )
 
-        with mock.patch("pipeline.snapshot_drift.time.sleep") as mock_sleep:
+        # Override the base class's SNAPSHOT_DRIFT_PACE_SEC=0 (WR-04)
+        # back to the real production default -- this is the one test
+        # that must exercise actual pacing config.
+        with mock.patch.dict(
+            "os.environ", {"SNAPSHOT_DRIFT_PACE_SEC": "2.0"}
+        ), mock.patch("pipeline.snapshot_drift.time.sleep") as mock_sleep:
             apply_snapshot_drift_holds(
                 [row1, row2], _source_sheets(), self.client,
                 self.session_start,

--- a/tests/test_snapshot_drift_audit.py
+++ b/tests/test_snapshot_drift_audit.py
@@ -689,6 +689,44 @@ class TestTask3HeldRowSurvivesExcelFilter(SnapshotDriftClassifierTestBase):
         )
 
 
+class TestTask3HoldSkippedWhenBaselineSnapshotDateIsNull(
+    SnapshotDriftClassifierTestBase
+):
+    """CR-02 regression: a hold whose baseline ``snapshot_date`` is
+    NULL must NOT write ``None`` into ``Snapshot Date`` -- that value
+    is silently dropped by the Excel Monday-Sunday day-block filter,
+    which is strictly worse than the drift itself. The candidate must
+    be skipped (row left untouched, not counted as a hold)."""
+
+    def test_null_prior_snapshot_date_skips_hold(self) -> None:
+        row = _row(week="2026-08-09", snapshot="2026-08-05")
+        original = dict(row)
+        baseline = {
+            (111, 222): _baseline(
+                billed_week="2026-08-02", snapshot_date=None,
+            )
+        }
+        self.mock_fetch.return_value = (baseline, "success")
+        self._wire_history(
+            snapshot_entries=[
+                _entry("2026-08-12T10:00:00Z",
+                       types.SimpleNamespace(email=AUTOMATION_EMAIL)),
+            ],
+            units_entries=[],
+        )
+
+        with mock.patch.dict(
+            "os.environ", {"SNAPSHOT_DRIFT_HOLD_ENABLED": "true"}
+        ):
+            summary = apply_snapshot_drift_holds(
+                [row], _source_sheets(), self.client, self.session_start
+            )
+
+        self.assertEqual(summary["automation_self_fire"], 1)
+        self.assertEqual(summary["automation_self_fire_holds"], 0)
+        self.assertEqual(row, original)
+
+
 class TestTask3PriorWeekHashStability(SnapshotDriftClassifierTestBase):
     def test_hash_stable_across_drift_and_hold_both_modes(self) -> None:
         import generate_weekly_pdfs as _gwp

--- a/tests/test_snapshot_drift_audit.py
+++ b/tests/test_snapshot_drift_audit.py
@@ -444,9 +444,13 @@ class TestTask2BudgetGuardSkipsAll(SnapshotDriftClassifierTestBase):
             ],
         )
         # session_start far enough in the past that remaining budget
-        # (TIME_BUDGET_MINUTES - elapsed) is below SNAPSHOT_DRIFT_MAX_MINUTES.
+        # (TIME_BUDGET_MINUTES - elapsed) is comfortably below
+        # SNAPSHOT_DRIFT_MAX_MINUTES (5) -- margin wide enough that
+        # normal test-execution latency cannot flip the outcome
+        # (a boundary-exact 160/165 margin was observed flaky under
+        # the full suite's slower wall-clock scheduling).
         stale_session_start = (
-            datetime.datetime.now() - datetime.timedelta(minutes=160)
+            datetime.datetime.now() - datetime.timedelta(minutes=163)
         )
 
         with mock.patch.dict(
@@ -539,6 +543,345 @@ class TestTask2PacingBetweenCalls(SnapshotDriftClassifierTestBase):
         self.assertEqual(mock_sleep.call_count, 3)
         for call in mock_sleep.call_args_list:
             self.assertAlmostEqual(call.args[0], 2.0)
+
+
+# ── Task 3: hold-prior-week override + audit risk wiring ────────────
+
+def _billable_row(sheet_id=111, row_id=222, wr="90001", cu="ABC-123",
+                   week="2026-08-09", snapshot="2026-08-05",
+                   price="$777.00"):
+    row = _row(sheet_id=sheet_id, row_id=row_id, wr=wr, cu=cu,
+               week=week, snapshot=snapshot)
+    row.update({
+        "Units Total Price": price,
+        "Quantity": "2",
+        "Customer Name": "TestCustomer",
+        "Dept #": "500",
+        "Job #": "J-1",
+        "Work Type": "Install",
+        "Pole #": "P-1",
+        "Foreman": "TestForeman",
+        "__variant": "primary",
+        "__current_foreman": "TestForeman",
+        "__effective_user": "TestForeman",
+        "Units Completed?": True,
+    })
+    return row
+
+
+class TestTask3HoldRewritesBothFields(SnapshotDriftClassifierTestBase):
+    def test_hold_rewrites_both_fields_and_preserves_originals(self) -> None:
+        row, baseline = _drift_row_and_baseline()
+        self.mock_fetch.return_value = (baseline, "success")
+        self._wire_history(
+            snapshot_entries=[
+                _entry("2026-08-12T10:00:00Z",
+                       types.SimpleNamespace(email=AUTOMATION_EMAIL)),
+            ],
+            units_entries=[],
+        )
+
+        with mock.patch.dict(
+            "os.environ", {"SNAPSHOT_DRIFT_HOLD_ENABLED": "true"}
+        ):
+            summary = apply_snapshot_drift_holds(
+                [row], _source_sheets(), self.client, self.session_start
+            )
+
+        self.assertEqual(summary["automation_self_fire_holds"], 1)
+        self.assertEqual(row["Weekly Reference Logged Date"], "2026-08-02")
+        self.assertEqual(row["Snapshot Date"], "2026-07-29")
+        self.assertEqual(
+            row["__drifted_weekly_reference_logged_date"], "2026-08-09"
+        )
+        self.assertEqual(row["__drifted_snapshot_date"], "2026-08-05")
+        self.assertEqual(
+            row["__snapshot_drift_classification"], "automation_self_fire"
+        )
+
+
+class TestTask3HeldRowSurvivesExcelFilter(SnapshotDriftClassifierTestBase):
+    def test_held_row_appears_in_generated_workbook(self) -> None:
+        import tempfile
+
+        import openpyxl
+
+        import generate_weekly_pdfs as _gwp
+        from pipeline.excel import generate_excel
+
+        row = _billable_row()
+        baseline = {
+            (111, 222): _baseline(
+                billed_week="2026-08-02", snapshot_date="2026-07-29"
+            )
+        }
+        self.mock_fetch.return_value = (baseline, "success")
+        self._wire_history(
+            snapshot_entries=[
+                _entry("2026-08-12T10:00:00Z",
+                       types.SimpleNamespace(email=AUTOMATION_EMAIL)),
+            ],
+            units_entries=[],
+        )
+
+        with mock.patch.dict(
+            "os.environ", {"SNAPSHOT_DRIFT_HOLD_ENABLED": "true"}
+        ):
+            summary = apply_snapshot_drift_holds(
+                [row], _source_sheets(), self.client, self.session_start
+            )
+        self.assertEqual(summary["automation_self_fire_holds"], 1)
+
+        # After the hold, grouping.py would compute the row's week from
+        # the (restored) Weekly Reference Logged Date -- reproduce that
+        # here since this test calls generate_excel directly.
+        row["__week_ending_date"] = datetime.datetime(2026, 8, 2)
+
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        orig_output = _gwp.OUTPUT_FOLDER
+        _gwp.OUTPUT_FOLDER = tmp.name
+        self.addCleanup(lambda: setattr(_gwp, "OUTPUT_FOLDER", orig_output))
+
+        result = generate_excel(
+            "080226_90001", [row], datetime.datetime(2026, 8, 2),
+            data_hash="deadbeefcafe0002",
+        )
+        excel_path = result[0]
+
+        wb = openpyxl.load_workbook(excel_path)
+        ws = wb.active
+        found = any(
+            ws.cell(row=r, column=c).value == 777.0
+            for r in range(1, ws.max_row + 1)
+            for c in range(1, ws.max_column + 1)
+        )
+        self.assertTrue(
+            found,
+            "Held row's price must appear in a day-table -- if it does "
+            "not, the row was silently dropped by the Monday-Sunday "
+            "Snapshot Date filter (RESEARCH pitfall 1)."
+        )
+
+
+class TestTask3PriorWeekHashStability(SnapshotDriftClassifierTestBase):
+    def test_hash_stable_across_drift_and_hold_both_modes(self) -> None:
+        import generate_weekly_pdfs as _gwp
+        from pipeline.change_detection import calculate_data_hash
+
+        orig_extended = _gwp.EXTENDED_CHANGE_DETECTION
+        self.addCleanup(
+            lambda: setattr(_gwp, "EXTENDED_CHANGE_DETECTION", orig_extended)
+        )
+
+        for extended in (False, True):
+            with self.subTest(extended=extended):
+                _gwp.EXTENDED_CHANGE_DETECTION = extended
+                row = _billable_row(snapshot="2026-07-29", week="2026-08-02")
+                hash_before = calculate_data_hash([row])
+
+                # Simulate the automation drift: both fields re-stamped.
+                row["Snapshot Date"] = "2026-08-05"
+                row["Weekly Reference Logged Date"] = "2026-08-09"
+
+                baseline = {
+                    (111, 222): _baseline(
+                        billed_week="2026-08-02", snapshot_date="2026-07-29"
+                    )
+                }
+                self.mock_fetch.return_value = (baseline, "success")
+                self._wire_history(
+                    snapshot_entries=[
+                        _entry("2026-08-12T10:00:00Z",
+                               types.SimpleNamespace(email=AUTOMATION_EMAIL)),
+                    ],
+                    units_entries=[],
+                )
+                with mock.patch.dict(
+                    "os.environ", {"SNAPSHOT_DRIFT_HOLD_ENABLED": "true"}
+                ):
+                    apply_snapshot_drift_holds(
+                        [row], _source_sheets(), self.client,
+                        self.session_start,
+                    )
+
+                hash_after = calculate_data_hash([row])
+                self.assertEqual(hash_before, hash_after)
+
+
+class TestTask3ManualNeverMutated(SnapshotDriftClassifierTestBase):
+    def test_manual_candidate_never_mutated_even_with_hold_enabled(self) -> None:
+        row, baseline = _drift_row_and_baseline()
+        original = dict(row)
+        self.mock_fetch.return_value = (baseline, "success")
+        self._wire_history(
+            snapshot_entries=[
+                _entry("2026-08-12T10:00:00Z",
+                       types.SimpleNamespace(email="human@example.com")),
+            ],
+        )
+
+        with mock.patch.dict(
+            "os.environ", {"SNAPSHOT_DRIFT_HOLD_ENABLED": "true"}
+        ):
+            summary = apply_snapshot_drift_holds(
+                [row], _source_sheets(), self.client, self.session_start
+            )
+
+        self.assertEqual(summary["manual"], 1)
+        self.assertEqual(summary["automation_self_fire_holds"], 0)
+        self.assertEqual(row, original)
+        self.assertNotIn("__drifted_snapshot_date", row)
+
+
+class TestTask3UnclassifiedNeverMutated(SnapshotDriftClassifierTestBase):
+    def test_unclassified_candidate_never_mutated_even_with_hold_enabled(
+        self,
+    ) -> None:
+        row, baseline = _drift_row_and_baseline()
+        original = dict(row)
+        self.mock_fetch.return_value = (baseline, "success")
+        self.client.Cells.get_cell_history.side_effect = Exception("boom")
+
+        with mock.patch.dict(
+            "os.environ", {"SNAPSHOT_DRIFT_HOLD_ENABLED": "true"}
+        ):
+            summary = apply_snapshot_drift_holds(
+                [row], _source_sheets(), self.client, self.session_start
+            )
+
+        self.assertEqual(summary["unclassified"], 1)
+        self.assertEqual(summary["automation_self_fire_holds"], 0)
+        self.assertEqual(row, original)
+
+
+class TestTask3HoldGateDefaultOffDoesNotMutate(SnapshotDriftClassifierTestBase):
+    def test_default_hold_off_flags_but_does_not_mutate(self) -> None:
+        row, baseline = _drift_row_and_baseline()
+        original = dict(row)
+        self.mock_fetch.return_value = (baseline, "success")
+        self._wire_history(
+            snapshot_entries=[
+                _entry("2026-08-12T10:00:00Z",
+                       types.SimpleNamespace(email=AUTOMATION_EMAIL)),
+            ],
+            units_entries=[],
+        )
+
+        summary = apply_snapshot_drift_holds(
+            [row], _source_sheets(), self.client, self.session_start
+        )
+
+        self.assertEqual(summary["automation_self_fire"], 1)
+        self.assertEqual(summary["automation_self_fire_holds"], 0)
+        self.assertFalse(summary["hold_enabled"])
+        self.assertEqual(row, original)
+
+
+class TestTask3RiskEscalation(unittest.TestCase):
+    def _base_summary(self) -> dict:
+        return {
+            "total_anomalies": 0,
+            "total_unauthorized_changes": 0,
+            "total_data_issues": 0,
+            "total_rate_sanity_mismatches": 0,
+            "risk_level": "LOW",
+            "recommendations": [],
+        }
+
+    def test_four_holds_escalate_to_high(self) -> None:
+        from audit_billing_changes import escalate_risk_for_snapshot_drift
+
+        summary = self._base_summary()
+        escalate_risk_for_snapshot_drift(summary, 4)
+
+        self.assertEqual(summary["risk_level"], "HIGH")
+        self.assertEqual(summary["total_snapshot_drift_holds"], 4)
+
+    def test_zero_holds_leaves_risk_level_unchanged(self) -> None:
+        """Manual/unclassified drift never reaches this function as a
+        hold count -- it is recorded via Supabase + the run log only,
+        never folded into risk_level (RESEARCH caveat 5)."""
+        from audit_billing_changes import escalate_risk_for_snapshot_drift
+
+        summary = self._base_summary()
+        escalate_risk_for_snapshot_drift(summary, 0)
+
+        self.assertEqual(summary["risk_level"], "LOW")
+        self.assertEqual(summary["total_snapshot_drift_holds"], 0)
+
+
+class TestTask3DriftEventsRecordEveryCandidate(SnapshotDriftClassifierTestBase):
+    def test_events_carry_classification_and_held_for_all_outcomes(self) -> None:
+        row_self_fire, b1 = _drift_row_and_baseline(row_id=1, wr="90101")
+        row_manual, b2 = _drift_row_and_baseline(row_id=2, wr="90102")
+        row_unclassified, b3 = _drift_row_and_baseline(row_id=3, wr="90103")
+        merged = {**b1, **b2, **b3}
+        self.mock_fetch.return_value = (merged, "success")
+
+        def _side_effect(sheet_id, row_id, column_id, include_all=True):
+            if row_id == 1:
+                if column_id == SNAPSHOT_COL:
+                    return _history([_entry(
+                        "2026-08-12T10:00:00Z",
+                        types.SimpleNamespace(email=AUTOMATION_EMAIL),
+                    )])
+                return _history([])
+            if row_id == 2:
+                if column_id == SNAPSHOT_COL:
+                    return _history([_entry(
+                        "2026-08-12T10:00:00Z",
+                        types.SimpleNamespace(email="human@example.com"),
+                    )])
+                return _history([])
+            if row_id == 3:
+                raise Exception("api error")
+            raise AssertionError(f"unexpected row_id {row_id}")
+
+        self.client.Cells.get_cell_history.side_effect = _side_effect
+
+        with mock.patch.dict(
+            "os.environ", {"SNAPSHOT_DRIFT_HOLD_ENABLED": "true"}
+        ):
+            apply_snapshot_drift_holds(
+                [row_self_fire, row_manual, row_unclassified],
+                _source_sheets(), self.client, self.session_start,
+            )
+
+        self.mock_insert.assert_called_once()
+        events = self.mock_insert.call_args[0][0]
+        by_row = {e["row_id"]: e for e in events}
+
+        self.assertEqual(by_row[1]["classification"], "automation_self_fire")
+        self.assertTrue(by_row[1]["held"])
+        self.assertEqual(by_row[2]["classification"], "manual")
+        self.assertFalse(by_row[2]["held"])
+        self.assertEqual(by_row[3]["classification"], "unclassified")
+        self.assertFalse(by_row[3]["held"])
+
+
+class TestTask3BothSwitchesOffEquivalence(SnapshotDriftClassifierTestBase):
+    def test_both_switches_off_reproduces_baseline(self) -> None:
+        row, baseline = _drift_row_and_baseline()
+        original = dict(row)
+        self.mock_fetch.return_value = (baseline, "success")
+
+        with mock.patch.dict(
+            "os.environ",
+            {
+                "SNAPSHOT_DRIFT_AUDIT_ENABLED": "false",
+                "SNAPSHOT_DRIFT_HOLD_ENABLED": "false",
+            },
+        ):
+            summary = apply_snapshot_drift_holds(
+                [row], _source_sheets(), self.client, self.session_start
+            )
+
+        self.assertFalse(summary["enabled"])
+        self.assertEqual(row, original)
+        self.mock_fetch.assert_not_called()
+        self.mock_upsert.assert_not_called()
+        self.mock_insert.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_snapshot_drift_audit.py
+++ b/tests/test_snapshot_drift_audit.py
@@ -276,6 +276,44 @@ class TestTask1BatchedProvenanceUpsert(SnapshotDriftDetectionTestBase):
         self.assertEqual(summary["seeded"] + summary["unchanged"], 3)
 
 
+class TestTask1UnclassifiedDriftKeepsBaseline(SnapshotDriftDetectionTestBase):
+    """Greptile PR#330 regression: an unclassified drift must NOT
+    finalize -- upserting its drifted week would rebase the baseline,
+    so the next run would read the moved row as 'unchanged' and never
+    retry classification (or hold/restore it). The prior billed_week
+    stays authoritative and the row re-enters candidacy next run,
+    while the drift event is still logged this run."""
+
+    def test_unclassified_candidate_absent_from_upsert(self) -> None:
+        self.mock_fetch.return_value = (
+            {(111, 222): _baseline(
+                billed_week="2026-08-02", snapshot_date="2026-07-29"
+            )},
+            "success",
+        )
+        # Empty source_sheets -> no column mapping -> classification
+        # degrades to 'unclassified' without any cell-history call.
+        row = _row(week="2026-08-09", snapshot="2026-08-05")
+
+        summary = apply_snapshot_drift_holds(
+            [row], [], self.client, self.session_start
+        )
+
+        self.assertEqual(summary["candidates"], 1)
+        self.assertEqual(summary["unclassified"], 1)
+        # Fail-closed logging: the sighting is still recorded.
+        events = self.mock_insert.call_args[0][0]
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0]["classification"], "unclassified")
+        # Baseline preserved: no provenance record for the
+        # unclassified row may reach the upsert.
+        records = (
+            self.mock_upsert.call_args[0][0]
+            if self.mock_upsert.call_args else []
+        )
+        self.assertEqual([r for r in records if r["row_id"] == 222], [])
+
+
 SNAPSHOT_COL = 5001
 UNITS_COL = 5002
 AUTOMATION_EMAIL = "automation@smartsheet.com"

--- a/tests/test_snapshot_drift_audit.py
+++ b/tests/test_snapshot_drift_audit.py
@@ -18,6 +18,7 @@ override in later sections of this file.
 from __future__ import annotations
 
 import datetime
+import types
 import unittest
 from unittest import mock
 
@@ -248,6 +249,296 @@ class TestTask1BatchedProvenanceUpsert(SnapshotDriftDetectionTestBase):
         records = self.mock_upsert.call_args[0][0]
         self.assertEqual(len(records), 3)
         self.assertEqual(summary["seeded"] + summary["unchanged"], 3)
+
+
+SNAPSHOT_COL = 5001
+UNITS_COL = 5002
+AUTOMATION_EMAIL = "automation@smartsheet.com"
+
+
+def _source_sheets(sheet_id: int = 111, snapshot_col=SNAPSHOT_COL,
+                    units_col=UNITS_COL) -> list:
+    mapping = {}
+    if snapshot_col is not None:
+        mapping["Snapshot Date"] = snapshot_col
+    if units_col is not None:
+        mapping["Units Completed?"] = units_col
+    return [{"id": sheet_id, "name": "Sheet A", "column_mapping": mapping}]
+
+
+def _entry(modified_at: str, modified_by):
+    return types.SimpleNamespace(modified_at=modified_at, modified_by=modified_by)
+
+
+def _history(entries: list):
+    return types.SimpleNamespace(data=list(entries))
+
+
+def _drift_row_and_baseline(sheet_id=111, row_id=222, wr="90001"):
+    row = _row(sheet_id=sheet_id, row_id=row_id, wr=wr,
+               week="2026-08-09", snapshot="2026-08-05")
+    baseline = {
+        (sheet_id, row_id): _baseline(
+            sheet_id=sheet_id, row_id=row_id, wr=wr,
+            billed_week="2026-08-02", snapshot_date="2026-07-29",
+        )
+    }
+    return row, baseline
+
+
+class SnapshotDriftClassifierTestBase(SnapshotDriftDetectionTestBase):
+    """Adds a configurable Cells.get_cell_history side_effect keyed by
+    column id, so each test only needs to describe the two histories."""
+
+    def _wire_history(self, snapshot_entries=None, units_entries=None):
+        snapshot_entries = snapshot_entries or []
+        units_entries = units_entries or []
+
+        def _side_effect(sheet_id, row_id, column_id, include_all=True):
+            if column_id == SNAPSHOT_COL:
+                return _history(snapshot_entries)
+            if column_id == UNITS_COL:
+                return _history(units_entries)
+            raise AssertionError(f"unexpected column_id {column_id}")
+
+        self.client.Cells.get_cell_history.side_effect = _side_effect
+
+
+class TestTask2AutomationSelfFire(SnapshotDriftClassifierTestBase):
+    def test_automation_write_no_nearby_units_change_is_self_fire(self) -> None:
+        row, baseline = _drift_row_and_baseline()
+        self.mock_fetch.return_value = (baseline, "success")
+        self._wire_history(
+            snapshot_entries=[
+                _entry("2026-08-12T10:00:00Z",
+                       types.SimpleNamespace(email=AUTOMATION_EMAIL)),
+            ],
+            units_entries=[],
+        )
+
+        summary = apply_snapshot_drift_holds(
+            [row], _source_sheets(), self.client, self.session_start
+        )
+
+        self.assertEqual(summary["automation_self_fire"], 1)
+        self.assertEqual(summary["manual"], 0)
+        self.assertEqual(summary["unclassified"], 0)
+        self.assertEqual(self.client.Cells.get_cell_history.call_count, 2)
+
+
+class TestTask2AutomationWriteWithNearbyUnitsChangeIsManual(
+    SnapshotDriftClassifierTestBase
+):
+    def test_nearby_units_change_within_window_is_manual(self) -> None:
+        row, baseline = _drift_row_and_baseline()
+        self.mock_fetch.return_value = (baseline, "success")
+        self._wire_history(
+            snapshot_entries=[
+                _entry("2026-08-12T10:00:00Z",
+                       types.SimpleNamespace(email=AUTOMATION_EMAIL)),
+            ],
+            units_entries=[
+                _entry("2026-08-12T09:59:30Z",
+                       types.SimpleNamespace(email="foreman@example.com")),
+            ],
+        )
+
+        summary = apply_snapshot_drift_holds(
+            [row], _source_sheets(), self.client, self.session_start
+        )
+
+        self.assertEqual(summary["manual"], 1)
+        self.assertEqual(summary["automation_self_fire"], 0)
+
+
+class TestTask2HumanEmailIsManualNoSecondCall(SnapshotDriftClassifierTestBase):
+    def test_human_email_is_manual_zero_second_call(self) -> None:
+        row, baseline = _drift_row_and_baseline()
+        self.mock_fetch.return_value = (baseline, "success")
+        self._wire_history(
+            snapshot_entries=[
+                _entry("2026-08-12T10:00:00Z",
+                       types.SimpleNamespace(email="foreman@example.com")),
+            ],
+        )
+
+        summary = apply_snapshot_drift_holds(
+            [row], _source_sheets(), self.client, self.session_start
+        )
+
+        self.assertEqual(summary["manual"], 1)
+        # Snapshot Date history alone already rules out automation --
+        # skip the Units Completed? call and save the quota.
+        self.assertEqual(self.client.Cells.get_cell_history.call_count, 1)
+
+
+class TestTask2ApiErrorIsUnclassified(SnapshotDriftClassifierTestBase):
+    def test_get_cell_history_raises_is_unclassified(self) -> None:
+        row, baseline = _drift_row_and_baseline()
+        self.mock_fetch.return_value = (baseline, "success")
+        self.client.Cells.get_cell_history.side_effect = Exception("429")
+
+        summary = apply_snapshot_drift_holds(
+            [row], _source_sheets(), self.client, self.session_start
+        )
+
+        self.assertEqual(summary["unclassified"], 1)
+        self.assertEqual(summary["automation_self_fire"], 0)
+        self.assertEqual(summary["manual"], 0)
+
+
+class TestTask2MissingColumnIdIsUnclassified(SnapshotDriftClassifierTestBase):
+    def test_missing_column_id_unclassified_zero_calls(self) -> None:
+        row, baseline = _drift_row_and_baseline()
+        self.mock_fetch.return_value = (baseline, "success")
+
+        summary = apply_snapshot_drift_holds(
+            [row], _source_sheets(units_col=None), self.client,
+            self.session_start,
+        )
+
+        self.assertEqual(summary["unclassified"], 1)
+        self.client.Cells.get_cell_history.assert_not_called()
+
+
+class TestTask2PerRunCap(SnapshotDriftClassifierTestBase):
+    def test_cap_of_one_classifies_first_leaves_second_unclassified(self) -> None:
+        row1, baseline1 = _drift_row_and_baseline(row_id=100, wr="90001")
+        row2, baseline2 = _drift_row_and_baseline(row_id=200, wr="90002")
+        merged_baseline = {**baseline1, **baseline2}
+        self.mock_fetch.return_value = (merged_baseline, "success")
+        # row1 (lower row id, classified first in deterministic order)
+        # requires BOTH calls: automation write with no nearby units
+        # change.
+        self._wire_history(
+            snapshot_entries=[
+                _entry("2026-08-12T10:00:00Z",
+                       types.SimpleNamespace(email=AUTOMATION_EMAIL)),
+            ],
+            units_entries=[],
+        )
+
+        with mock.patch.dict(
+            "os.environ", {"SNAPSHOT_DRIFT_MAX_ROWS": "1"}
+        ):
+            summary = apply_snapshot_drift_holds(
+                [row1, row2], _source_sheets(), self.client,
+                self.session_start,
+            )
+
+        self.assertEqual(
+            summary["automation_self_fire"] + summary["manual"], 1
+        )
+        self.assertEqual(summary["unclassified"], 1)
+        self.assertEqual(self.client.Cells.get_cell_history.call_count, 2)
+
+
+class TestTask2BudgetGuardSkipsAll(SnapshotDriftClassifierTestBase):
+    def test_low_remaining_budget_skips_classification_entirely(self) -> None:
+        row, baseline = _drift_row_and_baseline()
+        self.mock_fetch.return_value = (baseline, "success")
+        self._wire_history(
+            snapshot_entries=[
+                _entry("2026-08-12T10:00:00Z",
+                       types.SimpleNamespace(email=AUTOMATION_EMAIL)),
+            ],
+        )
+        # session_start far enough in the past that remaining budget
+        # (TIME_BUDGET_MINUTES - elapsed) is below SNAPSHOT_DRIFT_MAX_MINUTES.
+        stale_session_start = (
+            datetime.datetime.now() - datetime.timedelta(minutes=160)
+        )
+
+        with mock.patch.dict(
+            "os.environ",
+            {"GITHUB_ACTIONS": "true", "TIME_BUDGET_MINUTES": "165"},
+        ):
+            summary = apply_snapshot_drift_holds(
+                [row], _source_sheets(), self.client, stale_session_start
+            )
+
+        self.assertEqual(summary["unclassified"], 1)
+        self.assertIsNotNone(summary["skip_reason"])
+        self.client.Cells.get_cell_history.assert_not_called()
+
+
+class TestTask2HistoryOrderingIndependence(SnapshotDriftClassifierTestBase):
+    def test_newest_first_and_oldest_first_agree(self) -> None:
+        older = _entry("2026-08-12T09:00:00Z",
+                        types.SimpleNamespace(email="foreman@example.com"))
+        newer = _entry("2026-08-12T10:00:00Z",
+                        types.SimpleNamespace(email=AUTOMATION_EMAIL))
+
+        results = []
+        for order in ([older, newer], [newer, older]):
+            row, baseline = _drift_row_and_baseline()
+            self.mock_fetch.return_value = (baseline, "success")
+            self._wire_history(snapshot_entries=order, units_entries=[])
+            summary = apply_snapshot_drift_holds(
+                [row], _source_sheets(), self.client, self.session_start
+            )
+            if summary["automation_self_fire"]:
+                results.append("automation_self_fire")
+            elif summary["manual"]:
+                results.append("manual")
+            else:
+                results.append("unclassified")
+
+        self.assertEqual(results[0], results[1])
+        self.assertEqual(results[0], "automation_self_fire")
+
+
+class TestTask2ModifiedByShapes(SnapshotDriftClassifierTestBase):
+    def test_modified_by_object_string_and_none_never_raise(self) -> None:
+        shapes = [
+            types.SimpleNamespace(email=AUTOMATION_EMAIL),
+            AUTOMATION_EMAIL,
+            None,
+        ]
+        for shape in shapes:
+            row, baseline = _drift_row_and_baseline()
+            self.mock_fetch.return_value = (baseline, "success")
+            self._wire_history(
+                snapshot_entries=[_entry("2026-08-12T10:00:00Z", shape)],
+                units_entries=[],
+            )
+            # Must not raise.
+            summary = apply_snapshot_drift_holds(
+                [row], _source_sheets(), self.client, self.session_start
+            )
+            self.assertIn(
+                summary["automation_self_fire"] + summary["manual"]
+                + summary["unclassified"],
+                [1],
+            )
+
+
+class TestTask2PacingBetweenCalls(SnapshotDriftClassifierTestBase):
+    def test_sleep_between_calls_not_before_first(self) -> None:
+        row1, baseline1 = _drift_row_and_baseline(row_id=100, wr="90001")
+        row2, baseline2 = _drift_row_and_baseline(row_id=200, wr="90002")
+        merged_baseline = {**baseline1, **baseline2}
+        self.mock_fetch.return_value = (merged_baseline, "success")
+        self._wire_history(
+            snapshot_entries=[
+                _entry("2026-08-12T10:00:00Z",
+                       types.SimpleNamespace(email=AUTOMATION_EMAIL)),
+            ],
+            units_entries=[],
+        )
+
+        with mock.patch("pipeline.snapshot_drift.time.sleep") as mock_sleep:
+            apply_snapshot_drift_holds(
+                [row1, row2], _source_sheets(), self.client,
+                self.session_start,
+            )
+
+        # 2 candidates x 2 calls each = 4 calls -> 3 sleeps, never
+        # before the first call.
+        self.assertEqual(self.client.Cells.get_cell_history.call_count, 4)
+        self.assertEqual(mock_sleep.call_count, 3)
+        for call in mock_sleep.call_args_list:
+            self.assertAlmostEqual(call.args[0], 2.0)
 
 
 if __name__ == "__main__":

--- a/tests/test_snapshot_drift_audit.py
+++ b/tests/test_snapshot_drift_audit.py
@@ -1,0 +1,254 @@
+"""Tests for the snapshot-date drift audit (quick task 260812-jqx).
+
+RED-first suite covering the 9 research cases: detection with zero
+extra Smartsheet API calls, first-sight seeding, classification via
+targeted cell-history lookups (capped/paced/budget-aware), the
+hold-prior-week override (both fields), and the audit risk-level
+wiring. Mirrors ``tests/test_rate_sanity_audit.py`` (no-network
+fixture pattern) and ``tests/test_billing_audit_shadow.py`` (Supabase
+writer mocks).
+
+Task 1 covers detection only: no classifier and no hold override
+exist yet at this point in the suite's history, so drift candidates
+are asserted generically (not pinned to a specific classification
+value) -- Task 2 adds the classifier and Task 3 adds the hold
+override in later sections of this file.
+"""
+
+from __future__ import annotations
+
+import datetime
+import unittest
+from unittest import mock
+
+from pipeline.snapshot_drift import apply_snapshot_drift_holds
+
+
+def _row(
+    sheet_id: int = 111,
+    row_id: int = 222,
+    wr: str = "90001",
+    cu: str = "ABC-123",
+    week: str = "2026-08-09",
+    snapshot: str = "2026-08-05",
+) -> dict:
+    return {
+        "__source_sheet_id": sheet_id,
+        "__row_id": row_id,
+        "Work Request #": wr,
+        "CU": cu,
+        "Weekly Reference Logged Date": week,
+        "Snapshot Date": snapshot,
+    }
+
+
+def _baseline(
+    sheet_id: int = 111,
+    row_id: int = 222,
+    billed_week: str = "2026-08-09",
+    snapshot_date: str = "2026-08-05",
+    wr: str = "90001",
+    cu: str = "ABC-123",
+    first_seen_at: str = "2026-07-01T00:00:00+00:00",
+) -> dict:
+    return {
+        "sheet_id": sheet_id,
+        "row_id": row_id,
+        "wr": wr,
+        "cu": cu,
+        "snapshot_date": snapshot_date,
+        "billed_week": billed_week,
+        "run_id": "prior-run",
+        "first_seen_at": first_seen_at,
+        "last_seen_at": "2026-08-05T00:00:00+00:00",
+    }
+
+
+class SnapshotDriftDetectionTestBase(unittest.TestCase):
+    """Shared patches for the Supabase snapshot_store surface."""
+
+    def setUp(self) -> None:
+        self.session_start = datetime.datetime.now()
+        self.client = mock.MagicMock()
+
+        self._fetch_patch = mock.patch(
+            "billing_audit.snapshot_store.fetch_snapshot_provenance"
+        )
+        self._upsert_patch = mock.patch(
+            "billing_audit.snapshot_store.upsert_snapshot_provenance"
+        )
+        self._insert_patch = mock.patch(
+            "billing_audit.snapshot_store.insert_snapshot_drift_events"
+        )
+        self.mock_fetch = self._fetch_patch.start()
+        self.mock_upsert = self._upsert_patch.start()
+        self.mock_insert = self._insert_patch.start()
+        self.addCleanup(self._fetch_patch.stop)
+        self.addCleanup(self._upsert_patch.stop)
+        self.addCleanup(self._insert_patch.stop)
+
+
+class TestTask1NoBaselineSeeds(SnapshotDriftDetectionTestBase):
+    """No provenance baseline -> silent seed, zero drift, zero API (D-09)."""
+
+    def test_no_baseline_seeds_silently(self) -> None:
+        self.mock_fetch.return_value = ({}, "no_row")
+        row = _row()
+
+        summary = apply_snapshot_drift_holds(
+            [row], [], self.client, self.session_start
+        )
+
+        self.assertTrue(summary["enabled"])
+        self.assertEqual(summary["candidates"], 0)
+        self.assertEqual(summary["seeded"], 1)
+        self.client.Cells.get_cell_history.assert_not_called()
+        self.mock_upsert.assert_called_once()
+        records = self.mock_upsert.call_args[0][0]
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0]["sheet_id"], 111)
+        self.assertEqual(records[0]["row_id"], 222)
+        # No baseline -> no drift -> no event written.
+        self.mock_insert.assert_called_once_with([])
+
+
+class TestTask1WeekUnchangedCostsNothing(SnapshotDriftDetectionTestBase):
+    """Computed week == baseline billed_week -> zero drift, zero API (D-04)."""
+
+    def test_unchanged_week_costs_zero_api_calls(self) -> None:
+        self.mock_fetch.return_value = (
+            {(111, 222): _baseline(billed_week="2026-08-09")},
+            "success",
+        )
+        row = _row(week="2026-08-09")
+
+        summary = apply_snapshot_drift_holds(
+            [row], [], self.client, self.session_start
+        )
+
+        self.assertEqual(summary["candidates"], 0)
+        self.assertEqual(summary["unchanged"], 1)
+        self.client.Cells.get_cell_history.assert_not_called()
+        self.mock_insert.assert_called_once_with([])
+
+
+class TestTask1WeekDriftIsACandidate(SnapshotDriftDetectionTestBase):
+    """Computed week != baseline billed_week -> candidate, not held,
+    row fields left untouched at this point in the audit (Task 1)."""
+
+    def test_drifted_week_emits_candidate_without_mutation(self) -> None:
+        self.mock_fetch.return_value = (
+            {(111, 222): _baseline(
+                billed_week="2026-08-02", snapshot_date="2026-07-29"
+            )},
+            "success",
+        )
+        row = _row(week="2026-08-09", snapshot="2026-08-05")
+
+        summary = apply_snapshot_drift_holds(
+            [row], [], self.client, self.session_start
+        )
+
+        self.assertEqual(summary["candidates"], 1)
+        self.assertEqual(summary["automation_self_fire_holds"], 0)
+        # Task 1 never mutates rows.
+        self.assertEqual(row["Weekly Reference Logged Date"], "2026-08-09")
+        self.assertEqual(row["Snapshot Date"], "2026-08-05")
+
+        self.mock_insert.assert_called_once()
+        events = self.mock_insert.call_args[0][0]
+        self.assertEqual(len(events), 1)
+        event = events[0]
+        self.assertEqual(event["sheet_id"], 111)
+        self.assertEqual(event["row_id"], 222)
+        self.assertEqual(event["prior_billed_week"], "2026-08-02")
+        self.assertEqual(event["new_week"], "2026-08-09")
+        self.assertFalse(event["held"])
+        self.assertTrue(event["classification"])  # non-empty placeholder/real
+
+
+class TestTask1KillSwitchDisabled(SnapshotDriftDetectionTestBase):
+    """SNAPSHOT_DRIFT_AUDIT_ENABLED=false -> zeroed summary, no
+    Supabase call, rows byte-identical (D-08)."""
+
+    def test_disabled_is_a_pure_noop(self) -> None:
+        row = _row()
+        original = dict(row)
+
+        with mock.patch.dict(
+            "os.environ", {"SNAPSHOT_DRIFT_AUDIT_ENABLED": "false"}
+        ):
+            summary = apply_snapshot_drift_holds(
+                [row], [], self.client, self.session_start
+            )
+
+        self.assertFalse(summary["enabled"])
+        self.assertEqual(summary["candidates"], 0)
+        self.mock_fetch.assert_not_called()
+        self.mock_upsert.assert_not_called()
+        self.mock_insert.assert_not_called()
+        self.assertEqual(row, original)
+
+
+class TestTask1ClientUnavailable(SnapshotDriftDetectionTestBase):
+    """get_client() unavailable -> flagged unavailable, no exception."""
+
+    def test_unavailable_client_flags_summary_and_does_not_raise(self) -> None:
+        self.mock_fetch.return_value = ({}, "unavailable")
+        row = _row()
+
+        summary = apply_snapshot_drift_holds(
+            [row], [], self.client, self.session_start
+        )
+
+        self.assertFalse(summary["available"])
+        self.assertEqual(summary["candidates"], 0)
+        self.client.Cells.get_cell_history.assert_not_called()
+
+
+class TestTask1FetchRaisesDegradesToSeed(SnapshotDriftDetectionTestBase):
+    """A raised exception from the bulk read is swallowed and
+    degrades to the no-baseline (seed) path."""
+
+    def test_fetch_exception_is_swallowed(self) -> None:
+        self.mock_fetch.side_effect = Exception("boom")
+        row = _row()
+
+        summary = apply_snapshot_drift_holds(
+            [row], [], self.client, self.session_start
+        )
+
+        self.assertFalse(summary["available"])
+        self.assertEqual(summary["seeded"], 1)
+        self.assertEqual(summary["candidates"], 0)
+
+
+class TestTask1BatchedProvenanceUpsert(SnapshotDriftDetectionTestBase):
+    """Provenance upsert is invoked at most once per run with a
+    batched payload -- never once per row (RESEARCH caveat 6)."""
+
+    def test_upsert_called_once_with_batched_payload(self) -> None:
+        self.mock_fetch.return_value = (
+            {
+                (111, 222): _baseline(sheet_id=111, row_id=222, billed_week="2026-08-09"),
+            },
+            "success",
+        )
+        rows = [
+            _row(sheet_id=111, row_id=222, wr="90001", week="2026-08-09"),
+            _row(sheet_id=111, row_id=333, wr="90002", week="2026-08-09"),
+            _row(sheet_id=222, row_id=444, wr="90003", week="2026-08-09"),
+        ]
+
+        summary = apply_snapshot_drift_holds(
+            rows, [], self.client, self.session_start
+        )
+
+        self.assertEqual(self.mock_upsert.call_count, 1)
+        records = self.mock_upsert.call_args[0][0]
+        self.assertEqual(len(records), 3)
+        self.assertEqual(summary["seeded"] + summary["unchanged"], 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_snapshot_drift_audit.py
+++ b/tests/test_snapshot_drift_audit.py
@@ -222,6 +222,31 @@ class TestTask1FetchRaisesDegradesToSeed(SnapshotDriftDetectionTestBase):
         self.assertFalse(summary["available"])
         self.assertEqual(summary["seeded"], 1)
         self.assertEqual(summary["candidates"], 0)
+        # CR-01 regression: a fetch failure must never poison existing
+        # baselines by upserting the degraded (empty-baseline) seed
+        # records.
+        self.mock_upsert.assert_not_called()
+
+
+class TestTask1FetchFailureStatusSkipsUpsert(SnapshotDriftDetectionTestBase):
+    """CR-01 regression: an explicit ``fetch_failure`` status (bulk
+    read's own retry-exhaustion / circuit-breaker path, not a raised
+    exception) must ALSO skip the provenance upsert -- otherwise a
+    transient read failure rebases every existing baseline's
+    ``billed_week`` to the current week and silently launders any
+    in-flight drift."""
+
+    def test_fetch_failure_status_skips_upsert(self) -> None:
+        self.mock_fetch.return_value = ({}, "fetch_failure")
+        row = _row()
+
+        summary = apply_snapshot_drift_holds(
+            [row], [], self.client, self.session_start
+        )
+
+        self.assertFalse(summary["available"])
+        self.assertEqual(summary["seeded"], 1)
+        self.mock_upsert.assert_not_called()
 
 
 class TestTask1BatchedProvenanceUpsert(SnapshotDriftDetectionTestBase):

--- a/website/blog/2026-08-12-snapshot-drift-audit.md
+++ b/website/blog/2026-08-12-snapshot-drift-audit.md
@@ -1,0 +1,77 @@
+---
+slug: snapshot-drift-audit
+title: "feat: snapshot-date drift audit detects automation re-stamps (report-only)"
+authors: [runbook-bot]
+tags: [project, python, tests, workflows]
+date: 2026-08-12T22:00:00+00:00
+---
+
+**Component:** Python billing pipeline (`pipeline/snapshot_drift.py`, seam in
+`pipeline/orchestrate.py`, shadow log in `billing_audit/`) — runs inside every
+scheduled `generate_weekly_pdfs.py` billing run.
+
+<!-- truncate -->
+
+## What changed
+
+The pipeline gains a **snapshot-date drift audit**. Each run, every row's
+current `Snapshot Date`-derived billing week is compared against a Supabase
+provenance baseline (`snapshot_provenance`) recording the week each row was
+first billed under. A row whose week *moved* is a drift candidate; candidates
+are classified by reading the Smartsheet **cell history** of `Snapshot Date`
+and `Units Completed?`:
+
+- A `Snapshot Date` write by the automation identity
+  (`automation@smartsheet.com`) with **no** `Units Completed?` change within
+  the correlation window (default 15 minutes — the automation batches its
+  stamps, so legitimate writes can land several minutes after the checkbox) is
+  an **`automation_self_fire`** — the defect signature.
+- Anything else classifies as **`manual`** (never held) or
+  **`unclassified`** (never held) — every error path degrades away from
+  holding.
+
+Detection is **report-only by default**. A separate, default-OFF gate
+(`SNAPSHOT_DRIFT_HOLD_ENABLED`) can additionally *hold* automation self-fires
+at their previously-billed week (rewriting both `Snapshot Date` and
+`Weekly Reference Logged Date` in memory only — the source sheet is never
+written). Drift events are shadow-logged to Supabase (`snapshot_drift`) and
+raise the audit `risk_level`; a Sentry warning fires whenever a hold applies.
+
+## Why it changed
+
+The per-sheet "record Snapshot Date" Smartsheet automation uses trigger "when
+rows are changed" with condition "Units Completed? is checked" — conditions
+filter rows, not fields, so ANY edit to a completed row (even a same-value
+re-save) re-stamps `Snapshot Date` to today. Proven 2026-08-12 on WR 91916464
+/ Point 27: a Quantity re-save at 18:11:24Z drew an automation re-stamp at
+18:11:48Z (and a `Weekly Reference Logged Date` rewrite to the wrong Sunday)
+while `Units Completed?` had been unchanged for six days. Every re-stamp moves
+a unit into the current billing week — files regenerate, billing weeks shift,
+audit deltas appear. The Smartsheet-side fix (field-scoped trigger + write-once
+condition) is applied per sheet in the UI; this audit is the pipeline-side
+detector that catches any sheet where the broken automation still lives.
+
+## What operators need to know
+
+- **Kill switches:** `SNAPSHOT_DRIFT_AUDIT_ENABLED=false` disables detection
+  entirely (restores pre-change behavior). `SNAPSHOT_DRIFT_HOLD_ENABLED`
+  (default `false`) gates holding; leave OFF until burn-in completes.
+- **Tuning env vars:** `SNAPSHOT_DRIFT_MAX_ROWS` (default 40 cell-history
+  classifications per run, week-movers only), `SNAPSHOT_DRIFT_PACE_SEC`
+  (default 2.0s between history calls), `SNAPSHOT_DRIFT_MAX_MINUTES` (default
+  5, phase sub-budget under `TIME_BUDGET_MINUTES`),
+  `SNAPSHOT_DRIFT_AUTOMATION_EMAIL` (default `automation@smartsheet.com`),
+  `SNAPSHOT_DRIFT_UNITS_WINDOW_MINUTES` (default 15 — widen if legitimate
+  batched stamps ever classify as self-fires).
+- **Manual rollout step (required once):** apply the two appended DDL blocks
+  in `billing_audit/schema.sql` (`snapshot_provenance`, `snapshot_drift`) to
+  Supabase and confirm the `billing_audit` schema stays PostgREST-exposed.
+  Until applied, the feature safely no-ops (fetches degrade, nothing is
+  logged, nothing is held).
+- **Fail-open guarantee:** Supabase outages, classification errors, malformed
+  history, and budget exhaustion all degrade to today's behavior — rows bill
+  exactly as they do now. A hold can only apply to a row positively classified
+  as an automation self-fire with a known prior week.
+- **Owner:** Python billing pipeline. Stacked on the rate-sanity audit change
+  (#329); the Supabase tables live in the same `billing_audit` schema as the
+  billing audit shadow log.


### PR DESCRIPTION
> Follow-up to #329 (merged). Originally stacked; rebased onto `master` after the squash-merge.

## Objective

Detect (and, behind a default-OFF gate, hold) billing-week drift caused by the Smartsheet "record Snapshot Date" automation defect: a row-change trigger with a "Units Completed? is checked" *condition* re-stamps `Snapshot Date` (and `Weekly Reference Logged Date`) on ANY edit to a completed row — moving units into the wrong billing week. Proven live on WR 91916464 / Point 27 (re-stamp at 2026-08-12 18:11:48Z after a same-value Quantity re-save, Units Completed? unchanged for 6 days).

## Changes Made

- **`pipeline/snapshot_drift.py` (new):** end-to-end drift audit at the pre-grouping seam — Supabase provenance baseline compare (zero extra Smartsheet API calls for detection), cell-history classifier (automation self-fire vs manual vs unclassified), and an opt-in hold-at-prior-week override that rewrites both `Snapshot Date` and `Weekly Reference Logged Date` **in memory only** (source sheets are never written).
- **`billing_audit/snapshot_store.py` (new) + `billing_audit/schema.sql` (append-only):** `snapshot_provenance` + `snapshot_drift` tables; shadow logging is fail-open/fail-closed per D-03.
- **`pipeline/config.py`:** 7 env knobs — `SNAPSHOT_DRIFT_AUDIT_ENABLED` (default on, report-only), `SNAPSHOT_DRIFT_HOLD_ENABLED` (**default OFF**), `SNAPSHOT_DRIFT_MAX_ROWS` (40), `SNAPSHOT_DRIFT_PACE_SEC` (2.0), `SNAPSHOT_DRIFT_MAX_MINUTES` (5), `SNAPSHOT_DRIFT_AUTOMATION_EMAIL`, `SNAPSHOT_DRIFT_UNITS_WINDOW_MINUTES` (15).
- **`pipeline/orchestrate.py`:** 2 hunks (import + seam) incl. Sentry warning capture whenever a hold applies.
- **`audit_billing_changes.py`:** self-fire holds escalate audit `risk_level` via the existing 0/≤3/else ladder.
- **Review fix round** (2 Critical fixed): provenance upsert gated on fetch status, so a failed Supabase read can never rebase existing baselines; holds skip null-prior-date baselines, so a hold can never blank `Snapshot Date` and drop a billed row; unparseable history timestamps classify `unclassified`; correlation window env-tunable (live evidence: the automation batches stamps up to ~4.5 min after the checkbox); test pacing zeroed (drift tests 31.7s → 1.35s).
- **Docs:** runbook changelog entry (`website/blog/2026-08-12-snapshot-drift-audit.md`), Living Ledger entries incl. live-verified signature corrections, review/verification artifacts, planning docs.
- **Tests:** `tests/test_snapshot_drift_audit.py` — 32 tests. Full suite **1262 passed + 132 subtests** (re-run green after the rebase onto master), zero regressions.

## Production Safety Check

Existing production logic is unbroken: **zero hunks** in `pipeline/grouping.py` and `pipeline/excel.py`; detection is report-only and additive; the hold gate ships **default OFF**; every failure path (Supabase outage, classification error, budget exhaustion, malformed history) degrades to today's exact behavior. No new Smartsheet mutations (`AUDIT_SHEET_ID` untouched; cell-history reads only, 40-row cap, 2s paced). Schema change is append-only and **manual-apply by Juan**. Verified by: gsd-verifier (8/8, independently reran the suite), independent code review (all Critical/targeted Warning findings fixed), haiku rubric checks (10/10 feature, 7/7 fix round), and live read-only A1/A4 verification against the real drifted row.

**Rollout (user_setup):** 1) apply the two appended DDL blocks in `billing_audit/schema.sql`; 2) burn in report-only; 3) only then consider `SNAPSHOT_DRIFT_HOLD_ENABLED=true` in the workflow.

**Deferred follow-ups (documented in `260812-jqx-REVIEW.md`):** WR-02 bulk provenance read via RPC instead of dual `.in_` filters; WR-03 `ENABLE ROW LEVEL SECURITY` on the new tables (owner's call at DDL time); WR-05 direct `snapshot_store` I/O tests; info nits (utcnow deprecation, env-default duplication, INFO-level email logging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds a pre-grouping snapshot-date drift audit with persistent provenance, cell-history classification, and an optional prior-week hold.
- Detects billing-week movement against Supabase provenance without extra Smartsheet calls during detection.
- Classifies candidates through capped, paced, read-only cell-history requests.
- Preserves unclassified baselines so classification can be retried on later runs.
- Keeps the hold gate disabled by default and records drift events independently of hold decisions.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pipeline/snapshot_drift.py | Implements drift detection, classification, optional holds, and classification-aware provenance finalization; the previously reported unclassified-baseline overwrite is fixed. |
| billing_audit/snapshot_store.py | Adds fail-safe bulk provenance reads, batched upserts, and append-only drift-event persistence. |
| pipeline/orchestrate.py | Integrates the audit at the pre-grouping seam and propagates hold results into audit reporting. |
| audit_billing_changes.py | Adds post-audit risk escalation for automation self-fire holds. |
| billing_audit/schema.sql | Defines the additive provenance and drift-event tables for manual deployment. |
| tests/test_snapshot_drift_audit.py | Exercises detection, classification, budget and pacing controls, hold behavior, persistence gating, and the unclassified-baseline regression. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Rows before grouping] --> B[Read provenance baseline]
    B --> C{Billing week changed?}
    C -- No --> D[Refresh provenance]
    C -- Yes --> E[Read cell history]
    E --> F{Classification}
    F -- Manual --> G[Accept current week and update baseline]
    F -- Unclassified --> H[Log event and preserve prior baseline]
    F -- Automation self-fire --> I{Hold enabled?}
    I -- No --> J[Log event and accept current week]
    I -- Yes --> K[Restore prior snapshot date and billing week]
    D --> L[Continue to grouping]
    G --> L
    H --> L
    J --> L
    K --> L
```
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22jflo21%2Fgenerate-weekly-pdfs-dsr-resiliency%22%20on%20the%20existing%20branch%20%22feat%2F260812-jqx-snapshot-drift-audit%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F260812-jqx-snapshot-drift-audit%22.%0A%0AGreploop%20jflo21%2Fgenerate-weekly-pdfs-dsr-resiliency%20PR%20%23330%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF&repo=jflo21%2Fgenerate-weekly-pdfs-dsr-resiliency&pr=330&platform=github"><img alt="Fix All in Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=1"></a>

<sub>Reviews (3): Last reviewed commit: ["docs: state ledger — Greptile baseline f..."](https://github.com/jflo21/generate-weekly-pdfs-dsr-resiliency/commit/1040c478a47739da18dcd35f8b341f2fb1e12e57) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52766282)</sub>

<!-- /greptile_comment -->