### PR TITLE
feat: scope rate-sanity audit to current cycle (#329 follow-up)

### DIFF
--- a/.claude/skills/run-billing-pipeline-locally/SKILL.md
+++ b/.claude/skills/run-billing-pipeline-locally/SKILL.md
@@ -13,7 +13,7 @@ runnable** — use the env-var switches it already exposes.
 |---|---|---|
 | No Smartsheet token, fully synthetic | `TEST_MODE=true python generate_weekly_pdfs.py` | Safest. No API calls. |
 | Real fetch, **no upload** (verify Excel output) | `SKIP_UPLOAD=true python generate_weekly_pdfs.py` | Needs `SMARTSHEET_API_TOKEN`. Writes to `generated_docs/`. |
-| Scope to specific WRs | add `WR_FILTER=WR_12345,WR_67890` | Comma list. Combine with either mode. |
+| Scope to specific WRs | add `WR_FILTER=WR_12345,WR_67890` | Comma list. **TEST_MODE only** — the filter is gated on `WR_FILTER and TEST_MODE` (`pipeline/grouping.py:1222`); with plain `SKIP_UPLOAD=true` it is silently ignored and ALL groups process. |
 | Cap work for a fast loop | add `MAX_GROUPS=10` | |
 | Force regen despite change-detection | add `FORCE_GENERATION=true` | For unchanged-hash groups. |
 
@@ -21,6 +21,9 @@ Examples:
 ```bash
 TEST_MODE=true WR_FILTER=WR_12345 python generate_weekly_pdfs.py
 SKIP_UPLOAD=true MAX_GROUPS=5 python generate_weekly_pdfs.py
+# Real fetch scoped to one WR: combine the modes — WR_FILTER needs TEST_MODE,
+# and TEST_MODE with a real SMARTSHEET_API_TOKEN still performs real reads.
+TEST_MODE=true SKIP_UPLOAD=true WR_FILTER=WR_12345 python generate_weekly_pdfs.py
 ```
 
 ## Always gate before pushing

--- a/audit_billing_changes.py
+++ b/audit_billing_changes.py
@@ -77,6 +77,33 @@ def _rate_sanity_expected_price(row: Dict) -> Optional[float]:
     return rate * qty
 
 
+def _rate_sanity_in_scope(row: Dict) -> bool:
+    """Return True when the row belongs to the current (New-Rates) cycle.
+
+    The expected price basis (``new_*_price``) only applies to rows
+    billed under the 2026-04-12 subcontractor rate contract, so the
+    detector reuses the production era gate (SUB-01 / D-08, same rule
+    grouping uses for ``_AEPBillable`` emission): ``Snapshot Date >=
+    _AEP_BILLABLE_CUTOFF`` (env-overridable via ``AEP_BILLABLE_CUTOFF``),
+    with the Weekly Reference Logged Date fallback of
+    ``_resolve_rate_recalc_cutoff_date`` rescuing current-week rows
+    whose Snapshot Date automation has not fired yet. Pre-cutoff and
+    undatable rows are OUT of scope: checking them against the
+    New-Rates basis produced the 2026-08-12 live-dry-run noise class
+    (115,272/199,717 rows flagged -> risk_level HIGH every CI run).
+    """
+    # Same lazy-import rationale as _rate_sanity_expected_price above.
+    import generate_weekly_pdfs as _gwp  # noqa: PLC0415
+    from pipeline.utils import (  # noqa: PLC0415
+        _resolve_rate_recalc_cutoff_date,
+    )
+
+    effective_date, _used_fallback = _resolve_rate_recalc_cutoff_date(
+        row, _gwp._AEP_BILLABLE_CUTOFF
+    )
+    return effective_date is not None
+
+
 def _rate_sanity_is_mismatch(expected: float, actual: float) -> bool:
     """Return True when ``actual`` diverges from ``expected`` beyond tolerance.
 
@@ -89,6 +116,21 @@ def _rate_sanity_is_mismatch(expected: float, actual: float) -> bool:
         RATE_SANITY_ABS_TOLERANCE, RATE_SANITY_PCT_TOLERANCE * expected
     )
     return abs(actual - expected) > tolerance
+
+
+def _risk_level_for(total_issues: int) -> str:
+    """Map an issue total onto the audit risk ladder (0 / <=3 / else).
+
+    Single source of truth for BOTH ``_generate_audit_summary`` and
+    ``escalate_risk_for_snapshot_drift`` (IN-07, 260812-jqx review) —
+    the ladder was previously re-derived in each, so a threshold change
+    in one place would silently diverge the other.
+    """
+    if total_issues == 0:
+        return "LOW"
+    if total_issues <= 3:
+        return "MEDIUM"
+    return "HIGH"
 
 
 def _rate_sanity_looks_like_zero(raw_price: Any) -> bool:
@@ -133,6 +175,11 @@ class BillingAudit:
         # (missing CU, zero/unparseable quantity or price, unknown work
         # type) — read by _generate_audit_summary().
         self._rate_sanity_skipped = 0
+        # Rows outside the current New-Rates cycle (pre-cutoff or
+        # undatable — see _rate_sanity_in_scope). Counted separately
+        # from skips so CI logs surface how much history the scoping
+        # excluded (260813 scoping follow-up).
+        self._rate_sanity_out_of_scope = 0
         
         self.logger.info("🔍 Billing Audit System initialized")
         if self.skip_cell_history:
@@ -369,9 +416,16 @@ class BillingAudit:
         CU, non-positive quantity, unknown work type, unparseable
         price) are silent per-row and reported only as an aggregate
         count via ``self._rate_sanity_skipped``.
+
+        SCOPED to current-cycle rows (260813 follow-up): rows failing
+        ``_rate_sanity_in_scope`` (pre-cutoff or undatable — the
+        old-rates history that made 58% of a live run flag falsely)
+        are excluded BEFORE any skip classification and aggregated in
+        ``self._rate_sanity_out_of_scope``.
         """
         mismatches: List[Dict] = []
         self._rate_sanity_skipped = 0
+        self._rate_sanity_out_of_scope = 0
 
         if os.getenv("RATE_SANITY_AUDIT_ENABLED", "true").lower() != "true":
             return mismatches
@@ -382,6 +436,10 @@ class BillingAudit:
 
             checked = 0
             for row in rows:
+                if not _rate_sanity_in_scope(row):
+                    self._rate_sanity_out_of_scope += 1
+                    continue
+
                 expected = _rate_sanity_expected_price(row)
                 if expected is None:
                     self._rate_sanity_skipped += 1
@@ -427,8 +485,10 @@ class BillingAudit:
             # Aggregate-only, per T-ISX-01: counts only, never price,
             # quantity, foreman, or WR-level detail at INFO level.
             self.logger.info(
-                "Rate-sanity audit: checked=%d skipped=%d mismatches=%d",
-                checked, self._rate_sanity_skipped, len(mismatches),
+                "Rate-sanity audit: checked=%d skipped=%d "
+                "out_of_scope=%d mismatches=%d",
+                checked, self._rate_sanity_skipped,
+                self._rate_sanity_out_of_scope, len(mismatches),
             )
         except Exception as e:
             self.logger.warning(
@@ -494,6 +554,7 @@ class BillingAudit:
                 audit_results.get("rate_sanity_mismatches", [])
             ),
             "rate_sanity_skipped": self._rate_sanity_skipped,
+            "rate_sanity_out_of_scope": self._rate_sanity_out_of_scope,
             # Snapshot-date drift audit (260812-jqx): placeholder,
             # always present for key-set stability. The drift pass
             # runs AFTER audit_financial_data (pre-grouping seam in
@@ -512,14 +573,12 @@ class BillingAudit:
             + summary["total_rate_sanity_mismatches"]
         )
 
