### PR TITLE
feat: demote legacy price-variance detector from risk ladder

### DIFF
--- a/.github/prompts/configuration-environment.md
+++ b/.github/prompts/configuration-environment.md
@@ -69,6 +69,15 @@ REGEN_WEEKS=081725,082425        # Force regenerate specific week endings
 RESET_WR_LIST=WR123,WR456        # Only purge these WR numbers (overrides full reset)
 KEEP_HISTORICAL_WEEKS=false      # Preserve attachments for unprocessed weeks
 
+# Billing Audit Risk Controls
+PRICE_VARIANCE_IN_RISK=false     # Count legacy price-variance anomalies toward
+                                 # audit risk_level. Demoted to report-only
+                                 # 2026-08-14 (575 structural false flags pinned
+                                 # risk HIGH; see living-ledger). Set true to
+                                 # restore legacy escalation. Dispatch-time
+                                 # override: advanced_options
+                                 # price_variance_in_risk:true
+
 # Advanced Testing Controls
 SYNTHETIC_WR_COUNT=8             # Number of Work Requests to generate in TEST_MODE
 SYNTHETIC_ROW_VARIANCE=15        # Row count variation per WR in synthetic data

--- a/.github/workflows/weekly-excel-generation.yml
+++ b/.github/workflows/weekly-excel-generation.yml
@@ -98,7 +98,7 @@ on:
         default: ''
         type: string
       advanced_options:
-        description: 'Advanced: max_groups:X,regen_weeks:MMDDYY1;MMDDYY2,reset_wr_list:WR1;WR2,remediate_claimers:1,remediation_dry_run:1,remediation_window_weeks:26'
+        description: 'Advanced: max_groups:X,regen_weeks:MMDDYY1;MMDDYY2,reset_wr_list:WR1;WR2,remediate_claimers:1,remediation_dry_run:1,remediation_window_weeks:26,price_variance_in_risk:true'
         required: false
         default: ''
         type: string
@@ -230,6 +230,7 @@ jobs:
               remediate_claimers) echo "REMEDIATE_CLAIMERS=${value}" >> "$GITHUB_ENV" ;;
               remediation_dry_run) echo "REMEDIATION_DRY_RUN=${value}" >> "$GITHUB_ENV" ;;
               remediation_window_weeks) echo "REMEDIATION_WINDOW_WEEKS=${value}" >> "$GITHUB_ENV" ;;
+              price_variance_in_risk) echo "PRICE_VARIANCE_IN_RISK=${value}" >> "$GITHUB_ENV" ;;
             esac
           done
       - name: Generate reports

--- a/audit_billing_changes.py
+++ b/audit_billing_changes.py
@@ -203,6 +203,51 @@ def _risk_level_for(total_issues: int) -> str:
     return "HIGH"
 
 
