### PR TITLE
feat: enable snapshot-drift hold gate after clean burn-in

### DIFF
--- a/.github/workflows/weekly-excel-generation.yml
+++ b/.github/workflows/weekly-excel-generation.yml
@@ -250,7 +250,16 @@ jobs:
           # safe to land before the secrets exist at the repo level.
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-          
+          # Snapshot-drift hold gate (260814, Juan-approved after
+          # burn-in): holds ONLY automation-self-fire drift candidates
+          # at their prior billed week (D-01 — manual and unclassified
+          # drift is logged, never held). Enabled after two clean
+          # burn-in runs: 31761117011 (first seed, candidates=0) and
+          # 31805121266 (steady state: candidates=0, seeded=155,
+          # unchanged=200,765, holds=0). Flip to 'false' to revert to
+          # log-only behavior instantly.
+          SNAPSHOT_DRIFT_HOLD_ENABLED: 'true'
+
           # Basic Operation Controls
           TEST_MODE: ${{ github.event.inputs.test_mode || 'false' }}
           FORCE_GENERATION: ${{ github.event.inputs.force_generation || 'false' }}

--- a/memory-bank/living-ledger.md
+++ b/memory-bank/living-ledger.md
@@ -5769,3 +5769,26 @@ follow-up findings closed, same 6 files.
   path. Watch the run log for `Snapshot-drift audit:` and
   `Rate-sanity audit:` aggregate lines. Hold gate remains OFF
   (`SNAPSHOT_DRIFT_HOLD_ENABLED` unset) until burn-in is judged.
+
+## [2026-08-14 11:25] Snapshot-drift HOLD GATE ENABLED (workflow env) + IN-04 resolved: changed_by KEPT on the hold line (automation-only by construction)
+
+- **What:** `SNAPSHOT_DRIFT_HOLD_ENABLED: 'true'` added to the
+  `Generate reports` env in weekly-excel-generation.yml. Burn-in
+  criterion met first: run 31761117011 (first seed, candidates=0) and
+  run 31805121266 (steady state: candidates=0, seeded=155 new rows,
+  unchanged=200,765, holds=0). Rollback = flip the env to 'false'.
+- **Blast radius (D-01, verified at snapshot_drift.py:465):** holds
+  apply ONLY to `automation_self_fire` candidates; manual and
+  unclassified drift is never held — run 31813915527's 110 legit
+  Thursday-morning candidates (manual=40, unclassified=70,
+  self_fire=0) would all have passed through untouched. With the
+  automation trigger fixed (2026-08-13), expected steady state is
+  holds=0; any nonzero hold = the re-stamp defect recurred and was
+  contained.
+- **IN-04 DECISION — keep `changed_by` in the per-hold INFO line:**
+  the hold path is reachable only for automation_self_fire
+  candidates, so changed_by on that line is by construction the
+  Smartsheet automation identity, never a personal email (verified:
+  line 512 is the ONLY log site that formats changed_by; manual
+  drift goes to aggregate counters + the billing_audit.snapshot_drift
+  shadow table). Documented in-code at the hold line.

--- a/memory-bank/living-ledger.md
+++ b/memory-bank/living-ledger.md
@@ -5950,7 +5950,9 @@ follow-up findings closed, same 6 files.
   criterion met first: run 31761117011 (first seed, candidates=0) and
   run 31805121266 (steady state: candidates=0, seeded=155 new rows,
   unchanged=200,765, holds=0). Rollback = flip the env to 'false'.