-        if total_issues == 0:
-            summary["risk_level"] = "LOW"
+        summary["risk_level"] = _risk_level_for(total_issues)
+        if summary["risk_level"] == "LOW":
             summary["recommendations"].append("No issues detected. Continue monitoring.")
-        elif total_issues <= 3:
-            summary["risk_level"] = "MEDIUM"
+        elif summary["risk_level"] == "MEDIUM":
             summary["recommendations"].append("Minor issues detected. Review flagged items.")
         else:
-            summary["risk_level"] = "HIGH"
             summary["recommendations"].append("Multiple issues detected. Immediate review recommended.")
 
         # Add specific recommendations based on findings
@@ -708,9 +767,8 @@ def escalate_risk_for_snapshot_drift(
     (the pre-grouping seam sits downstream of the audit block in
     ``pipeline/orchestrate.py``), so this module-level function
     re-derives ``total_issues`` from the SAME fields
-    ``_generate_audit_summary`` uses (:502-507) plus
-    ``self_fire_holds``, then re-applies the identical 0 / <=3 / else
-    thresholds (:509-517).
+    ``_generate_audit_summary`` uses plus ``self_fire_holds``, then
+    applies the shared ``_risk_level_for`` ladder (IN-07).
 
     Only automation self-fire HOLDS feed this -- folding in manual or
     unclassified drift would drive a routine batch of legitimate edits
@@ -732,12 +790,7 @@ def escalate_risk_for_snapshot_drift(
         + self_fire_holds
     )
 
-    if total_issues == 0:
-        summary["risk_level"] = "LOW"
-    elif total_issues <= 3:
-        summary["risk_level"] = "MEDIUM"
-    else:
-        summary["risk_level"] = "HIGH"
+    summary["risk_level"] = _risk_level_for(total_issues)
 
     summary.setdefault("recommendations", []).append(
         "Snapshot-drift automation self-fire hold(s) detected: "

--- a/billing_audit/snapshot_store.py
+++ b/billing_audit/snapshot_store.py
@@ -68,29 +68,33 @@ def fetch_snapshot_provenance(
     if not keys:
         return {}, "no_row"
 
-    from billing_audit import client as _client_mod  # noqa: PLC0415
-
-    client = get_client()
-    if client is None:
-        if _client_mod._global_disable_reason is not None:
-            return {}, "fetch_failure"
-        return {}, "unavailable"
-
-    sheet_ids = sorted({int(k[0]) for k in keys})
-    row_ids = sorted({int(k[1]) for k in keys})
-    wanted = {(int(k[0]), int(k[1])) for k in keys}
-
-    def _op():
-        return (
-            client.schema("billing_audit")
-            .table(_PROVENANCE_TABLE)
-            .select(_PROVENANCE_COLUMNS)
-            .in_("sheet_id", sheet_ids)
-            .in_("row_id", row_ids)
-            .execute()
-        )
-
+    # IN-05 (260812-jqx review): client acquisition, the
+    # disable-reason peek, and the key coercions live INSIDE the
+    # try so the NEVER-raises contract holds at this boundary, not
+    # only via the caller-side wrap in pipeline/snapshot_drift.py.
     try:
+        from billing_audit import client as _client_mod  # noqa: PLC0415
+
+        client = get_client()
+        if client is None:
+            if _client_mod._global_disable_reason is not None:
+                return {}, "fetch_failure"
+            return {}, "unavailable"
+
+        sheet_ids = sorted({int(k[0]) for k in keys})
+        row_ids = sorted({int(k[1]) for k in keys})
+        wanted = {(int(k[0]), int(k[1])) for k in keys}
+
+        def _op():
+            return (
+                client.schema("billing_audit")
+                .table(_PROVENANCE_TABLE)
+                .select(_PROVENANCE_COLUMNS)
+                .in_("sheet_id", sheet_ids)
+                .in_("row_id", row_ids)
+                .execute()
+            )
+
         resp = with_retry(_op, op="fetch_snapshot_provenance")
         if resp is None:
             return {}, "fetch_failure"

--- a/memory-bank/living-ledger.md
+++ b/memory-bank/living-ledger.md
@@ -5480,3 +5480,50 @@ exceptions. No SDK 4.3.0 error-shape drift observed — `pipeline/retry.py`'s
   window env-tunable per correction 1; test pacing zeroed in the
   shared base (drift tests 31.7s → 1.35s). Suite 1262 passed + 132
   subtests.
+
+
+## [2026-08-13 15:30] Rate-sanity audit scoped to the current (New-Rates) cycle + jqx info-nit closure
+
+- **Rule: the rate-sanity check only evaluates New-Rates-era rows.**
+  `_rate_sanity_in_scope()` (`audit_billing_changes.py`) reuses the
+  production era gate (SUB-01 / D-08) via
+  `pipeline/utils._resolve_rate_recalc_cutoff_date`: `Snapshot Date >=
+  _AEP_BILLABLE_CUTOFF` (2026-04-12 contract award; env
+  `AEP_BILLABLE_CUTOFF`), with the Weekly Reference Logged Date
+  fallback rescuing current-week rows the snapshot automation has not
+  stamped yet. Pre-cutoff and undatable rows are counted in
+  `rate_sanity_out_of_scope` (summary field + run-log aggregate) and
+  NEVER checked. Why: the 2026-08-12 live dry run flagged
+  115,272/199,717 rows (58%) — history legitimately priced under OLD
+  contract rates vs the New-Rates expected basis — pinning
+  `risk_level` HIGH on every scheduled run. Do NOT "fix" a noisy
+  rate-sanity run by widening tolerances; scope is the lever. Scope
+  precedence: out-of-scope classification runs BEFORE skip
+  classification (a pre-cutoff row with a bad CU counts out-of-scope,
+  not skipped).
+- **Do not re-point the scope at a new env var.** Coupling to
+  `AEP_BILLABLE_CUTOFF` is deliberate: "which rows bill under New
+  Rates" and "which rows the New-Rates sanity check covers" must move
+  together when the cutoff is rolled for retroactive billing
+  decisions.
+- **jqx review info nits closed (260812-jqx REVIEW.md):** IN-01
+  `utcnow()` -> `now(timezone.utc)` in `_build_run_id`; IN-02 all
+  `pipeline/snapshot_drift.py` logging standardized on the module
+  `logger`; IN-03 cross-pin comments added on BOTH sides of the
+  env-default duplication (`pipeline/config.py` SNAPSHOT_DRIFT family
+  <-> `snapshot_drift.py` call sites); IN-05
+  `fetch_snapshot_provenance` NEVER-raises contract now real (client
+  acquisition + key coercion moved inside the try; locked by new
+  `tests/test_snapshot_store.py`, first direct snapshot_store
+  coverage — chips at WR-05); IN-07 risk ladder extracted to
+  `_risk_level_for()` used by BOTH `_generate_audit_summary` and
+  `escalate_risk_for_snapshot_drift`. Deliberately NOT done: IN-04
+  (changed_by email at INFO — PII-posture call reserved for Juan),
+  WR-02 (RPC bulk read), WR-03 (RLS — Juan's DDL call).
+- **Skill-doc correction:** `WR_FILTER` only filters when
+  `TEST_MODE=true` (`pipeline/grouping.py:1222` gates on `WR_FILTER
+  and TEST_MODE`); with plain `SKIP_UPLOAD=true` it is silently
+  ignored. `run-billing-pipeline-locally` skill table fixed; the
+  scoped real-fetch recipe is `TEST_MODE=true SKIP_UPLOAD=true
+  WR_FILTER=...` (TEST_MODE with a real token still performs real
+  reads).

--- a/pipeline/config.py
+++ b/pipeline/config.py
@@ -135,6 +135,9 @@ ATTACHMENT_PREFETCH_GENERATION_HEADROOM_MIN = int(os.getenv('ATTACHMENT_PREFETCH
 # ``RATE_SANITY_AUDIT_ENABLED`` pattern in ``audit_billing_changes.py``.
 # These module-level constants exist for documentation/discoverability,
 # matching the TIME_BUDGET_MINUTES family's convention.
+# IN-03 cross-pin: each default below is duplicated at its
+# ``pipeline/snapshot_drift.py`` call site (env-var helpers section) --
+# change BOTH sides together or they silently diverge.
 #
 # Detection + Supabase shadow-logging kill switch. Defaults ON: the
 # audit is report-only and additive (D-08).

--- a/pipeline/snapshot_drift.py
+++ b/pipeline/snapshot_drift.py
@@ -67,6 +67,10 @@ _CLASSIFICATION_UNCLASSIFIED = "unclassified"
 # Read PER CALL, not at import (D-08) -- exactly as
 # ``audit_billing_changes.py:376`` does for ``RATE_SANITY_AUDIT_ENABLED``
 # -- so tests can toggle any switch without reloading a module.
+# IN-03 cross-pin: every SNAPSHOT_DRIFT_* default passed at the call
+# sites in this module is duplicated by the documentation constants in
+# ``pipeline/config.py`` (SNAPSHOT_DRIFT family) -- change BOTH sides
+# together or they silently diverge.
 
 def _bool_env(name: str, default: bool) -> bool:
     raw = os.getenv(name)
@@ -117,7 +121,9 @@ def _build_run_id() -> str:
     if ga_run_id:
         attempt = os.getenv("GITHUB_RUN_ATTEMPT", "")
         return f"{ga_run_id}.{attempt}" if attempt else ga_run_id
-    return "local-" + datetime.datetime.utcnow().strftime("%Y%m%dT%H%M%S%fZ")
+    return "local-" + datetime.datetime.now(
+        datetime.timezone.utc
+    ).strftime("%Y%m%dT%H%M%S%fZ")
 
 
 def _coerce_date(value: Any) -> "datetime.date | None":
@@ -384,7 +390,7 @@ def _classify_candidates(
             )
             for candidate in candidates:
                 candidate["classification"] = _CLASSIFICATION_UNCLASSIFIED
-            logging.info(
+            logger.info(
                 "⏩ Snapshot-drift classification skipped: %s", skip_reason
             )
             return skip_reason
@@ -468,7 +474,7 @@ def _apply_holds(
         # the hold for this candidate (classify + log only).
         prior_snapshot = _coerce_date(candidate["prior_snapshot_date"])
         if prior_snapshot is None:
-            logging.warning(
+            logger.warning(
                 "⚠️ Snapshot-drift hold skipped for WR %s row %s: no "
                 "prior snapshot date on baseline (row would be dropped "
                 "by the Excel week filter).",
@@ -494,7 +500,7 @@ def _apply_holds(
         candidate["held"] = True
         held_count += 1
 
-        logging.info(
+        logger.info(
             "🔒 Snapshot-drift hold: WR %s row %s held at prior week %s "
             "(drifted to %s, changed_by=%s)",
             candidate["wr"], candidate["row_id"],
@@ -678,7 +684,7 @@ def apply_snapshot_drift_holds(
                 "(non-fatal)."
             )
 
-        logging.info(
+        logger.info(
             "📌 Snapshot-drift audit: candidates=%d seeded=%d unchanged=%d "
             "automation_self_fire=%d manual=%d unclassified=%d holds=%d",
             summary["candidates"], summary["seeded"], summary["unchanged"],

--- a/tests/test_rate_sanity_audit.py
+++ b/tests/test_rate_sanity_audit.py
@@ -60,6 +60,9 @@ class TestRateSanityIncidentRegression(RateSanityTestBase):
             'Work Type': 'Inst',
             'Quantity': '3',
             'Units Total Price': '$341.04',
+            # Post-cutoff: keeps the row inside the current-cycle
+            # scope gate (260813 scoping follow-up).
+            'Snapshot Date': '2026-08-09',
         }
         mismatches = self.audit._detect_rate_sanity_mismatches([row])
         self.assertEqual(len(mismatches), 1)
@@ -78,6 +81,7 @@ class TestRateSanityIncidentRegression(RateSanityTestBase):
             'Work Type': 'Inst',
             'Quantity': '1',
             'Units Total Price': '$56.84',
+            'Snapshot Date': '2026-08-09',
         }
         mismatches = self.audit._detect_rate_sanity_mismatches([row])
         self.assertEqual(mismatches, [])
@@ -93,6 +97,7 @@ class TestRateSanityEndToEndWiring(RateSanityTestBase):
             'Work Type': 'Inst',
             'Quantity': '3',
             'Units Total Price': '$341.04',
+            'Snapshot Date': '2026-08-09',
         }
         with tempfile.TemporaryDirectory() as tmp_dir, \
                 mock.patch.object(BillingAudit, '_save_audit_state'), \
@@ -126,6 +131,9 @@ class TestRateSanitySkipsAndTolerance(RateSanityTestBase):
             'Work Type': 'Inst',
             'Quantity': '3',
             'Units Total Price': '$341.04',
+            # Post-cutoff: skip/tolerance classes are asserted for
+            # IN-SCOPE rows (260813 scoping follow-up).
+            'Snapshot Date': '2026-08-09',
         }
         row.update(overrides)
         return row
@@ -233,6 +241,7 @@ class TestRateSanitySummary(RateSanityTestBase):
             'Work Type': 'Inst',
             'Quantity': '3',
             'Units Total Price': '$341.04',
+            'Snapshot Date': '2026-08-09',
         }
         with tempfile.TemporaryDirectory() as tmp_dir, \
                 mock.patch.object(BillingAudit, '_save_audit_state'), \
@@ -256,6 +265,7 @@ class TestRateSanitySummary(RateSanityTestBase):
             'Work Type': 'Inst',
             'Quantity': '3',
             'Units Total Price': '$341.04',
+            'Snapshot Date': '2026-08-09',
         }
         with tempfile.TemporaryDirectory() as tmp_dir, \
                 mock.patch.object(BillingAudit, '_save_audit_state'), \
@@ -297,6 +307,7 @@ class TestRateSanityAggregateInclusion(RateSanityTestBase):
             'Work Type': 'Inst',
             'Quantity': '3',
             'Units Total Price': '$341.04',
+            'Snapshot Date': '2026-08-09',
         }
         with tempfile.TemporaryDirectory() as tmp_dir, \
                 mock.patch.object(BillingAudit, '_save_audit_state'), \
@@ -334,6 +345,7 @@ class TestRateSanityAggregateInclusion(RateSanityTestBase):
             'Work Type': 'Inst',
             'Quantity': '1',
             'Units Total Price': '$56.84',
+            'Snapshot Date': '2026-08-09',
         }
         mismatch_row = {
             'Work Request #': '91916464',
@@ -341,6 +353,7 @@ class TestRateSanityAggregateInclusion(RateSanityTestBase):
             'Work Type': 'Inst',
             'Quantity': '3',
             'Units Total Price': '$341.04',
+            'Snapshot Date': '2026-08-09',
         }
         with tempfile.TemporaryDirectory() as tmp_dir, \
                 mock.patch.object(BillingAudit, '_log_to_audit_sheet'):
@@ -356,6 +369,127 @@ class TestRateSanityAggregateInclusion(RateSanityTestBase):
         trend = results['trend']
         self.assertEqual(trend['issues_delta'], 1)
         self.assertEqual(trend['risk_direction'], 'worsening')
+
+
+class TestRateSanityCurrentCycleScoping(RateSanityTestBase):
+    """Scoping follow-up (260813): current-cycle rows only.
+
+    The expected price is the New Rates basis, which only applies to
+    rows billed under the 2026-04-12 subcontractor rate contract. The
+    2026-08-12 live dry run showed the unscoped detector flagging
+    115,272/199,717 rows (58% -- old-rates history vs New-Rates
+    expected) and pinning ``risk_level`` HIGH every CI run. The
+    detector now reuses the production era gate (SUB-01 / D-08):
+    ``Snapshot Date >= _AEP_BILLABLE_CUTOFF`` with the Weekly
+    Reference Logged Date fallback of
+    ``_resolve_rate_recalc_cutoff_date``.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.audit = BillingAudit(client=None, skip_cell_history=True)
+
+    def _mismatch_row(self, **overrides: Any) -> Dict[str, Any]:
+        row = {
+            'Work Request #': '91916464',
+            'CU': 'SAA-DE-20',
+            'Work Type': 'Inst',
+            'Quantity': '3',
+            'Units Total Price': '$341.04',
+        }
+        row.update(overrides)
+        return row
+
+    def test_pre_cutoff_snapshot_row_is_out_of_scope(self) -> None:
+        row = self._mismatch_row(**{'Snapshot Date': '2026-03-01'})
+        mismatches = self.audit._detect_rate_sanity_mismatches([row])
+        self.assertEqual(mismatches, [])
+        self.assertEqual(self.audit._rate_sanity_out_of_scope, 1)
+        self.assertEqual(self.audit._rate_sanity_skipped, 0)
+
+    def test_post_cutoff_snapshot_mismatch_still_flagged(self) -> None:
+        row = self._mismatch_row(**{'Snapshot Date': '2026-08-09'})
+        mismatches = self.audit._detect_rate_sanity_mismatches([row])
+        self.assertEqual(len(mismatches), 1)
+        self.assertEqual(self.audit._rate_sanity_out_of_scope, 0)
+
+    def test_blank_snapshot_with_post_cutoff_weekly_is_in_scope(
+        self,
+    ) -> None:
+        """Weekly-Ref fallback rescues rows the snapshot automation
+        has not stamped yet (the observed VAC crew failure mode)."""
+        row = self._mismatch_row(
+            **{'Weekly Reference Logged Date': '2026-08-09'}
+        )
+        mismatches = self.audit._detect_rate_sanity_mismatches([row])
+        self.assertEqual(len(mismatches), 1)
+        self.assertEqual(self.audit._rate_sanity_out_of_scope, 0)
+
+    def test_blank_snapshot_with_pre_cutoff_weekly_is_out_of_scope(
+        self,
+    ) -> None:
+        row = self._mismatch_row(
+            **{'Weekly Reference Logged Date': '2026-03-01'}
+        )
+        mismatches = self.audit._detect_rate_sanity_mismatches([row])
+        self.assertEqual(mismatches, [])
+        self.assertEqual(self.audit._rate_sanity_out_of_scope, 1)
+
+    def test_undated_row_is_out_of_scope(self) -> None:
+        """No Snapshot Date, no Weekly Reference Logged Date -> the
+        row cannot be placed in the New-Rates era -> never checked."""
+        row = self._mismatch_row()
+        mismatches = self.audit._detect_rate_sanity_mismatches([row])
+        self.assertEqual(mismatches, [])
+        self.assertEqual(self.audit._rate_sanity_out_of_scope, 1)
+        self.assertEqual(self.audit._rate_sanity_skipped, 0)
+
+    def test_pre_cutoff_snapshot_does_not_fall_back_to_weekly(
+        self,
+    ) -> None:
+        """A parseable pre-cutoff Snapshot Date is authoritative --
+        mirrors ``_resolve_rate_recalc_cutoff_date`` exactly."""
+        row = self._mismatch_row(**{
+            'Snapshot Date': '2026-03-01',
+            'Weekly Reference Logged Date': '2026-08-09',
+        })
+        mismatches = self.audit._detect_rate_sanity_mismatches([row])
+        self.assertEqual(mismatches, [])
+        self.assertEqual(self.audit._rate_sanity_out_of_scope, 1)
+
+    def test_out_of_scope_precedes_skip_classification(self) -> None:
+        """An out-of-scope row with a bad CU counts as out-of-scope,
+        not as a skip -- scope is evaluated first."""
+        row = self._mismatch_row(**{
+            'CU': 'NOT-IN-TABLE',
+            'Snapshot Date': '2026-03-01',
+        })
+        mismatches = self.audit._detect_rate_sanity_mismatches([row])
+        self.assertEqual(mismatches, [])
+        self.assertEqual(self.audit._rate_sanity_out_of_scope, 1)
+        self.assertEqual(self.audit._rate_sanity_skipped, 0)
+
+    def test_summary_reports_out_of_scope_and_stays_low_risk(
+        self,
+    ) -> None:
+        """A history-only run (all rows pre-cutoff) must report LOW
+        risk with the out-of-scope count surfaced in the summary."""
+        row = self._mismatch_row(**{'Snapshot Date': '2026-03-01'})
+        with tempfile.TemporaryDirectory() as tmp_dir, \
+                mock.patch.object(BillingAudit, '_save_audit_state'), \
+                mock.patch.object(BillingAudit, '_log_to_audit_sheet'):
+            original_cwd = os.getcwd()
+            os.chdir(tmp_dir)
+            try:
+                audit = BillingAudit(client=None, skip_cell_history=True)
+                results = audit.audit_financial_data([], [row])
+            finally:
+                os.chdir(original_cwd)
+
+        summary = results['summary']
+        self.assertEqual(summary['total_rate_sanity_mismatches'], 0)
+        self.assertEqual(summary['rate_sanity_out_of_scope'], 1)
+        self.assertEqual(summary['risk_level'], 'LOW')
 
 
 if __name__ == '__main__':

--- a/tests/test_snapshot_drift_audit.py
+++ b/tests/test_snapshot_drift_audit.py
@@ -18,11 +18,32 @@ override in later sections of this file.
 from __future__ import annotations
 
 import datetime
+import os
 import types
 import unittest
+import warnings
 from unittest import mock
 
 from pipeline.snapshot_drift import apply_snapshot_drift_holds
+
+
+class TestBuildRunIdNoDeprecationWarning(unittest.TestCase):
+    """IN-01 (260812-jqx review): the local-run branch must not use the
+    deprecated ``datetime.datetime.utcnow()``.
+
+    Only meaningfully RED on Python >= 3.12 (the CI runtime), where
+    ``utcnow()`` emits DeprecationWarning; on 3.11 the pre-fix code
+    passes too — the pin still guards the CI interpreter.
+    """
+
+    def test_local_run_id_emits_no_deprecation_warning(self) -> None:
+        from pipeline.snapshot_drift import _build_run_id
+
+        with mock.patch.dict(os.environ, {"GITHUB_RUN_ID": ""}):
+            with warnings.catch_warnings():
+                warnings.simplefilter("error", DeprecationWarning)
+                run_id = _build_run_id()
+        self.assertTrue(run_id.startswith("local-"))
 
 
 def _row(

--- a/tests/test_snapshot_store.py
+++ b/tests/test_snapshot_store.py
@@ -1,0 +1,47 @@
+"""Direct tests for ``billing_audit/snapshot_store.py``.
+
+Started as the IN-05 fix lock (260812-jqx review): the
+``fetch_snapshot_provenance`` "NEVER raises" contract had a hole --
+``get_client()``, the ``_global_disable_reason`` peek, and the key
+coercions ran OUTSIDE the try/except, so an exception there escaped
+despite the docstring. These tests pin the contract at the module
+boundary (the caller-side wrap in ``pipeline/snapshot_drift.py`` is
+belt-and-suspenders, not the contract). Chips at WR-05 (zero direct
+snapshot_store coverage); the fuller suite remains a follow-up.
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+from billing_audit.snapshot_store import fetch_snapshot_provenance
+
+
+class TestFetchSnapshotProvenanceNeverRaises(unittest.TestCase):
+    def test_get_client_raising_degrades_to_fetch_failure(self) -> None:
+        """A crash in client acquisition must degrade, not escape."""
+        with mock.patch(
+            'billing_audit.snapshot_store.get_client',
+            side_effect=RuntimeError('client bootstrap exploded'),
+        ):
+            rows, status = fetch_snapshot_provenance([(1, 2)])
+        self.assertEqual(rows, {})
+        self.assertEqual(status, 'fetch_failure')
+
+    def test_uncoercible_key_degrades_to_fetch_failure(self) -> None:
+        """Non-numeric key parts crash the sorted-set coercions --
+        that too must degrade to fetch_failure, never raise."""
+        with mock.patch(
+            'billing_audit.snapshot_store.get_client',
+            return_value=mock.MagicMock(),
+        ):
+            rows, status = fetch_snapshot_provenance(
+                [('not-a-sheet-id', 'not-a-row-id')]  # type: ignore[list-item]
+            )
+        self.assertEqual(rows, {})
+        self.assertEqual(status, 'fetch_failure')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/website/blog/2026-08-12-rate-sanity-audit-check.md
+++ b/website/blog/2026-08-12-rate-sanity-audit-check.md
@@ -25,6 +25,19 @@ This check is diagnostic only: it never mutates row price, quantity, grouping,
 filenames, hashes, or upload behavior. It only adds entries to the audit
 summary and, when applicable, raises the audit's `risk_level`.
 
+**Scoped to the current cycle (2026-08-13 follow-up).** The check only
+evaluates rows that belong to the New-Rates era — the same production gate the
+grouping engine uses for `_AEPBillable` emission: `Snapshot Date >=` the
+2026-04-12 contract-award cutoff (env-overridable via `AEP_BILLABLE_CUTOFF`),
+with the `Weekly Reference Logged Date` fallback rescuing current-week rows the
+snapshot automation has not stamped yet. Rows before the cutoff — or rows that
+carry no parseable date at all — are counted in a new
+`rate_sanity_out_of_scope` aggregate and never checked. Reason: the first full
+live dry run (2026-08-12) showed the unscoped check flagging 115,272 of
+199,717 rows (58%) — all historical rows legitimately priced under the *old*
+contract rates — which pinned `risk_level` at HIGH on every scheduled run and
+buried real findings.
+
 The same PR also fixes an inconsistency in how the audit counts issues:
 `total_issues` is computed in three separate places (the persisted local
 history in `generated_docs/risk_trend.json`, the audit-sheet payload, and the
@@ -59,6 +72,11 @@ gap without touching the pricing path itself.
   sheet. A mismatch between the two is the signature of this defect class —
   fix it by re-saving the row upstream (forces the formula to recalculate),
   never in the Python pricing path.
+- **Historical rows are not findings.** The run log line
+  (`Rate-sanity audit: checked=… skipped=… out_of_scope=… mismatches=…`) and
+  the summary field `rate_sanity_out_of_scope` report how many rows were
+  excluded as pre-cutoff / undatable history. A large out-of-scope count on a
+  full run is expected, not a defect.
 - **Emergency disable, no deploy needed:** set the environment variable
   `RATE_SANITY_AUDIT_ENABLED=false` to turn the check off. This restores the
   pre-change audit summary shape exactly (empty `rate_sanity_mismatches`,


### PR DESCRIPTION
## Objective

Stop the report-only rate-sanity check (#329) from pinning `risk_level` HIGH on every scheduled run. The 2026-08-12 live dry run showed it flagging **115,272 of 199,717 rows (58%)** — historical rows legitimately priced under the *old* contract rates being compared against the New-Rates expected basis. This PR scopes the check to current-cycle rows and folds in the small deferred review nits from the #330 code review plus the WR_FILTER skill-doc correction.

## Changes Made

**Rate-sanity scoping (`audit_billing_changes.py`, `tests/test_rate_sanity_audit.py`)**
- New `_rate_sanity_in_scope()` reuses the existing SUB-01/D-08 production era gate via `pipeline/utils._resolve_rate_recalc_cutoff_date`: `Snapshot Date >= _AEP_BILLABLE_CUTOFF` (2026-04-12 contract award, env-overridable via `AEP_BILLABLE_CUTOFF`), with the Weekly Reference Logged Date fallback rescuing current-week rows the snapshot automation has not stamped yet. The coupling to `AEP_BILLABLE_CUTOFF` is deliberate — the billing-variant era and the sanity-check era must roll together.
- Pre-cutoff / undatable rows are counted in a new `rate_sanity_out_of_scope` summary field and the run-log aggregate line, and are never checked. Scope classification runs BEFORE skip classification.
- TDD: 8 new scoping tests (red-first); existing fixtures updated with a post-cutoff `Snapshot Date`.

**Deferred #330 review info nits (note: the IN-07 diff rides in the feat commit)**
- IN-01: `_build_run_id` uses `now(timezone.utc)` instead of deprecated `utcnow()`; DeprecationWarning-as-error test pins CI's Python 3.12.
- IN-02: `pipeline/snapshot_drift.py` logging standardized on the module `logger`.
- IN-03: cross-pin comments on both sides of the env-default duplication (`pipeline/config.py` ↔ `snapshot_drift.py` call sites).
- IN-05: `fetch_snapshot_provenance` NEVER-raises contract made real (client acquisition + key coercions moved inside the try) — locked by new `tests/test_snapshot_store.py`, the first direct snapshot_store coverage (chips at WR-05).
- IN-07: risk ladder extracted to shared `_risk_level_for()` (used by `_generate_audit_summary` and `escalate_risk_for_snapshot_drift`).
- Deliberately NOT done: IN-04 (changed_by email at INFO — PII posture decision reserved for Juan), WR-02 (RPC bulk read), WR-03 (RLS — pending Juan's DDL).

**Docs**
- Runbook blog page for the rate-sanity check rewritten for the scoped behavior (large `out_of_scope` counts on full runs are expected, not a defect).
- Living Ledger entry `[2026-08-13 15:30]`.
- `run-billing-pipeline-locally` skill: `WR_FILTER` is TEST_MODE-only (`pipeline/grouping.py:1222`); documented the scoped real-fetch recipe (`TEST_MODE=true SKIP_UPLOAD=true WR_FILTER=…`).

## Production Safety Check

- The rate-sanity check remains **report-only**: no changes to pricing, grouping, hashing, filenames, attachments, or upload behavior. The kill switch `RATE_SANITY_AUDIT_ENABLED=false` still restores the pre-#329 summary shape exactly.
- Scoping is strictly subtractive on findings (a subset of previously-checked rows is now excluded); post-cutoff mismatch detection — the SAA-DE-20 incident class — is regression-locked by tests.
- `_resolve_rate_recalc_cutoff_date` is reused read-only; no grouping/variant behavior touched.
- Snapshot-drift changes are logging/hygiene + a strictly-tighter never-raise boundary; hold-gate semantics untouched (still default OFF).
- Full suite: **1274 passed** (1263 baseline + 11 new), `py_compile` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR scopes the report-only rate-sanity audit to rows in the New-Rates cycle and includes small resiliency, logging, configuration-comment, test, and operator-documentation improvements.

- Reuses the billing cutoff resolver and reports excluded rows through `rate_sanity_out_of_scope`.
- Consolidates audit risk-level calculation and strengthens snapshot-provenance read failure handling.
- Corrects snapshot-drift logging and local-run timestamp handling.
- Adds focused regression tests and updates the runbook, living ledger, and local execution guidance.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete blocking or independently actionable non-blocking issue identified.

The cutoff helper’s return contract matches the new scope check, the intended weekly fallback is regression-tested, the new aggregate is consistently reset and surfaced, and the auxiliary snapshot-drift changes preserve existing runtime behavior while tightening failure handling.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| audit_billing_changes.py | Adds current-cycle rate-sanity scoping, an out-of-scope aggregate, and a shared risk-level helper without an accepted correctness issue. |
| billing_audit/snapshot_store.py | Expands the provenance reader’s exception boundary so client acquisition and key coercion honor its never-raise contract. |
| pipeline/snapshot_drift.py | Replaces deprecated UTC timestamp construction and standardizes changed logging calls on the module logger. |
| pipeline/config.py | Adds cross-reference guidance for duplicated snapshot-drift environment defaults. |
| tests/test_rate_sanity_audit.py | Adds cutoff, fallback, precedence, aggregate, and risk regression coverage for the scoped audit. |
| tests/test_snapshot_store.py | Adds direct tests confirming provenance-read failures degrade to `fetch_failure`. |
| .claude/skills/run-billing-pipeline-locally/SKILL.md | Corrects WR_FILTER applicability and documents a mutation-safe, real-fetch scoped recipe. |
| website/blog/2026-08-12-rate-sanity-audit-check.md | Rewrites operator guidance to explain current-cycle scoping and expected historical exclusion counts. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Billing audit receives rows] --> B{Rate-sanity enabled?}
    B -- No --> G[Generate audit summary]
    B -- Yes --> C{Current New-Rates cycle?}
    C -- No --> D[Increment out-of-scope count]
    C -- Yes --> E{Price can be evaluated?}
    E -- No --> F[Increment skipped count]
    E -- Yes --> H{Actual differs beyond tolerance?}
    H -- Yes --> I[Record mismatch]
    H -- No --> J[Count as checked]
    D --> G
    F --> G
    I --> G
    J --> G
    G --> K[Apply shared risk ladder]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: scoping runbook, ledger entry, WR\_..."](https://github.com/jflo21/generate-weekly-pdfs-dsr-resiliency/commit/6e51313f6711fdb0b1b12cb932a355de07fa4064) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53114561)</sub>

<!-- /greptile_comment -->