+def _price_variance_in_risk() -> bool:
+    """Whether legacy price-variance anomalies count toward risk_level.
+
+    Default OFF (260814 demotion, Juan-approved): the legacy
+    ``_detect_price_anomalies`` pools Units Total Price per WR across
+    ALL history and ALL CUs, so any WR mixing cheap and expensive
+    line items flags by construction — 575 flags with zero confirmed
+    incidents pinned ``risk_level`` HIGH on every run. Scoping was
+    measured before demoting (2026-08-14 ledger entry): the
+    rate-sanity era gate only cuts 575 -> 239 (still HIGH), and
+    re-basing the same >50%-variance rule per (WR, CU) explodes to
+    5,192-6,968 groups — the rule is statistically unusable at any
+    scope, and a principled per-CU expected-rate check is exactly
+    what the rate-sanity audit already does. The detector still RUNS
+    and REPORTS (``anomalies_detected`` / ``total_anomalies`` /
+    audit-sheet displays / trend deltas all keep counting it) — only
+    the ``_risk_level_for`` input excludes it. Set
+    ``PRICE_VARIANCE_IN_RISK=true`` to restore legacy escalation.
+    """
+    return (
+        os.getenv("PRICE_VARIANCE_IN_RISK", "false").lower() == "true"
+    )
+
+
+def _total_issues_for_risk(summary: Dict, extra: int = 0) -> int:
+    """Single source of truth for the risk-ladder input (IN-07).
+
+    Used by BOTH ``_generate_audit_summary`` and
+    ``escalate_risk_for_snapshot_drift`` so a scope change in one
+    place cannot silently diverge the other. Informational totals
+    (audit-sheet "Total Issues", audit_state history, trend deltas)
+    are intentionally NOT derived here — they keep counting
+    price-variance anomalies for report-only visibility.
+    """
+    total = (
+        summary.get("total_unauthorized_changes", 0)
+        + summary.get("total_data_issues", 0)
+        + summary.get("total_rate_sanity_mismatches", 0)
+        + extra
+    )
+    if _price_variance_in_risk():
+        total += summary.get("total_anomalies", 0)
+    return total
+
+
 def _rate_sanity_looks_like_zero(raw_price: Any) -> bool:
     """Return True when ``raw_price`` is a genuinely zero-valued cell.
 
@@ -672,13 +717,10 @@ class BillingAudit:
             "recommendations": []
         }
 
-        # Determine risk level
-        total_issues = (
-            summary["total_anomalies"]
-            + summary["total_unauthorized_changes"]
-            + summary["total_data_issues"]
-            + summary["total_rate_sanity_mismatches"]
-        )
+        # Determine risk level. Price-variance anomalies are excluded
+        # from this input by default (260814 demotion) but stay in
+        # every informational total — see _total_issues_for_risk.
+        total_issues = _total_issues_for_risk(summary)
 
         summary["risk_level"] = _risk_level_for(total_issues)
         if summary["risk_level"] == "LOW":
@@ -873,9 +915,10 @@ def escalate_risk_for_snapshot_drift(
     AFTER ``audit_financial_data`` has already produced ``summary``
     (the pre-grouping seam sits downstream of the audit block in
     ``pipeline/orchestrate.py``), so this module-level function
-    re-derives ``total_issues`` from the SAME fields
-    ``_generate_audit_summary`` uses plus ``self_fire_holds``, then
-    applies the shared ``_risk_level_for`` ladder (IN-07).
+    re-derives ``total_issues`` via the SHARED
+    ``_total_issues_for_risk`` helper (same input
+    ``_generate_audit_summary`` uses, plus ``self_fire_holds``),
+    then applies the shared ``_risk_level_for`` ladder (IN-07).
 
     Only automation self-fire HOLDS feed this -- folding in manual or
     unclassified drift would drive a routine batch of legitimate edits
@@ -889,13 +932,7 @@ def escalate_risk_for_snapshot_drift(
     if self_fire_holds <= 0:
         return summary
 
-    total_issues = (
-        summary.get("total_anomalies", 0)
-        + summary.get("total_unauthorized_changes", 0)
-        + summary.get("total_data_issues", 0)
-        + summary.get("total_rate_sanity_mismatches", 0)
-        + self_fire_holds
-    )
+    total_issues = _total_issues_for_risk(summary, extra=self_fire_holds)
 
     summary["risk_level"] = _risk_level_for(total_issues)
 

--- a/memory-bank/living-ledger.md
+++ b/memory-bank/living-ledger.md
@@ -5769,3 +5769,176 @@ follow-up findings closed, same 6 files.
   path. Watch the run log for `Snapshot-drift audit:` and
   `Rate-sanity audit:` aggregate lines. Hold gate remains OFF
   (`SNAPSHOT_DRIFT_HOLD_ENABLED` unset) until burn-in is judged.
+
+## [2026-08-13 22:00] Burn-in run 1 CLEAN (GH run 31761117011): first seeding + RPC path verified live
+
+- **Snapshot-drift audit: candidates=0 seeded=200,765 unchanged=0
+  holds=0** — perfect first-sight seeding of the entire row universe;
+  no PGRST202/rpc-missing WARNING (RPC-first path active), no
+  fetch_failure, no corroboration ERROR (empty-table probe correctly
+  authorized the first seed). Run: scheduled 01:00 UTC cron,
+  conclusion=success, ~2h.
+- **Rate-sanity scoping validated at production scale:**
+  `checked=85,398 skipped=27 out_of_scope=115,340
+  (subcontractor_basis=810, pre_cutoff_or_undated=114,530)
+  mismatches=2` — from 115,272 false flags (2026-08-12 dry run) down
+  to TWO findings, and the out_of_scope split matches the research
+  prediction almost exactly.
+- **NEW FINDING — the remaining HIGH-risk driver is the LEGACY
+  price-variance detector, not rate-sanity:** audit totals were
+  Anomalies=575 / Unauthorized=0 / Data issues=1 / Rate-sanity=2 →
+  risk_level HIGH. `_detect_price_anomalies` groups Units Total Price
+  by WR across ALL history with no era/scope gate (same noise class
+  rate-sanity had). Candidate follow-up (needs Juan's go): scope or
+  re-baseline the price-variance detector; until then risk_level will
+  stay HIGH on every run for reasons unrelated to drift or rates.
+- **The 2 rate-sanity mismatches are real post-cutoff signal**
+  (SAA-DE-20 defect class) — WR-level detail is not in CI logs by
+  design (T-ISX-01); identify them via a local
+  TEST_MODE+SKIP_UPLOAD run or the audit artifacts when investigating.
+- **Next-run steady-state expectation (burn-in criterion):**
+  seeded≈new-rows-only, unchanged≈200K, candidates = genuine
+  week-movers only. After a few clean days: enable
+  `SNAPSHOT_DRIFT_HOLD_ENABLED` via workflow-env PR.
+
+## [2026-08-13 23:00] The 2 rate-sanity mismatches IDENTIFIED (both underbill-by-one-unit, SAA-DE-20 stale-formula class) + legacy price-variance detector scoping measured — era gate alone is NOT enough
+
+- **Method (read-only local repro, scratchpad driver):** production
+  `discover_source_sheets` → `get_all_source_rows` → ONLY
+  `_detect_rate_sanity_mismatches` (no `audit_financial_data`, so no
+  audit_state write, no Sentry event, no upload). Counters matched
+  burn-in run 31761117011 almost exactly: `checked=85,475
+  skipped=27 out_of_scope=115,340 (810/114,530) mismatches=2`
+  (burn-in: checked=85,398, same out_of_scope split, same 2) —
+  the local repro is a faithful oracle for CI audit behavior.
+- **Mismatch 1: WR 91718610 / CU SAA-DE-20 / Inst / Qty 2** —
+  expected $113.68 (2 × $56.84), actual $56.84 → **underbilled
+  exactly one unit** (actual = rate × (qty−1)). Same CU as the
+  2026-08-12 incident, opposite direction. Source rows live on
+  Resiliency Promax Database Backup 82/83 + Intake Promax 9.
+- **Mismatch 2: WR 91173728 / CU DEC-20AL-C / Inst / Qty 4** —
+  expected $1,179.36 (4 × $294.84), actual $884.52 (3 × $294.84) →
+  **underbilled exactly one unit**, same class. (Smartsheet search
+  didn't surface its ProMax source sheet — index lag; find by WR
+  filter.)
+- **Action (upstream, per the [2026-08-12 13:40] rule):** on each
+  source row compare `Quantity` vs `Install Quantity` (stale SUMIFS
+  cell) and re-save the row to force recalc; next scheduled run
+  regenerates via hash change. NEVER patch the pricing path for this.
+- **Legacy `_detect_price_anomalies` scoping measured at production
+  scale** (200,842 rows; 85,502 in-scope under the rate-sanity gate):
+  current = 575 flagged WRs (matches CI); **era gate alone → 239**
+  (still ≫3 → risk_level stays HIGH); the same >50%-range rule
+  re-based per (WR, CU) era-gated → 6,968 groups (total price) /
+  5,192 (unit price = total/qty; zero-price rows poison it) — the
+  variance rule is statistically unusable at ANY scope on this data.
+  A principled re-baseline (compare to expected rate per CU+era)
+  converges to what rate-sanity already does; residual unique value
+  ≈ CUs absent from `data/subcontractor_rates.csv` (skipped=27 rows
+  only). **Recommendation (needs Juan's decision):** retire/demote
+  the legacy detector — keep report-only but exclude its count from
+  `total_issues`/`_risk_level_for` (or env-flag default-off). Do NOT
+  invest in era-gating it; measurement shows that cannot clear HIGH.
+- **NEW observability gap:** `_log_audit_results` fires
+  `capture_message("AUDIT: Risk …")` on every HIGH run with
+  SENTRY_DSN set in CI, yet Sentry (org linetec-services-llc-hi) has
+  ZERO such events across 7 days, all projects. Suspect the attached
+  `scope.set_context("audit_results", …)` payload (575 anomaly
+  dicts + full lists) is dropped at ingest for size — and it also
+  ships WR+price detail, in tension with the T-ISX-01 aggregate-only
+  posture. Follow-up candidate: slim the Sentry context to
+  summary-only (fixes both delivery and PII posture).
+
+## [2026-08-14 00:50] ROOT CAUSE CONFIRMED via cell history: both rate-sanity mismatches are automation-triggered stale recalcs (2-3s after a human qty edit), with exact row pointers
+
+- **WR 91718610 / SAA-DE-20 / Inst — Resiliency Promax Database
+  Backup 83 (sheet 1751347954143108), row 5538447881863044.**
+  Cell-history timeline (UTC 2026-08-07): 00:15:38 Jose Mendez edits
+  Quantity 1→2 (+ checks Units Completed?); 00:16:01 automation
+  stamps Snapshot Date; 00:30:22 formula chain recalcs CORRECTLY
+  (Install Pricing Totals + Units Total Price → $113.68); **00:30:24
+  a "Smartsheet Automation"-attributed recalc reverts both to $56.84**
+  (rate × stale Install Quantity=1) and the value parks. Quantity/
+  Install Quantity currently agree at 2 — the stale cell is the
+  PRICING-TOTALS formula result, not the quantity SUMIFS. Billed week
+  2026-08-09 → that week's Excel already underbilled $56.84; re-save
+  regenerates via hash change.
+- **WR 91173728 / DEC-20AL-C / Inst — Resiliency Promax Database
+  Backup 73 (sheet 5545068919213956), row 1166598725369732.**
+  Timeline (UTC 2026-08-11): 22:33:31 Patrick Duffy edits Quantity
+  3→4; 22:33:48 price recalcs CORRECTLY to $1,179.36; **22:33:51
+  automation-attributed recalc reverts to $884.52** (3 × $294.84).
+  Quantity/Install Quantity currently agree at 4. **Billed week is
+  2026-08-16 (CURRENT) — bills $294.84 short this week unless the
+  row is re-saved before the next run.** (Do not confuse with Intake
+  Promax 9 row 8998903473897348 — qty 3 @ $884.52, consistent, fine.)
+- **Refined rule for the SAA-DE-20 class:** the defect is an
+  automation-TRIGGERED re-evaluation racing a human edit (recalc
+  reads a stale dependent 2-3s later and last-write-wins), not a
+  formula cell that "never recalculated". Both incidents predate
+  Juan's 2026-08-13 automation reconfiguration — watch rate-sanity
+  counters on future runs to verify the fix killed the race (any new
+  mismatch = race still alive). Locate source rows fast via
+  `billing_audit.snapshot_provenance` (sheet_id,row_id by wr+cu) —
+  used here read-only via Supabase MCP.
+
+## [2026-08-14 10:05] Both underbilled rows REPAIRED via approved API re-save; drift steady state ACHIEVED run 2; rate-sanity 2 -> 1 -> (expect 0)
+
+- **Repair method (Juan-approved live write):** a same-value Quantity
+  rewrite is a NO-OP for Smartsheet's dependency graph — no recalc,
+  no history entry (this is WHY the wrong values had persisted since
+  Aug 7/11: nothing ever invalidated them). Working idiom: two-step
+  type-flip — write Quantity as TEXT ("2", strict=true), then
+  immediately back as NUMBER — each step is a real change and the
+  second recalc lands on correct current inputs. Snapshot Date was
+  NOT re-stamped by automations on either edit.
+- **Row 1 (Backup 83 / 5538447881863044, WR 91718610):** fixed →
+  $113.68, stable through the automation window AND run 31805121266,
+  which REGENERATED Week=080926 (the underbilled 08-09 Excel is
+  corrected + re-uploaded). Caution logged: the session slept mid-
+  flip, leaving the row in text-Quantity state 07:06–08:11 UTC
+  (price $0 transiently); no run fetched in that window.
+- **Row 2 (Backup 73 / 1166598725369732, WR 91173728):** fixed →
+  $1,179.36 at 14:56 UTC (after run 31805121266 fetched), stable.
+  That run generated Week=081626 with the old $884.52 — the NEXT
+  scheduled run picks up the hash change and regenerates the
+  current-week file correctly. No manual regen needed.
+- **Run 31805121266 (13:31 UTC, success): rate-sanity mismatches=1**
+  (row 1 cleared pre-run) — next run expected 0. **Snapshot-drift
+  steady state ACHIEVED on run 2: candidates=0 seeded=155
+  unchanged=200,765 holds=0** (seeded ≈ new rows only) — burn-in
+  criterion met → SNAPSHOT_DRIFT_HOLD_ENABLED workflow-env PR is
+  now unblocked (GitHub Actions change — Juan approves).
+- **Automation-race signal:** neither of my two real edits triggered
+  the 2-3s revert that hit Jose's (Aug 7) and Patrick's (Aug 11)
+  edits — consistent with Juan's 2026-08-13 automation fix working.
+  Definitive proof = future foreman edits; watch rate-sanity
+  mismatch count each run (>0 new = race alive).
+
+## [2026-08-14 11:10] Legacy price-variance detector DEMOTED from risk ladder (Juan-approved) — report-only; PRICE_VARIANCE_IN_RISK restores legacy
+
+- **What:** `_detect_price_anomalies` findings no longer count toward
+  `risk_level` by default. New shared helper
+  `_total_issues_for_risk(summary, extra=0)` is the SINGLE risk-ladder
+  input used by BOTH `_generate_audit_summary` and
+  `escalate_risk_for_snapshot_drift` (extends IN-07: one derivation,
+  never two that can diverge). `PRICE_VARIANCE_IN_RISK=true` restores
+  the legacy escalation. The detector still runs; `total_anomalies`,
+  recommendations, audit-sheet "Total Issues", audit_state history,
+  and trend deltas all still count it (report-only visibility kept).
+- **Why (measured, ledger [2026-08-13 23:00]):** the detector pools
+  Units Total Price per WR across ALL history AND all CUs — multi-CU
+  WRs flag by construction: 575 flags, zero confirmed incidents,
+  risk pinned HIGH every run. Era gate cuts only to 239 (still
+  HIGH); per-(WR,CU) re-base explodes to 5,192–6,968. A principled
+  per-CU expected-rate check IS the rate-sanity audit (which is now
+  clean: mismatches=0 on run 31813915527).
+- **Effect:** `risk_level` becomes meaningful — driven by
+  unauthorized changes, data issues, rate-sanity mismatches, and
+  drift self-fire holds. The "AUDIT ALERT: HIGH" warning and the
+  Sentry send gate now fire only on genuine signal. Sentry AUDIT
+  events were not arriving anyway (open observability gap, entry
+  [2026-08-13 23:00]) — slimming that context is still a follow-up.
+- **Tests:** tests/test_price_variance_risk_demotion.py (13) — default
+  exclusion, report-only preservation, flag restore, drift-escalation
+  mirror, zero-hold no-op.

--- a/tests/test_price_variance_risk_demotion.py
+++ b/tests/test_price_variance_risk_demotion.py
@@ -1,0 +1,140 @@
+"""Legacy price-variance detector demotion (260814).
+
+``_detect_price_anomalies`` pools Units Total Price per WR across ALL
+history and ALL CUs, so multi-CU WRs flag by construction (575 flags,
+zero confirmed incidents, risk_level pinned HIGH every run). These
+tests lock in the demotion contract:
+
+- anomalies still DETECTED and REPORTED (``total_anomalies``,
+  recommendations) — report-only visibility is preserved;
+- anomalies NO LONGER count toward ``risk_level`` by default;
+- ``PRICE_VARIANCE_IN_RISK=true`` restores the legacy escalation;
+- ``escalate_risk_for_snapshot_drift`` mirrors the exclusion via the
+  shared ``_total_issues_for_risk`` helper (IN-07: one ladder input,
+  never two divergent derivations).
+"""
+import os
+import unittest
+from unittest import mock
+
+from audit_billing_changes import (
+    BillingAudit,
+    _total_issues_for_risk,
+    escalate_risk_for_snapshot_drift,
+)
+
+
+def _results(anomalies=0, unauthorized=0, data_issues=0, rate_sanity=0):
+    return {
+        "anomalies_detected": [{"type": "price_variance_anomaly"}] * anomalies,
+        "unauthorized_changes": [{}] * unauthorized,
+        "data_integrity_issues": [{}] * data_issues,
+        "rate_sanity_mismatches": [{}] * rate_sanity,
+    }
+
+
+class PriceVarianceDemotionBase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.audit = BillingAudit(client=None, skip_cell_history=True)
+
+    def _summary(self, **kwargs):
+        return self.audit._generate_audit_summary(_results(**kwargs))
+
+
+class TestAnomaliesExcludedFromRiskByDefault(PriceVarianceDemotionBase):
+    def test_anomalies_alone_leave_risk_low(self) -> None:
+        summary = self._summary(anomalies=575)
+        self.assertEqual(summary["risk_level"], "LOW")
+
+    def test_anomalies_still_reported(self) -> None:
+        summary = self._summary(anomalies=575)
+        self.assertEqual(summary["total_anomalies"], 575)
+        self.assertTrue(
+            any("price anomalies" in r.lower()
+                for r in summary["recommendations"])
+        )
+
+    def test_real_issues_still_escalate_medium(self) -> None:
+        summary = self._summary(anomalies=575, rate_sanity=2)
+        self.assertEqual(summary["risk_level"], "MEDIUM")
+
+    def test_real_issues_still_escalate_high(self) -> None:
+        summary = self._summary(anomalies=575, rate_sanity=4)
+        self.assertEqual(summary["risk_level"], "HIGH")
+
+    def test_zero_everything_is_low(self) -> None:
+        summary = self._summary()
+        self.assertEqual(summary["risk_level"], "LOW")
+
+
+class TestLegacyFlagRestoresEscalation(PriceVarianceDemotionBase):
+    def test_flag_on_counts_anomalies_high(self) -> None:
+        with mock.patch.dict(os.environ,
+                             {"PRICE_VARIANCE_IN_RISK": "true"}):
+            summary = self._summary(anomalies=5)
+        self.assertEqual(summary["risk_level"], "HIGH")
+
+    def test_flag_on_small_count_medium(self) -> None:
+        with mock.patch.dict(os.environ,
+                             {"PRICE_VARIANCE_IN_RISK": "true"}):
+            summary = self._summary(anomalies=2)
+        self.assertEqual(summary["risk_level"], "MEDIUM")
+
+
+class TestSharedRiskInputHelper(unittest.TestCase):
+    def test_excludes_anomalies_by_default(self) -> None:
+        summary = {
+            "total_anomalies": 575,
+            "total_unauthorized_changes": 1,
+            "total_data_issues": 1,
+            "total_rate_sanity_mismatches": 1,
+        }
+        self.assertEqual(_total_issues_for_risk(summary), 3)
+
+    def test_extra_is_added(self) -> None:
+        summary = {"total_anomalies": 575}
+        self.assertEqual(_total_issues_for_risk(summary, extra=2), 2)
+
+    def test_flag_on_includes_anomalies(self) -> None:
+        summary = {"total_anomalies": 5}
+        with mock.patch.dict(os.environ,
+                             {"PRICE_VARIANCE_IN_RISK": "true"}):
+            self.assertEqual(_total_issues_for_risk(summary), 5)
+
+
+class TestDriftEscalationMirrorsExclusion(unittest.TestCase):
+    def test_holds_with_anomalies_stay_medium(self) -> None:
+        summary = {
+            "total_anomalies": 575,
+            "total_unauthorized_changes": 0,
+            "total_data_issues": 0,
+            "total_rate_sanity_mismatches": 0,
+            "risk_level": "LOW",
+        }
+        out = escalate_risk_for_snapshot_drift(summary, self_fire_holds=2)
+        self.assertEqual(out["risk_level"], "MEDIUM")
+        self.assertEqual(out["total_snapshot_drift_holds"], 2)
+
+    def test_holds_with_flag_on_go_high(self) -> None:
+        summary = {
+            "total_anomalies": 575,
+            "total_unauthorized_changes": 0,
+            "total_data_issues": 0,
+            "total_rate_sanity_mismatches": 0,
+            "risk_level": "LOW",
+        }
+        with mock.patch.dict(os.environ,
+                             {"PRICE_VARIANCE_IN_RISK": "true"}):
+            out = escalate_risk_for_snapshot_drift(
+                summary, self_fire_holds=2
+            )
+        self.assertEqual(out["risk_level"], "HIGH")
+
+    def test_zero_holds_leaves_summary_untouched(self) -> None:
+        summary = {"total_anomalies": 575, "risk_level": "LOW"}
+        out = escalate_risk_for_snapshot_drift(summary, self_fire_holds=0)
+        self.assertEqual(out["risk_level"], "LOW")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_price_variance_risk_demotion.py
+++ b/tests/test_price_variance_risk_demotion.py
@@ -15,6 +15,7 @@ tests lock in the demotion contract:
 """
 import os
 import unittest