-- **Blast radius (D-01, verified at snapshot_drift.py:465):** holds
+- **Blast radius (D-01, verified at the
+  `_CLASSIFICATION_AUTOMATION_SELF_FIRE` gate in `_apply_holds()`,
+  `pipeline/snapshot_drift.py`):** holds
   apply ONLY to `automation_self_fire` candidates; manual and
   unclassified drift is never held — run 31813915527's 110 legit
   Thursday-morning candidates (manual=40, unclassified=70,
@@ -5962,6 +5964,7 @@ follow-up findings closed, same 6 files.
   the hold path is reachable only for automation_self_fire
   candidates, so changed_by on that line is by construction the
   Smartsheet automation identity, never a personal email (verified:
-  line 512 is the ONLY log site that formats changed_by; manual
+  the per-hold INFO log in `_apply_holds()` — the "🔒 Snapshot-drift
+  hold" line — is the ONLY log site that formats changed_by; manual
   drift goes to aggregate counters + the billing_audit.snapshot_drift
   shadow table). Documented in-code at the hold line.

--- a/pipeline/snapshot_drift.py
+++ b/pipeline/snapshot_drift.py
@@ -500,6 +500,13 @@ def _apply_holds(
         candidate["held"] = True
         held_count += 1
 
+        # IN-04 resolved (260814): changed_by stays in this INFO line.
+        # Only automation_self_fire candidates ever reach a hold
+        # (D-01 gate above), so changed_by here is by construction the
+        # Smartsheet automation identity — a personal email can never
+        # appear on this line. Manual/unclassified drift (where
+        # changed_by CAN be a person) is logged aggregate-only and
+        # recorded durably in billing_audit.snapshot_drift instead.
         logger.info(
             "🔒 Snapshot-drift hold: WR %s row %s held at prior week %s "
             "(drifted to %s, changed_by=%s)",


### PR DESCRIPTION
## Objective
Turn on the snapshot-drift hold gate now that the burn-in criterion is met. Two clean runs: 31761117011 (first seed, candidates=0) and 31805121266 (steady state: candidates=0, seeded=155 new rows only, unchanged=200,765, holds=0). With the gate on, a recurrence of the Snapshot Date automation re-stamp defect is contained (row held at its prior billed week) instead of silently moving billing weeks.

## Changes Made
- `.github/workflows/weekly-excel-generation.yml`: add the `SNAPSHOT_DRIFT_HOLD_ENABLED` env (value `'true'`) to the **Generate reports** step, with an in-file comment recording the burn-in evidence and rollback.
- `pipeline/snapshot_drift.py`: comment-only — documents the IN-04 decision at the hold log line: `changed_by` stays, because only `automation_self_fire` candidates ever reach a hold (D-01 gate at line 465), so that field is by construction the Smartsheet automation identity, never a personal email.
- `memory-bank/living-ledger.md`: dated entry with the burn-in evidence, blast-radius verification, and the IN-04 decision.

## Production Safety Check
No Python logic changes (comment only; `py_compile` + drift test file green: 34 passed + 2 subtests). Blast radius verified in code: holds apply **only** to `automation_self_fire` candidates — run 31813915527's 110 legitimate Thursday-morning candidates (manual=40, unclassified=70, self_fire=0) would all pass through untouched. Expected steady state with the fixed automation is holds=0; any nonzero hold is the defect recurring and being contained. Instant rollback: flip the env value to `'false'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This change enables the production snapshot-drift hold gate and updates its operational documentation to use stable code references. Executed coverage confirms that automatic self-fire drift is held to the prior billed week, while manual and unclassified changes remain unmodified.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

No blocking failure remains.

The enabled hold behavior was exercised across automatic, manual, and unclassified drift paths, and the observed results matched the intended billing behavior.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I inspected the Generate reports workflow and confirmed that the Generate reports step passes SNAPSHOT\_DRIFT\_HOLD\_ENABLED: 'true' to report generation.
- I ran a mocked Supabase and Smartsheet harness with the gate enabled and observed the run produced candidates=3, automation\_self\_fire=1, manual=1, unclassified=1, automation\_self\_fire\_holds=1, with only the automatic self-fire row restored to its prior billed week and prior snapshot date.
- I repeated the flow with the gate disabled and saw zero holds and no mutations; I also executed the focused hold-rewrite and non-automation regression tests, and all tests passed.
- I captured and cross-referenced implementation details and outputs to confirm the enabled-hold gate behavior, wiring of the hold gate into the automation/manual/unclassified paths, and the regression test coverage, using the referenced artifacts.

<a href="https://app.greptile.com/trex/runs/18942111/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["docs(ledger): use symbol refs for drift ..."](https://github.com/jflo21/generate-weekly-pdfs-dsr-resiliency/commit/874020e89c9479856d903790473aea8b2bc2143d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53381040)</sub>

<!-- /greptile_comment -->