+from typing import Any, Dict, List
 from unittest import mock
 
 from audit_billing_changes import (
@@ -24,7 +25,12 @@ from audit_billing_changes import (
 )
 
 
-def _results(anomalies=0, unauthorized=0, data_issues=0, rate_sanity=0):
+def _results(
+    anomalies: int = 0,
+    unauthorized: int = 0,
+    data_issues: int = 0,
+    rate_sanity: int = 0,
+) -> Dict[str, List[Dict[str, str]]]:
     return {
         "anomalies_detected": [{"type": "price_variance_anomaly"}] * anomalies,
         "unauthorized_changes": [{}] * unauthorized,
@@ -37,7 +43,7 @@ class PriceVarianceDemotionBase(unittest.TestCase):
     def setUp(self) -> None:
         self.audit = BillingAudit(client=None, skip_cell_history=True)
 
-    def _summary(self, **kwargs):
+    def _summary(self, **kwargs: int) -> Dict[str, Any]:
         return self.audit._generate_audit_summary(_results(**kwargs))
 
 


### PR DESCRIPTION
## Objective
Make `risk_level` meaningful again. The legacy `_detect_price_anomalies` pools Units Total Price per WR across ALL history and ALL CUs, so multi-CU WRs flag by construction — 575 flags with zero confirmed incidents pinned risk HIGH on every run. Scoping was measured before demoting (ledger `[2026-08-13 23:00]`): the rate-sanity era gate only cuts 575→239 (still HIGH); re-basing the >50%-variance rule per (WR, CU) explodes to 5,192–6,968 flags. The principled per-CU expected-rate check is the rate-sanity audit, which is now clean (mismatches=0 on run 31813915527).

## Changes Made
- `audit_billing_changes.py`: new `_price_variance_in_risk()` (env `PRICE_VARIANCE_IN_RISK`, default `false`) and `_total_issues_for_risk(summary, extra=0)` — the single shared risk-ladder input used by BOTH `_generate_audit_summary` and `escalate_risk_for_snapshot_drift` (extends IN-07).
- `tests/test_price_variance_risk_demotion.py`: 13 tests — default exclusion, report-only preservation, flag restore, drift-escalation mirror, zero-hold no-op.
- `memory-bank/living-ledger.md`: dated entries for the full investigation arc (mismatch identification, root-cause cell-history forensics, approved row repairs, scoping measurements, this demotion).

## Production Safety Check
Report-only surfaces are byte-identical: the detector still runs; `total_anomalies`, recommendations, audit-sheet "Total Issues", `audit_state` history, and trend deltas all still count anomalies. Only the `_risk_level_for` input changes, and `PRICE_VARIANCE_IN_RISK=true` restores legacy behavior instantly. No pricing, grouping, hashing, filename, attachment, or upload logic touched. Full suite: **1336 passed + 132 subtests, 0 regressions**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This change makes legacy price-variance anomalies report-only by default while retaining a rollback option to restore risk-level escalation. It also keeps snapshot-drift escalation aligned with the shared risk calculation and adds focused regression coverage.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with no blocking failure remaining.

No accepted P0 or P1 findings remain.
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(review): type test helpers, document..."](https://github.com/jflo21/generate-weekly-pdfs-dsr-resiliency/commit/f9e82adf6a1b8e32f17e6ec8481a40533b223af2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53379595)</sub>

**Context used:**

- Context used - .claude/rules/documentation-maintenance.md ([source](https://github.com/jflo21/generate-weekly-pdfs-dsr-resiliency/blob/master/.claude/rules/documentation-maintenance.md))

<!-- /greptile_comment -->