### PR TITLE
feat: add system health check entry point (#338 follow-up)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,7 @@ generated_docs/audit_state.json
 generated_docs/discovery_cache.json
 generated_docs/risk_trend.json
 generated_docs/run_summary.json
+generated_docs/system_health.json
 !generated_docs/README.md
 
 # Notion integration local config (contains database IDs)

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -38,7 +38,7 @@ Status: Ready to plan
   change; all 7 waves independently 6-gate-verified. Next: /gsd-verify-work 09,
   then PR / milestone close. (Phase 08 SDK 4.0.0 migration still outstanding — same
   file, so it could not run concurrently; now unblocked.)
-Last activity: 2026-08-13 - Completed quick task 260813-nhn: closed billing-audit shadow-layer follow-ups (P2/#333 flag parity, snapshot_store characterization suite, RPC bulk provenance read with chunked select fallback, chunked provenance upsert)
+Last activity: 2026-08-14 - Completed quick task 260814-me8: production-workflow config guardrail check for validate_system_health.py (closes PR #339 Greptile vacuous-pass finding)
 
 ### Infrastructure Topology (discovered 2026-06-01 via Supabase MCP) — READ BEFORE PHASE 05
 
@@ -213,6 +213,7 @@ See PROJECT.md `<decisions>` table for the full 30+ entry log.
 
 | # | Description | Date | Commit | Directory |
 |---|-------------|------|--------|-----------|
+| 260814-me8 | Close PR #339 Greptile vacuous-pass finding: new `check_production_workflow_config` parses weekly-excel-generation.yml directly (comment-stripped, `\|\| 'N'` expression fallbacks resolved) and grades PARALLEL_WORKERS/_DISCOVERY ≤ 8 and TIME_BUDGET_MINUTES strictly < max timeout-minutes; env check relabeled process-env-only scope; values redacted/truncated before report echo | 2026-08-14 | 9690cdd | [260814-me8](./quick/260814-me8-fix-health-check-config-guardrail-vacuou/) |
 | 260813-fast | Make schema.sql policy DDL reapply-safe (PR #335 review fix — DROP POLICY IF EXISTS before each CREATE POLICY) | 2026-08-13 | 350fd99 | — (fast task, inline) |
 | 260813-nhn | Closed 3 deferred billing-audit shadow-layer follow-ups: P2/#333 rate-sanity flag parity (`_gwp.RATE_RECALC_WEEKLY_FALLBACK` ANDed at the call site), WR-05 24-test `snapshot_store.py` characterization suite (regression oracle), WR-02 RPC-first bulk provenance read (`lookup_snapshot_provenance_bulk` DDL + chunked select fallback + one-time degrade log), WR-02b chunked provenance upsert (D-02 sibling defect, ~40MB unchunked body at live `all_rows` scale) | 2026-08-13 | 8918dea, e238978, 4292dd4, bcb79c3, e29c5ed | [260813-nhn](./quick/260813-nhn-rpc-bulk-provenance-read-snapshot-store-/) |
 | 260813-m5j | Harden rate-sanity scope gate per PR #332 review findings: exclude subcontractor-basis rows (F2 polarity corrected — incident sheet is NOT subcontractor), fail-closed weekly fallback gated on sheet's Snapshot Date column mapping (F1) | 2026-08-13 | 4245450, a7c27b2, 63c38c7 | [260813-m5j](./quick/260813-m5j-harden-rate-sanity-scope-gate-per-pr-332/) |

--- a/.planning/quick/260814-me8-fix-health-check-config-guardrail-vacuou/260814-me8-PLAN.md
+++ b/.planning/quick/260814-me8-fix-health-check-config-guardrail-vacuou/260814-me8-PLAN.md
@@ -1,0 +1,324 @@
+---
+phase: quick-260814-me8
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - validate_system_health.py
+  - tests/test_validate_system_health.py
+autonomous: true
+requirements: [GREPTILE-339-CONFIG-VACUOUS]
+
+estimate:
+  tokens: 55000
+  raw_tokens: 55000
+  tasks: 3
+  confidence: low        # 0 calibration samples available -> lowest tier
+
+must_haves:
+  truths:
+    - "The health run detects a PARALLEL_WORKERS drift in the production workflow file even though the health job's own process environment never exports PARALLEL_WORKERS (this is the whole point of the Greptile finding)."
+    - "A worker count above the documented cap of 8 in weekly-excel-generation.yml yields WARN, whether it is PARALLEL_WORKERS or PARALLEL_WORKERS_DISCOVERY."
+    - "TIME_BUDGET_MINUTES that is non-numeric, or not strictly less than the largest timeout-minutes in the workflow, yields WARN."
+    - "A commented-out line in the workflow can neither satisfy nor trip the guardrail — only live YAML lines are read."
+    - "A GitHub expression value resolves to its `|| 'N'` fallback literal, because that is the value a scheduled (non-dispatch) run actually receives."
+    - "An absent weekly-excel-generation.yml yields CRITICAL (the production schedule is gone); a present-but-unparseable value yields WARN; an absent key is an informational note only."
+    - "The check never echoes a secrets expression or an unbounded raw value into the report detail."
+    - "The pre-existing env-scoped check still runs and its detail states that its scope is this job's process environment."
+    - "The real .github/workflows/weekly-excel-generation.yml is read only — its bytes are unchanged by this work."
+  artifacts:
+    - validate_system_health.py
+    - tests/test_validate_system_health.py
+  key_links:
+    - "check_production_workflow_config must be registered inside run_checks() — a defined-but-unregistered check is exactly the same vacuous-pass class of defect this task is fixing."
+    - "WORKFLOW_PATH must resolve from os.path.dirname(os.path.abspath(__file__)), mirroring check_facade_import's cwd handling — a cwd-relative path re-creates a silent pass when the workflow runs from another directory."
+    - "The check takes an injectable path argument so tests point it at temp fixtures; production callers pass nothing and get WORKFLOW_PATH resolved at call time (the write_report pattern already in this module)."
+    - "STATUS_CRITICAL from this check escalates overall_status to CRITICAL, which the workflow's Evaluate health status step turns into a job failure — file-missing is deliberately the only CRITICAL path here."
+---
+
+<objective>
+Close the Greptile finding on PR #339: `check_config_sanity` reads PARALLEL_WORKERS
+and TIME_BUDGET_MINUTES from the health job's own process environment, but
+`system-health-check.yml` never exports them (only the weekly production workflow
+does), so the guardrail passes vacuously and cannot detect production config drift.
+
+Fix by validating the authoritative source directly — parse
+`.github/workflows/weekly-excel-generation.yml` from the repo checkout with stdlib
+text handling only, and keep the existing env check as an explicitly-labelled
+secondary layer.
+
+Purpose: the health check exists to catch drift in the billing pipeline's
+documented guardrails (worker cap of 8, TIME_BUDGET_MINUTES strictly below the
+runner ceiling). Reading an environment that is structurally guaranteed to be
+empty means the check has never once been capable of failing.
+
+Output: a new `check_production_workflow_config` health check, its registration in
+`run_checks()`, a scope relabel on `check_config_sanity`, and a temp-fixture test
+class covering the parse and disposition matrix.
+</objective>
+
+<execution_context>
+Work in the git worktree at
+`C:/Users/juflores/AppData/Local/Temp/claude/c--Users-juflores-dev-Generate-Weekly-PDFs-DSR-Resiliency-1/8a2ad347-a88a-41ce-937a-aa8307e19d64/scratchpad/pr339-wt`
+on branch `feat/260814-system-health-entrypoint`. All edits and the atomic commit
+happen there — `validate_system_health.py` does not exist on master.
+
+@~/.claude/gsd-core/workflows/execute-plan.md
+@~/.claude/gsd-core/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/STATE.md
+@CLAUDE.md
+
+Read in the worktree:
+@validate_system_health.py
+@tests/test_validate_system_health.py
+
+Read only (PROTECTED — never modify): `.github/workflows/weekly-excel-generation.yml`.
+The value shapes this parser must handle, confirmed at plan time:
+
+- line 6: a comment sentence that contains the words `timeout-minutes: 180`
+  inside prose — must not be read as a live setting.
+- line 130: `    timeout-minutes: 180` (live, job level).
+- lines 124-129: comments that mention TIME_BUDGET_MINUTES in prose.
+- line 271: `          PARALLEL_WORKERS: ${{ github.event.inputs.parallel_workers || '8' }}`
+- line 272: `          PARALLEL_WORKERS_DISCOVERY: ${{ github.event.inputs.parallel_workers_discovery || '8' }}`
+- line 535: `          TIME_BUDGET_MINUTES: '165'`
+</context>
+
+<tasks>
+
+<task type="tracer" tdd="true">
+  <name>Task 1: Parse the production workflow and grade it against the documented guardrails</name>
+  <files>validate_system_health.py, tests/test_validate_system_health.py</files>
+  <behavior>
+    Write these tests FIRST in a new `TestProductionWorkflowConfig` class. Each
+    test writes YAML text to a file inside `tempfile.TemporaryDirectory()` and
+    passes that path to the check — no network, no real workflow file.
+
+    - Happy path: both worker keys as `${{ github.event.inputs.x || '8' }}`
+      expressions, `TIME_BUDGET_MINUTES: '165'`, `timeout-minutes: 180`
+      -> STATUS_OK.
+    - Comment immunity: a fixture whose ONLY mention of a worker key and of
+      `timeout-minutes` is inside `#` comment lines (mirroring workflow line 6
+      and lines 124-129) -> the commented values are ignored; a commented
+      over-cap worker value does not produce a WARN, and a commented
+      `timeout-minutes` value does not become the max used for comparison.
+    - Over-cap primary: `PARALLEL_WORKERS` expression fallback `'12'` -> WARN,
+      detail names PARALLEL_WORKERS and the cap.
+    - Over-cap discovery: `PARALLEL_WORKERS_DISCOVERY` fallback `'16'` -> WARN.
+    - At-cap boundary: fallback `'8'` -> not a WARN (the cap is inclusive).
+    - Non-numeric budget: `TIME_BUDGET_MINUTES: 'ninety'` -> WARN naming
+      TIME_BUDGET_MINUTES.
+    - Budget not below ceiling: `TIME_BUDGET_MINUTES: '180'` with
+      `timeout-minutes: 180` -> WARN (the rule is strictly-less-than).
+    - Budget below ceiling: `'165'` vs `180` -> not a WARN.
+    - Missing file: path pointing at a nonexistent file -> STATUS_CRITICAL.
+    - Unparseable value: `PARALLEL_WORKERS: ${{ github.event.inputs.x }}`
+      (expression with no `||` fallback) -> WARN, and the check still grades
+      the other keys rather than aborting.
+    - Absent keys: a fixture with none of the three keys -> STATUS_OK, and
+      `ctx.notes` gains an informational entry naming what was absent.
+    - Detail hygiene: a fixture whose value is a secrets-context expression
+      -> the returned detail does not contain the verbatim expression text,
+      and every emitted detail stays within the echo limit.
+  </behavior>
+  <action>
+    Add to `validate_system_health.py`, near the existing module constants:
+    `WORKFLOW_PATH` built with `os.path.join` from
+    `os.path.dirname(os.path.abspath(__file__))` plus the `.github`,
+    `workflows`, `weekly-excel-generation.yml` segments — mirroring how
+    `check_facade_import` derives its `cwd`, never the process cwd;
+    `MAX_PARALLEL_WORKERS = 8`; `WORKFLOW_WORKER_KEYS` as a tuple of the two
+    worker key names; and a small echo-limit integer plus a redaction marker
+    string used for detail hygiene.
+
+    Add four private stdlib-only helpers (PyYAML is NOT in requirements.txt and
+    must not be added):
+
+    1. A comment stripper that returns an empty string when the first
+       non-space character of a line is a hash, and otherwise truncates the
+       line at the first occurrence of a space-then-hash sequence so trailing
+       inline comments are discarded.
+    2. A value resolver that takes the raw right-hand side of a mapping line
+       and returns an optional resolved literal: when the text contains a
+       GitHub expression opener, apply a regex for a double-pipe followed by a
+       single-quoted literal and return that captured fallback (that fallback
+       is what a scheduled, non-dispatch run receives); otherwise strip
+       matching single or double quotes and return the bare literal; return
+       None when neither shape applies.
+    3. A key finder that walks the comment-stripped lines, matches an anchored
+       regex of optional leading whitespace, the key name, a colon, optional
+       whitespace, then the rest of the line, and returns the first raw
+       right-hand side found (or None).
+    4. A ceiling collector that walks the comment-stripped lines with an
+       anchored regex for optional whitespace, the literal timeout-minutes key,
+       a colon, and one or more digits, returning every match as an int.
+
+    Then add `check_production_workflow_config(ctx, path=None)` returning the
+    module's standard `(status, detail)` tuple. Resolve `path` to the
+    module-level `WORKFLOW_PATH` at call time when it is None (the pattern
+    `write_report` already uses, so tests can patch the module global). If the
+    file is not a regular file, return STATUS_CRITICAL with a detail saying the
+    production workflow file was not found — the billing schedule itself is
+    gone, which is a genuine emergency. Read the file as UTF-8 with
+    `errors="replace"` and split to lines.
+
+    Grade, accumulating problem strings:
+    - For each of the two worker keys: absent -> append an informational entry
+      to `ctx.notes` (engine defaults apply, not a warning). Present but the
+      resolver returns None, or the literal is not an integer -> a problem
+      naming the key. Integer above `MAX_PARALLEL_WORKERS` -> a problem naming
+      the key and the cap.
+    - For TIME_BUDGET_MINUTES: absent -> `ctx.notes` entry. Present but not
+      parseable as a float -> a problem. Parseable and at least one
+      timeout-minutes value was collected -> compare against the max of that
+      list and record a problem unless the budget is strictly less than the
+      max, quoting both numbers. If no timeout-minutes was collected, add a
+      `ctx.notes` entry instead of a problem.
+
+    Detail hygiene, applied to any raw value before it reaches a problem string
+    or a note: if the value contains the secrets-context marker, substitute the
+    redaction marker; then truncate to the echo limit. This keeps a workflow
+    value from ever landing in the JSON report verbatim.
+
+    Return WARN joined by a semicolon-space separator when problems exist,
+    otherwise STATUS_OK with a detail stating the production workflow file is
+    within the documented guardrails.
+
+    Style: PEP 8, type hints on every new symbol, lines at 79 characters or
+    fewer, PEP 257 docstrings, matching the module's existing status constants
+    and tuple-returning check convention.
+  </action>
+  <verify>
+    <automated>cd "C:/Users/juflores/AppData/Local/Temp/claude/c--Users-juflores-dev-Generate-Weekly-PDFs-DSR-Resiliency-1/8a2ad347-a88a-41ce-937a-aa8307e19d64/scratchpad/pr339-wt" &amp;&amp; python -m pytest tests/test_validate_system_health.py -q</automated>
+  </verify>
+  <done>
+    `TestProductionWorkflowConfig` passes every case in the behavior block, and
+    the pre-existing tests in the file still pass. Running the check against a
+    fixture that mirrors the real workflow's line 271/272/535/130 shapes returns
+    STATUS_OK, while raising the fixture's worker fallback above 8 returns
+    STATUS_WARN — proving the check can actually fail, which the env-only check
+    could not.
+  </done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Register the check in run_checks and relabel the env check's scope</name>
+  <files>validate_system_health.py, tests/test_validate_system_health.py</files>
+  <behavior>
+    - `test_production_check_is_registered`: patch `vsh._timed` with a
+      side-effect that records the name and returns a `CheckResult` without
+      calling the wrapped function, call `run_checks(HealthContext())`, and
+      assert `production_workflow_config` is in the returned names. Patching
+      `_timed` keeps the subprocess facade import and the Smartsheet calls
+      from ever running.
+    - `test_env_check_detail_states_process_scope`: with a cleared environment,
+      `check_config_sanity` returns STATUS_OK and its detail states that the
+      values it read came from this job's process environment.
+    - The existing `TestConfigSanity` cases keep passing unchanged — the
+      relabel changes detail wording only, never a status.
+  </behavior>
+  <action>
+    In `run_checks`, append a `_timed("production_workflow_config", lambda:
+    check_production_workflow_config(ctx))` entry after the existing
+    `config_sanity` entry, so the two config layers report adjacently.
+
+    Relabel `check_config_sanity` so its scope is unambiguous: update its
+    docstring to say it grades only the values present in this process's own
+    environment and that the authoritative production values are graded by
+    `check_production_workflow_config`; prefix each problem string it emits and
+    its OK detail so a reader of the JSON report can tell which scope produced
+    the finding. Do not change any status logic, any threshold, or the
+    SENTRY_DSN note behavior — wording only.
+  </action>
+  <verify>
+    <automated>cd "C:/Users/juflores/AppData/Local/Temp/claude/c--Users-juflores-dev-Generate-Weekly-PDFs-DSR-Resiliency-1/8a2ad347-a88a-41ce-937a-aa8307e19d64/scratchpad/pr339-wt" &amp;&amp; python -m pytest tests/test_validate_system_health.py -q</automated>
+  </verify>
+  <done>
+    `production_workflow_config` appears in the `run_checks` output names, the
+    scope-label test passes, and no pre-existing status assertion in
+    `TestConfigSanity` had to be edited to make the suite green.
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Full-suite validation and atomic commit</name>
+  <files>validate_system_health.py, tests/test_validate_system_health.py</files>
+  <precondition>The worktree at scratchpad/pr339-wt is checked out on branch feat/260814-system-health-entrypoint and `git status` shows changes limited to the two files above.</precondition>
+  <action>
+    Run the syntax check and the full pytest suite in the worktree. Confirm via
+    `git status --short` that `.github/workflows/weekly-excel-generation.yml` is
+    NOT in the changed set — it is a protected file this task only reads.
+
+    Then run the real check once against the actual repo file by importing the
+    module and calling `check_production_workflow_config` with a fresh
+    `HealthContext` and no path argument; the live workflow currently pins both
+    worker fallbacks to 8, TIME_BUDGET_MINUTES to 165, and timeout-minutes to
+    180, so the expected live result is STATUS_OK. A WARN here would mean real
+    drift already exists and must be reported rather than silenced.
+
+    Commit both files in one atomic commit with a Conventional Commits subject
+    of 50 characters or fewer along the lines of a `fix:` for the vacuous health
+    config guardrail, referencing PR #339 in the body together with a
+    Production Safety Check line confirming no production pipeline logic and no
+    workflow YAML changed.
+  </action>
+  <verify>
+    <automated>cd "C:/Users/juflores/AppData/Local/Temp/claude/c--Users-juflores-dev-Generate-Weekly-PDFs-DSR-Resiliency-1/8a2ad347-a88a-41ce-937a-aa8307e19d64/scratchpad/pr339-wt" &amp;&amp; python -m py_compile validate_system_health.py &amp;&amp; python -m pytest tests/ -q</automated>
+  </verify>
+  <done>
+    Full suite green with no pre-existing test regressions; `git status --short`
+    lists only `validate_system_health.py` and
+    `tests/test_validate_system_health.py`; the live-file smoke call returns
+    STATUS_OK (or the WARN is reported to the operator, not suppressed); one
+    atomic commit exists on `feat/260814-system-health-entrypoint`.
+  </done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| repo file -> health report JSON | Workflow YAML text is read and fragments may be echoed into `generated_docs/system_health.json`, which is uploaded as a CI artifact. |
+| health check -> workflow exit code | A CRITICAL from this check fails the scheduled health job. |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Severity | Disposition | Mitigation Plan |
+|-----------|----------|-----------|----------|-------------|-----------------|
+| T-me8-01 | Information Disclosure | `check_production_workflow_config` detail strings | medium | mitigate | Redact any value containing the secrets-context marker and truncate every echoed value to the echo limit before it reaches a detail string or a note (Task 1 detail-hygiene step + the detail-hygiene test). |
+| T-me8-02 | Denial of Service | health job exit code | medium | mitigate | Only a missing workflow file is CRITICAL; every parse ambiguity degrades to WARN, so a formatting change in the YAML cannot hard-fail the health job. |
+| T-me8-03 | Tampering | `.github/workflows/weekly-excel-generation.yml` | high | mitigate | Read-only access by construction; Task 3 asserts via `git status --short` that the protected workflow file is absent from the changed set. |
+| T-me8-04 | Spoofing | comment lines in the YAML | low | mitigate | Comment stripping runs before every key and ceiling match, so a commented value can neither satisfy nor trip a guardrail (comment-immunity test). |
+| T-me8-SC | Tampering | npm/pip/cargo installs | high | mitigate | No package is installed or added — the fix is stdlib-only (regex plus os plus tempfile in tests); PyYAML is explicitly excluded, so no package-legitimacy checkpoint is required. |
+</threat_model>
+
+<verification>
+- `python -m pytest tests/test_validate_system_health.py -q` passes.
+- `python -m pytest tests/ -q` passes with no regressions against the branch's
+  pre-change baseline.
+- `python -m py_compile validate_system_health.py` is clean.
+- `git status --short` in the worktree lists exactly two changed files.
+- Mutating a temp fixture's worker fallback above 8 flips the check to WARN,
+  demonstrating the guardrail is no longer vacuous.
+</verification>
+
+<success_criteria>
+- A drifted PARALLEL_WORKERS, PARALLEL_WORKERS_DISCOVERY, or TIME_BUDGET_MINUTES
+  in `weekly-excel-generation.yml` is detected by the scheduled health job even
+  though that job exports none of those variables.
+- Comment lines, GitHub expression fallbacks, and inline trailing comments are
+  all handled without PyYAML.
+- The pre-existing env check survives as a clearly-scoped secondary layer.
+- The protected production workflow file is unchanged.
+</success_criteria>
+
+<output>
+Create `.planning/quick/260814-me8-fix-health-check-config-guardrail-vacuou/260814-me8-SUMMARY.md` when done.
+</output>

--- a/.planning/quick/260814-me8-fix-health-check-config-guardrail-vacuou/260814-me8-SUMMARY.md
+++ b/.planning/quick/260814-me8-fix-health-check-config-guardrail-vacuou/260814-me8-SUMMARY.md
@@ -1,0 +1,141 @@
+---
+phase: quick-260814-me8
+plan: 01
+subsystem: infra
+tags: [health-check, github-actions, ci, config-guardrail, greptile]
+
+# Dependency graph
+requires:
+  - phase: quick-260814-system-health-entrypoint
+    provides: validate_system_health.py entry point and CheckResult/HealthContext scaffolding
+provides:
+  - check_production_workflow_config() parsing weekly-excel-generation.yml directly for PARALLEL_WORKERS / PARALLEL_WORKERS_DISCOVERY / TIME_BUDGET_MINUTES drift
+  - registration of production_workflow_config in run_checks()
+  - relabeled check_config_sanity scope (process-env-only, secondary layer)
+affects: [system-health-check-workflow, billing-pipeline-guardrails]
+
+actuals:
+  tokens: 5093
+  tasks: 3
+  commits: 1
+
+tech-stack:
+  added: []
+  patterns:
+    - "stdlib-only YAML text parsing (comment-stripping + regex key/value extraction) instead of adding PyYAML, mirroring the module's existing no-new-deps posture"
+    - "detail-hygiene helper (redact secrets-context marker + echo-limit truncation) applied to every raw value before it can reach a JSON report string"
+
+key-files:
+  created: []
+  modified:
+    - validate_system_health.py
+    - tests/test_validate_system_health.py
+
+key-decisions:
+  - "Parse the authoritative workflow file (weekly-excel-generation.yml) directly instead of trusting the health job's own process environment, which structurally never carries PARALLEL_WORKERS/TIME_BUDGET_MINUTES"
+  - "GitHub expression values (${{ ... || 'N' }}) resolve to their || fallback literal, since that is what a scheduled (non-dispatch) run actually receives"
+  - "Only a missing workflow file is CRITICAL; every parse ambiguity (unresolvable expression, non-numeric value) degrades to WARN so a YAML formatting change cannot hard-fail the health job"
+  - "check_config_sanity kept as an explicitly-labelled secondary layer (process-environment scope only) rather than removed, in case the health job is ever given those env vars directly"
+
+patterns-established:
+  - "Detail-hygiene: redact any value containing the secrets-context marker and cap echo length before a workflow value reaches a problem string or a ctx.notes entry"
+
+requirements-completed: [GREPTILE-339-CONFIG-VACUOUS]
+
+coverage:
+  - id: D1
+    description: "check_production_workflow_config detects PARALLEL_WORKERS / PARALLEL_WORKERS_DISCOVERY / TIME_BUDGET_MINUTES drift in weekly-excel-generation.yml even though the health job's process env never exports them"
+    requirement: "GREPTILE-339-CONFIG-VACUOUS"
+    verification:
+      - kind: unit
+        ref: "tests/test_validate_system_health.py::TestProductionWorkflowConfig (12 cases: happy path, comment immunity, over-cap primary/discovery, at-cap boundary, non-numeric budget, ceiling comparison both directions, missing file, unresolvable expression, absent keys, detail hygiene)"
+        status: pass
+    human_judgment: false
+  - id: D2
+    description: "production_workflow_config is registered inside run_checks() and check_config_sanity states its process-environment-only scope"
+    requirement: "GREPTILE-339-CONFIG-VACUOUS"
+    verification:
+      - kind: unit
+        ref: "tests/test_validate_system_health.py::TestProductionCheckRegistration::test_production_check_is_registered"
+        status: pass
+      - kind: unit
+        ref: "tests/test_validate_system_health.py::TestConfigSanityScopeLabel::test_env_check_detail_states_process_scope"
+        status: pass
+    human_judgment: false
+  - id: D3
+    description: "Full test suite passes with no regressions, py_compile clean, and the live workflow file (currently pinned to worker=8/8, TIME_BUDGET_MINUTES=165, timeout-minutes=180) grades STATUS_OK"
+    verification:
+      - kind: unit
+        ref: "python -m pytest tests/ -q -> 1371 passed, 132 subtests passed"
+        status: pass
+      - kind: other
+        ref: "python -c \"import validate_system_health as vsh; vsh.check_production_workflow_config(vsh.HealthContext())\" -> ('ok', 'production workflow config within documented guardrails')"
+        status: pass
+    human_judgment: false
+
+duration: ~15min
+completed: 2026-08-14
+status: complete
+---
+
+# Quick Task 260814-me8: Fix vacuous health-check config guardrail Summary
+
+**`check_production_workflow_config` parses `weekly-excel-generation.yml` directly with stdlib-only regex/comment-stripping so the health check can actually catch PARALLEL_WORKERS/TIME_BUDGET_MINUTES drift, closing the Greptile finding that the guardrail read an environment structurally guaranteed to be empty.**
+
+## Performance
+
+- **Duration:** ~15 min
+- **Tasks:** 3/3 completed
+- **Files modified:** 2 (`validate_system_health.py`, `tests/test_validate_system_health.py`)
+- **Commits:** 1 atomic commit
+
+## Accomplishments
+
+- Added `check_production_workflow_config(ctx, path=None)` — reads `.github/workflows/weekly-excel-generation.yml` from disk (path resolved from `__file__`, never process cwd, mirroring `check_facade_import`), strips comments before any key/ceiling match, resolves GitHub Actions expression fallbacks (`${{ ... || 'N' }}`), and grades the two `PARALLEL_WORKERS*` keys against the documented cap of 8 and `TIME_BUDGET_MINUTES` as strictly-less-than the max live `timeout-minutes`.
+- Registered `production_workflow_config` inside `run_checks()` immediately after `config_sanity`, so both config layers report adjacently in the JSON output and CI logs.
+- Relabeled `check_config_sanity`'s docstring and every emitted problem/OK string to explicitly state its scope is "process environment" only (wording-only change — no status, threshold, or SENTRY_DSN behavior touched).
+- Added detail-hygiene: any raw workflow value that contains a secrets-context marker is fully redacted, and every echoed value is truncated to a fixed limit, before it can reach a problem string, a note, or the JSON report.
+- Verified live: importing the module and calling the new check against the real (unmodified) `weekly-excel-generation.yml` returns `STATUS_OK` — the file currently pins both worker fallbacks to 8, `TIME_BUDGET_MINUTES` to 165, and `timeout-minutes` to 180.
+
+## Task Commits
+
+Executed as a single atomic commit per plan's Task 3 instruction (both files changed together; TDD red/green was done inline within the one commit rather than as separate test/feat commits, since the plan's task-level commit protocol calls for one commit covering the two files):
+
+1. **Tasks 1–3: parse production workflow, register check, relabel scope, validate + commit** — `9690cdd` (`fix(quick-260814-me8): parse prod workflow for health config drift`)
+
+## Files Created/Modified
+
+- `validate_system_health.py` — added `WORKFLOW_PATH`, `MAX_PARALLEL_WORKERS`, `WORKFLOW_WORKER_KEYS`, detail-hygiene constants, four private stdlib parsing helpers (`_strip_comment`, `_resolve_value`, `_find_key_value`, `_find_timeout_minutes`), `_sanitize_detail_value`, `check_production_workflow_config`, registration in `run_checks()`, and the `check_config_sanity` scope relabel.
+- `tests/test_validate_system_health.py` — new `TestProductionWorkflowConfig` (12 cases against temp-file fixtures), `TestProductionCheckRegistration`, and `TestConfigSanityScopeLabel` classes (14 new tests total; suite grew from 21 to 35 tests).
+
+## Decisions Made
+
+- Parsed the workflow YAML with stdlib regex/text handling rather than adding PyYAML — the plan explicitly excluded that dependency, and the existing module has zero non-stdlib parsing dependencies today.
+- Comment lines are stripped globally before any regex match runs (both for key lookups and the `timeout-minutes` ceiling collector), so a value or ceiling that only ever appears inside a `#` comment can neither satisfy nor trip the guardrail.
+- `TIME_BUDGET_MINUTES` is only compared against the ceiling when at least one live `timeout-minutes` value was found; otherwise the ambiguity becomes an informational note, not a problem, keeping the disposition monotonically conservative (never false-positive WARN on absence).
+
+## Deviations from Plan
+
+None — plan executed exactly as written. All `must_haves.truths` and `key_links` in the plan frontmatter are satisfied by the implementation (verified against the live workflow file's actual line content, which had drifted a few lines from the plan's stated line numbers 271/272/535 to 280/281/544 due to intervening commits — the parser is line-number-agnostic by design, so this had no functional impact).
+
+## Issues Encountered
+
+None. The parser was validated against the real (unmodified) `weekly-excel-generation.yml` file content before finalizing the tests, confirming the comment-stripping and expression-fallback logic matches the file's actual shapes (prose mention of `timeout-minutes: 180` at line 6, prose mentions of `TIME_BUDGET_MINUTES` in the comment block preceding line 544, live `timeout-minutes: 180` at line 130, live worker/budget keys at lines 280/281/544).
+
+## User Setup Required
+
+None — no external service configuration required. This is a pure code change to a health-check script that already runs unattended in `system-health-check.yml`.
+
+## Next Phase Readiness
+
+- The fix is committed on `feat/260814-system-health-entrypoint` at `9690cdd` in the worktree `scratchpad/pr339-wt`, ready to be pushed/reviewed as part of PR #339's follow-up.
+- `.github/workflows/weekly-excel-generation.yml` was read-only throughout — confirmed via `git status --short` showing only the two intended files changed.
+- No blockers. This closes the single outstanding Greptile finding referenced by requirement `GREPTILE-339-CONFIG-VACUOUS`.
+
+---
+*Quick task: 260814-me8*
+*Completed: 2026-08-14*
+
+## Self-Check: PASSED
+- FOUND: .planning/quick/260814-me8-fix-health-check-config-guardrail-vacuou/260814-me8-SUMMARY.md
+- FOUND: commit 9690cdd (worktree scratchpad/pr339-wt, branch feat/260814-system-health-entrypoint)

--- a/memory-bank/living-ledger.md
+++ b/memory-bank/living-ledger.md
@@ -5968,3 +5968,43 @@ follow-up findings closed, same 6 files.
   hold" line — is the ONLY log site that formats changed_by; manual
   drift goes to aggregate counters + the billing_audit.snapshot_drift
   shadow table). Documented in-code at the hold line.
+
+## [2026-08-14 15:00] Maintained validate_system_health.py added — nightly system-health-check.yml no longer fails on a missing entry point
+
+- **What shipped:** `validate_system_health.py` (new, standalone,
+  read-only) + `tests/test_validate_system_health.py` (21 offline
+  tests). The scheduled `system-health-check.yml` had been failing
+  EVERY night (confirmed: last 3 runs before the fix all `failure`)
+  because it invoked a script that never existed in the repo — a red
+  ❌ that meant "entry point missing", not "billing system unhealthy".
+- **Contract rule (load-bearing, do not change casually):** the
+  script ALWAYS writes `generated_docs/system_health.json` and ALWAYS
+  exits 0 when the report was written — the workflow's
+  `Evaluate health status` step is the single owner of pass/fail
+  (exits 1 on CRITICAL). The script exits 1 only when the report
+  itself could not be written. This is why the workflow file needed
+  ZERO changes (protected area untouched).
+- **Checks (all read-only, ≤2 Smartsheet API calls/run):** python
+  version; core imports (smartsheet/openpyxl/dateutil/dotenv =
+  CRITICAL) vs optional imports (sentry_sdk/pandas/supabase/psutil =
+  WARN); facade import probe; token presence; `get_current_user`
+  auth probe; TARGET_SHEET_ID metadata probe at `page_size=1`
+  (mirrors `pipeline/config.py` default 5723337641643908);
+  generated_docs writability; config guardrails
+  (`PARALLEL_WORKERS≤8`, numeric `TIME_BUDGET_MINUTES`). No secret
+  values or user identity in any output (T-ISX-01 discipline).
+- **Rule: probe production imports in a SUBPROCESS with forced
+  UTF-8.** `import generate_weekly_pdfs` runs as a child process so
+  an import-time crash is a captured CRITICAL finding, not a health-
+  check crash. The facade prints emoji at import; on Windows a child
+  defaults to cp1252 stdout and dies in `UnicodeEncodeError` before
+  proving the import (false CRITICAL that cannot reproduce on the
+  UTF-8 CI runner). Fix pattern pinned by the smoke run: child env
+  `PYTHONUTF8=1` AND parent-side `encoding="utf-8",
+  errors="replace"` (bare `text=True` decodes with the locale codec
+  and raises in reader threads). Any future subprocess probe of an
+  emoji-printing module must do both.
+- **Housekeeping:** `generated_docs/system_health.json` gitignored
+  (local smoke runs must not dirty the tree). Follow-up: the
+  PR #338 run-log doc carries a KNOWN BROKEN callout for this
+  workflow — remove it once BOTH PRs are merged.

--- a/tests/test_validate_system_health.py
+++ b/tests/test_validate_system_health.py
@@ -1,0 +1,230 @@
+"""Tests for validate_system_health.py (offline, no network).
+
+The script's contract with system-health-check.yml:
+* always writes generated_docs/system_health.json,
+* always exits 0 when the report was written (the workflow's
+  evaluate step owns pass/fail),
+* overall_status reduces check statuses: any critical -> CRITICAL,
+  else any warn -> WARN, else OK; skipped never escalates.
+"""
+
+import json
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+import validate_system_health as vsh
+
+
+def _result(name: str, status: str) -> vsh.CheckResult:
+    return vsh.CheckResult(name=name, status=status, detail="test")
+
+
+class TestOverallStatus(unittest.TestCase):
+    """The OK/WARN/CRITICAL reduction the workflow consumes."""
+
+    def test_all_ok_is_ok(self):
+        checks = [_result("a", vsh.STATUS_OK)]
+        self.assertEqual(vsh.overall_status(checks), "OK")
+
+    def test_warn_escalates_to_warn(self):
+        checks = [
+            _result("a", vsh.STATUS_OK),
+            _result("b", vsh.STATUS_WARN),
+        ]
+        self.assertEqual(vsh.overall_status(checks), "WARN")
+
+    def test_critical_wins_over_warn(self):
+        checks = [
+            _result("a", vsh.STATUS_WARN),
+            _result("b", vsh.STATUS_CRITICAL),
+        ]
+        self.assertEqual(vsh.overall_status(checks), "CRITICAL")
+
+    def test_skipped_never_escalates(self):
+        checks = [
+            _result("a", vsh.STATUS_OK),
+            _result("b", vsh.STATUS_SKIPPED),
+        ]
+        self.assertEqual(vsh.overall_status(checks), "OK")
+
+
+class TestTimedWrapper(unittest.TestCase):
+    """_timed must capture exceptions as CRITICAL, never raise."""
+
+    def test_exception_becomes_critical(self):
+        def boom():
+            raise RuntimeError("kaput")
+
+        result = vsh._timed("boom", boom)
+        self.assertEqual(result.status, vsh.STATUS_CRITICAL)
+        self.assertIn("RuntimeError", result.detail)
+
+    def test_success_passes_through(self):
+        result = vsh._timed("ok", lambda: (vsh.STATUS_OK, "fine"))
+        self.assertEqual(result.status, vsh.STATUS_OK)
+        self.assertEqual(result.detail, "fine")
+
+
+class TestTokenCheck(unittest.TestCase):
+    """SMARTSHEET_API_TOKEN presence gates the API checks."""
+
+    def test_missing_token_is_critical(self):
+        ctx = vsh.HealthContext()
+        with mock.patch.dict(os.environ, {}, clear=True):
+            status, detail = vsh.check_smartsheet_token(ctx)
+        self.assertEqual(status, vsh.STATUS_CRITICAL)
+        self.assertFalse(ctx.token_present)
+
+    def test_present_token_is_ok_and_never_logged(self):
+        ctx = vsh.HealthContext()
+        env = {"SMARTSHEET_API_TOKEN": "secret-value"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            status, detail = vsh.check_smartsheet_token(ctx)
+        self.assertEqual(status, vsh.STATUS_OK)
+        self.assertTrue(ctx.token_present)
+        self.assertNotIn("secret-value", detail)
+
+
+class TestApiChecks(unittest.TestCase):
+    """API checks skip without a token and use the mocked client."""
+
+    def test_api_check_skips_without_token(self):
+        ctx = vsh.HealthContext()
+        ctx.token_present = False
+        status, _ = vsh.check_smartsheet_api(ctx)
+        self.assertEqual(status, vsh.STATUS_SKIPPED)
+
+    def test_api_check_authenticates_with_client(self):
+        ctx = vsh.HealthContext()
+        ctx.token_present = True
+        fake_client = mock.Mock()
+        env = {"SMARTSHEET_API_TOKEN": "t"}
+        with mock.patch.dict(os.environ, env, clear=True), \
+                mock.patch.object(
+                    vsh, "_build_client", return_value=fake_client
+                ):
+            status, _ = vsh.check_smartsheet_api(ctx)
+        self.assertEqual(status, vsh.STATUS_OK)
+        fake_client.Users.get_current_user.assert_called_once()
+
+    def test_target_sheet_skips_without_client(self):
+        ctx = vsh.HealthContext()
+        status, _ = vsh.check_target_sheet(ctx)
+        self.assertEqual(status, vsh.STATUS_SKIPPED)
+
+    def test_target_sheet_uses_default_id(self):
+        ctx = vsh.HealthContext()
+        ctx.client = mock.Mock()
+        with mock.patch.dict(os.environ, {}, clear=True):
+            status, _ = vsh.check_target_sheet(ctx)
+        self.assertEqual(status, vsh.STATUS_OK)
+        ctx.client.Sheets.get_sheet.assert_called_once_with(
+            vsh.DEFAULT_TARGET_SHEET_ID, page_size=1
+        )
+
+    def test_target_sheet_honors_env_override(self):
+        ctx = vsh.HealthContext()
+        ctx.client = mock.Mock()
+        env = {"TARGET_SHEET_ID": "12345"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            vsh.check_target_sheet(ctx)
+        ctx.client.Sheets.get_sheet.assert_called_once_with(
+            12345, page_size=1
+        )
+
+
+class TestConfigSanity(unittest.TestCase):
+    """Guardrail values: PARALLEL_WORKERS cap and budget parsing."""
+
+    def test_workers_over_cap_warns(self):
+        ctx = vsh.HealthContext()
+        env = {"PARALLEL_WORKERS": "12"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            status, detail = vsh.check_config_sanity(ctx)
+        self.assertEqual(status, vsh.STATUS_WARN)
+        self.assertIn("exceeds cap 8", detail)
+
+    def test_workers_at_cap_ok(self):
+        ctx = vsh.HealthContext()
+        env = {"PARALLEL_WORKERS": "8"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            status, _ = vsh.check_config_sanity(ctx)
+        self.assertEqual(status, vsh.STATUS_OK)
+
+    def test_bad_budget_warns(self):
+        ctx = vsh.HealthContext()
+        env = {"TIME_BUDGET_MINUTES": "ninety"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            status, detail = vsh.check_config_sanity(ctx)
+        self.assertEqual(status, vsh.STATUS_WARN)
+        self.assertIn("TIME_BUDGET_MINUTES", detail)
+
+    def test_sentry_absence_is_note_not_warn(self):
+        ctx = vsh.HealthContext()
+        with mock.patch.dict(os.environ, {}, clear=True):
+            status, _ = vsh.check_config_sanity(ctx)
+        self.assertEqual(status, vsh.STATUS_OK)
+        self.assertTrue(
+            any("SENTRY_DSN" in note for note in ctx.notes)
+        )
+
+
+class TestReport(unittest.TestCase):
+    """Report assembly and writing."""
+
+    def test_report_shape(self):
+        checks = [_result("a", vsh.STATUS_OK)]
+        report = vsh.build_report(checks, ["note"])
+        self.assertEqual(report["overall_status"], "OK")
+        self.assertIn("generated_at_utc", report)
+        self.assertEqual(report["summary"], {"ok": 1})
+        self.assertEqual(len(report["checks"]), 1)
+
+    def test_write_report_round_trips(self):
+        checks = [_result("a", vsh.STATUS_WARN)]
+        report = vsh.build_report(checks, [])
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "sub", "health.json")
+            vsh.write_report(report, path)
+            with open(path, encoding="utf-8") as handle:
+                loaded = json.load(handle)
+        self.assertEqual(loaded["overall_status"], "WARN")
+
+
+class TestMainContract(unittest.TestCase):
+    """main() exits 0 whenever the report is written."""
+
+    def _run_main_with_stubbed_checks(self, tmp: str) -> int:
+        stub = [_result("stub", vsh.STATUS_CRITICAL)]
+        path = os.path.join(tmp, "system_health.json")
+        with mock.patch.object(
+            vsh, "run_checks", return_value=stub
+        ), mock.patch.object(vsh, "REPORT_PATH", path), \
+                mock.patch.dict(os.environ, {}, clear=True):
+            exit_code = vsh.main()
+        self.assertTrue(os.path.exists(path))
+        with open(path, encoding="utf-8") as handle:
+            self.report = json.load(handle)
+        return exit_code
+
+    def test_critical_still_exits_zero_with_report(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            exit_code = self._run_main_with_stubbed_checks(tmp)
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(self.report["overall_status"], "CRITICAL")
+
+    def test_unwritable_report_exits_one(self):
+        stub = [_result("stub", vsh.STATUS_OK)]
+        with mock.patch.object(
+            vsh, "run_checks", return_value=stub
+        ), mock.patch.object(
+            vsh, "write_report", side_effect=OSError("disk full")
+        ), mock.patch.dict(os.environ, {}, clear=True):
+            exit_code = vsh.main()
+        self.assertEqual(exit_code, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_validate_system_health.py
+++ b/tests/test_validate_system_health.py
@@ -171,6 +171,263 @@ class TestConfigSanity(unittest.TestCase):
         )
 
 
+class TestProductionWorkflowConfig(unittest.TestCase):
+    """Grades .github/workflows/weekly-excel-generation.yml directly.
+
+    Each test writes a YAML fixture into a TemporaryDirectory and
+    passes that path explicitly -- no network, no real workflow file.
+    """
+
+    def _fixture(self, tmp: str, text: str) -> str:
+        path = os.path.join(tmp, "weekly-excel-generation.yml")
+        with open(path, "w", encoding="utf-8") as handle:
+            handle.write(text)
+        return path
+
+    def test_happy_path_mirrors_real_workflow_is_ok(self):
+        text = (
+            "jobs:\n"
+            "  core:\n"
+            "    timeout-minutes: 180\n"
+            "    env:\n"
+            "      PARALLEL_WORKERS: "
+            "${{ github.event.inputs.parallel_workers || '8' }}\n"
+            "      PARALLEL_WORKERS_DISCOVERY: "
+            "${{ github.event.inputs.parallel_workers_discovery"
+            " || '8' }}\n"
+            "      TIME_BUDGET_MINUTES: '165'\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._fixture(tmp, text)
+            ctx = vsh.HealthContext()
+            status, detail = vsh.check_production_workflow_config(
+                ctx, path=path
+            )
+        self.assertEqual(status, vsh.STATUS_OK)
+
+    def test_comment_immunity(self):
+        text = (
+            "# Serialize runs. With timeout-minutes: 500 in prose,\n"
+            "# and an example PARALLEL_WORKERS: 99 for reference.\n"
+            "jobs:\n"
+            "  core:\n"
+            "    env:\n"
+            "      TIME_BUDGET_MINUTES: '165'\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._fixture(tmp, text)
+            ctx = vsh.HealthContext()
+            status, detail = vsh.check_production_workflow_config(
+                ctx, path=path
+            )
+        self.assertEqual(status, vsh.STATUS_OK)
+        self.assertNotIn("99", detail)
+        self.assertFalse(
+            any("99" in note or "500" in note for note in ctx.notes)
+        )
+
+    def test_over_cap_primary_worker_warns(self):
+        text = (
+            "jobs:\n"
+            "  core:\n"
+            "    env:\n"
+            "      PARALLEL_WORKERS: "
+            "${{ github.event.inputs.parallel_workers || '12' }}\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._fixture(tmp, text)
+            ctx = vsh.HealthContext()
+            status, detail = vsh.check_production_workflow_config(
+                ctx, path=path
+            )
+        self.assertEqual(status, vsh.STATUS_WARN)
+        self.assertIn("PARALLEL_WORKERS", detail)
+        self.assertIn("8", detail)
+
+    def test_over_cap_discovery_worker_warns(self):
+        text = (
+            "jobs:\n"
+            "  core:\n"
+            "    env:\n"
+            "      PARALLEL_WORKERS_DISCOVERY: "
+            "${{ github.event.inputs.parallel_workers_discovery"
+            " || '16' }}\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._fixture(tmp, text)
+            ctx = vsh.HealthContext()
+            status, detail = vsh.check_production_workflow_config(
+                ctx, path=path
+            )
+        self.assertEqual(status, vsh.STATUS_WARN)
+        self.assertIn("PARALLEL_WORKERS_DISCOVERY", detail)
+
+    def test_at_cap_boundary_is_not_warn(self):
+        text = (
+            "jobs:\n"
+            "  core:\n"
+            "    env:\n"
+            "      PARALLEL_WORKERS: "
+            "${{ github.event.inputs.parallel_workers || '8' }}\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._fixture(tmp, text)
+            ctx = vsh.HealthContext()
+            status, _ = vsh.check_production_workflow_config(
+                ctx, path=path
+            )
+        self.assertEqual(status, vsh.STATUS_OK)
+
+    def test_non_numeric_budget_warns(self):
+        text = (
+            "jobs:\n"
+            "  core:\n"
+            "    env:\n"
+            "      TIME_BUDGET_MINUTES: 'ninety'\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._fixture(tmp, text)
+            ctx = vsh.HealthContext()
+            status, detail = vsh.check_production_workflow_config(
+                ctx, path=path
+            )
+        self.assertEqual(status, vsh.STATUS_WARN)
+        self.assertIn("TIME_BUDGET_MINUTES", detail)
+
+    def test_budget_not_below_ceiling_warns(self):
+        text = (
+            "jobs:\n"
+            "  core:\n"
+            "    timeout-minutes: 180\n"
+            "    env:\n"
+            "      TIME_BUDGET_MINUTES: '180'\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._fixture(tmp, text)
+            ctx = vsh.HealthContext()
+            status, detail = vsh.check_production_workflow_config(
+                ctx, path=path
+            )
+        self.assertEqual(status, vsh.STATUS_WARN)
+        self.assertIn("TIME_BUDGET_MINUTES", detail)
+
+    def test_budget_below_ceiling_is_not_warn(self):
+        text = (
+            "jobs:\n"
+            "  core:\n"
+            "    timeout-minutes: 180\n"
+            "    env:\n"
+            "      TIME_BUDGET_MINUTES: '165'\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._fixture(tmp, text)
+            ctx = vsh.HealthContext()
+            status, _ = vsh.check_production_workflow_config(
+                ctx, path=path
+            )
+        self.assertEqual(status, vsh.STATUS_OK)
+
+    def test_missing_file_is_critical(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "does-not-exist.yml")
+            ctx = vsh.HealthContext()
+            status, _ = vsh.check_production_workflow_config(
+                ctx, path=path
+            )
+        self.assertEqual(status, vsh.STATUS_CRITICAL)
+
+    def test_unparseable_value_warns_but_grades_others(self):
+        text = (
+            "jobs:\n"
+            "  core:\n"
+            "    timeout-minutes: 180\n"
+            "    env:\n"
+            "      PARALLEL_WORKERS: "
+            "${{ github.event.inputs.parallel_workers }}\n"
+            "      PARALLEL_WORKERS_DISCOVERY: "
+            "${{ github.event.inputs.parallel_workers_discovery"
+            " || '8' }}\n"
+            "      TIME_BUDGET_MINUTES: '165'\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._fixture(tmp, text)
+            ctx = vsh.HealthContext()
+            status, detail = vsh.check_production_workflow_config(
+                ctx, path=path
+            )
+        self.assertEqual(status, vsh.STATUS_WARN)
+        self.assertIn("PARALLEL_WORKERS", detail)
+        self.assertNotIn("PARALLEL_WORKERS_DISCOVERY", detail)
+
+    def test_absent_keys_are_notes_not_problems(self):
+        text = "jobs:\n  core:\n    env: {}\n"
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._fixture(tmp, text)
+            ctx = vsh.HealthContext()
+            status, _ = vsh.check_production_workflow_config(
+                ctx, path=path
+            )
+        self.assertEqual(status, vsh.STATUS_OK)
+        self.assertTrue(
+            any("PARALLEL_WORKERS" in note for note in ctx.notes)
+        )
+        self.assertTrue(
+            any(
+                "TIME_BUDGET_MINUTES" in note or "timeout" in note
+                for note in ctx.notes
+            )
+        )
+
+    def test_detail_hygiene_redacts_and_truncates(self):
+        long_value = "x" * 300
+        text = (
+            "jobs:\n"
+            "  core:\n"
+            "    env:\n"
+            "      PARALLEL_WORKERS: "
+            "${{ secrets.SOME_TOKEN_NEVER_SHOWN }}\n"
+            "      PARALLEL_WORKERS_DISCOVERY: '" + long_value
+            + "'\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._fixture(tmp, text)
+            ctx = vsh.HealthContext()
+            status, detail = vsh.check_production_workflow_config(
+                ctx, path=path
+            )
+        self.assertEqual(status, vsh.STATUS_WARN)
+        self.assertNotIn("SOME_TOKEN_NEVER_SHOWN", detail)
+        self.assertNotIn(long_value, detail)
+        self.assertLess(len(detail), 400)
+
+
+class TestProductionCheckRegistration(unittest.TestCase):
+    """production_workflow_config must be wired into run_checks()."""
+
+    def test_production_check_is_registered(self):
+        recorded_names = []
+
+        def _fake_timed(name, fn):
+            recorded_names.append(name)
+            return _result(name, vsh.STATUS_OK)
+
+        with mock.patch.object(vsh, "_timed", side_effect=_fake_timed):
+            vsh.run_checks(vsh.HealthContext())
+        self.assertIn("production_workflow_config", recorded_names)
+
+
+class TestConfigSanityScopeLabel(unittest.TestCase):
+    """check_config_sanity must state its process-env-only scope."""
+
+    def test_env_check_detail_states_process_scope(self):
+        ctx = vsh.HealthContext()
+        with mock.patch.dict(os.environ, {}, clear=True):
+            status, detail = vsh.check_config_sanity(ctx)
+        self.assertEqual(status, vsh.STATUS_OK)
+        self.assertIn("process", detail.lower())
+        self.assertIn("environment", detail.lower())
+
+
 class TestReport(unittest.TestCase):
     """Report assembly and writing."""
 

--- a/validate_system_health.py
+++ b/validate_system_health.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python3
+"""System health check entry point for ``system-health-check.yml``.
+
+Runs a read-only daily diagnostic of the billing infrastructure and
+writes ``generated_docs/system_health.json`` with an
+``overall_status`` of ``OK`` / ``WARN`` / ``CRITICAL``.
+
+Contract with the workflow (do not change casually):
+
+* The workflow step ``Run system health check`` invokes
+  ``python validate_system_health.py``.
+* This script ALWAYS writes the JSON report and ALWAYS exits 0 when
+  the report was written -- the workflow's ``Evaluate health status``
+  step reads ``overall_status`` and is the single owner of pass/fail
+  (it exits 1 on CRITICAL). This script exits 1 only when the report
+  itself could not be written.
+* Checks are strictly read-only: two Smartsheet API calls at most
+  (current user + target-sheet metadata at ``page_size=1``), no row
+  writes, no attachment operations.
+* Output must never contain secret values or personal data -- only
+  presence booleans, counts, and durations.
+"""
+
+import datetime
+import importlib
+import json
+import logging
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import asdict, dataclass, field
+from typing import Any, Callable, Dict, List, Optional
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger("system_health")
+
+# Mirrors pipeline/config.py (default-fallback is the correct
+# behavior; TARGET_SHEET_ID has no "disabled" state). Read directly
+# from the environment so a broken pipeline import cannot prevent
+# the API checks from running -- facade import health is its own
+# check below.
+DEFAULT_TARGET_SHEET_ID = 5723337641643908
+
+REPORT_PATH = os.path.join("generated_docs", "system_health.json")
+
+# Import failures here mean the production pipeline cannot run.
+CORE_IMPORTS = ("smartsheet", "openpyxl", "dateutil", "dotenv")
+
+# Import failures here degrade monitoring/optional surfaces only.
+OPTIONAL_IMPORTS = ("sentry_sdk", "pandas", "supabase", "psutil")
+
+FACADE_IMPORT_TIMEOUT_SEC = 180
+
+STATUS_OK = "ok"
+STATUS_WARN = "warn"
+STATUS_CRITICAL = "critical"
+STATUS_SKIPPED = "skipped"
+
+
+@dataclass
+class CheckResult:
+    """Outcome of a single health check."""
+
+    name: str
+    status: str
+    detail: str
+    duration_ms: int = 0
+
+
+@dataclass
+class HealthContext:
+    """Mutable state shared across checks (client reuse)."""
+
+    token_present: bool = False
+    client: Any = None
+    notes: List[str] = field(default_factory=list)
+
+
+def _timed(
+    name: str, fn: Callable[[], "tuple[str, str]"]
+) -> CheckResult:
+    """Run ``fn`` and wrap its (status, detail) into a CheckResult.
+
+    Any unexpected exception is captured as CRITICAL for that check
+    rather than crashing the whole health run.
+    """
+    start = time.monotonic()
+    try:
+        status, detail = fn()
+    except Exception as exc:  # noqa: BLE001 - report, never crash
+        status = STATUS_CRITICAL
+        detail = f"unexpected {type(exc).__name__}: {exc}"
+    duration_ms = int((time.monotonic() - start) * 1000)
+    return CheckResult(name, status, detail, duration_ms)
+
+
+def check_python_version() -> "tuple[str, str]":
+    """WARN when below the documented 3.10+ floor."""
+    version = ".".join(str(part) for part in sys.version_info[:3])
+    if sys.version_info < (3, 10):
+        return STATUS_WARN, f"python {version} < required 3.10"
+    return STATUS_OK, f"python {version}"
+
+
+def check_core_dependencies() -> "tuple[str, str]":
+    """CRITICAL when a pipeline-required package cannot import."""
+    missing = []
+    for module_name in CORE_IMPORTS:
+        try:
+            importlib.import_module(module_name)
+        except Exception:  # noqa: BLE001 - any failure counts
+            missing.append(module_name)
+    if missing:
+        return STATUS_CRITICAL, "missing core: " + ", ".join(missing)
+    return STATUS_OK, f"all {len(CORE_IMPORTS)} core imports OK"
+
+
+def check_optional_dependencies() -> "tuple[str, str]":
+    """WARN when a monitoring/optional package cannot import."""
+    missing = []
+    for module_name in OPTIONAL_IMPORTS:
+        try:
+            importlib.import_module(module_name)
+        except Exception:  # noqa: BLE001 - any failure counts
+            missing.append(module_name)
+    if missing:
+        return STATUS_WARN, "missing optional: " + ", ".join(missing)
+    return STATUS_OK, f"all {len(OPTIONAL_IMPORTS)} optional imports OK"
+
+
+def check_facade_import() -> "tuple[str, str]":
+    """CRITICAL when ``import generate_weekly_pdfs`` fails.
+
+    Runs in a subprocess so an import-time crash (or hang) in the
+    production facade is captured as a finding instead of killing
+    this health run. Covers syntax errors, broken pipeline modules,
+    and import-time regressions in one real-world probe.
+    """
+    # PYTHONUTF8=1: the facade prints emoji at import time; without
+    # this, a Windows child process defaults to cp1252 stdout and
+    # dies in UnicodeEncodeError before the import is proven -- a
+    # false CRITICAL that cannot happen on the UTF-8 CI runner.
+    child_env = {**os.environ, "PYTHONUTF8": "1"}
+    # encoding/errors: decode the child's UTF-8 output explicitly --
+    # bare text=True decodes with the locale codec (cp1252 on
+    # Windows), which raises in the reader threads on emoji output.
+    proc = subprocess.run(
+        [sys.executable, "-c", "import generate_weekly_pdfs"],
+        capture_output=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=FACADE_IMPORT_TIMEOUT_SEC,
+        cwd=os.path.dirname(os.path.abspath(__file__)),
+        env=child_env,
+    )
+    if proc.returncode != 0:
+        tail = (proc.stderr or proc.stdout or "").strip()
+        # Last line only: enough to identify the exception without
+        # dumping a full traceback (which could embed local paths).
+        last_line = tail.splitlines()[-1] if tail else "no output"
+        return STATUS_CRITICAL, f"facade import failed: {last_line}"
+    return STATUS_OK, "generate_weekly_pdfs imports cleanly"
+
+
+def check_smartsheet_token(ctx: HealthContext) -> "tuple[str, str]":
+    """CRITICAL when SMARTSHEET_API_TOKEN is absent or empty."""
+    ctx.token_present = bool(os.getenv("SMARTSHEET_API_TOKEN"))
+    if not ctx.token_present:
+        return STATUS_CRITICAL, "SMARTSHEET_API_TOKEN not set"
+    return STATUS_OK, "SMARTSHEET_API_TOKEN present (value not logged)"
+
+
+def _build_client(token: str) -> Any:
+    """Construct a Smartsheet client with exceptions enabled."""
+    import smartsheet
+
+    client = smartsheet.Smartsheet(token)
+    client.errors_as_exceptions(True)
+    return client
+
+
+def check_smartsheet_api(ctx: HealthContext) -> "tuple[str, str]":
+    """CRITICAL when the API rejects auth or is unreachable.
+
+    One read-only request: ``Users.get_current_user``. The identity
+    payload is intentionally NOT logged (no emails in CI logs).
+    """
+    if not ctx.token_present:
+        return STATUS_SKIPPED, "skipped: no API token"
+    token = os.environ["SMARTSHEET_API_TOKEN"]
+    ctx.client = _build_client(token)
+    ctx.client.Users.get_current_user()
+    return STATUS_OK, "authenticated; API reachable"
+
+
+def check_target_sheet(ctx: HealthContext) -> "tuple[str, str]":
+    """CRITICAL when the upload destination sheet is inaccessible.
+
+    One read-only request at ``page_size=1`` -- metadata only, the
+    row payload is never inspected.
+    """
+    if ctx.client is None:
+        return STATUS_SKIPPED, "skipped: no authenticated client"
+    raw = os.getenv("TARGET_SHEET_ID")
+    try:
+        sheet_id = int(raw) if raw else DEFAULT_TARGET_SHEET_ID
+    except ValueError:
+        sheet_id = DEFAULT_TARGET_SHEET_ID
+    sheet = ctx.client.Sheets.get_sheet(sheet_id, page_size=1)
+    total_rows = getattr(sheet, "total_row_count", None)
+    return STATUS_OK, (
+        f"target sheet reachable (total rows: {total_rows})"
+    )
+
+
+def check_generated_docs_writable() -> "tuple[str, str]":
+    """CRITICAL when the report/output directory is not writable."""
+    directory = os.path.dirname(REPORT_PATH) or "."
+    os.makedirs(directory, exist_ok=True)
+    with tempfile.NamedTemporaryFile(dir=directory, delete=True):
+        pass
+    return STATUS_OK, f"{directory}/ writable"
+
+
+def check_config_sanity(ctx: HealthContext) -> "tuple[str, str]":
+    """WARN on config values that violate documented guardrails."""
+    problems = []
+    raw_workers = os.getenv("PARALLEL_WORKERS")
+    if raw_workers:
+        try:
+            if int(raw_workers) > 8:
+                problems.append(
+                    f"PARALLEL_WORKERS={raw_workers} exceeds cap 8"
+                )
+        except ValueError:
+            problems.append(
+                f"PARALLEL_WORKERS={raw_workers!r} not an integer"
+            )
+    raw_budget = os.getenv("TIME_BUDGET_MINUTES")
+    if raw_budget:
+        try:
+            float(raw_budget)
+        except ValueError:
+            problems.append(
+                f"TIME_BUDGET_MINUTES={raw_budget!r} not numeric"
+            )
+    if os.getenv("SENTRY_DSN"):
+        ctx.notes.append("SENTRY_DSN present")
+    else:
+        ctx.notes.append("SENTRY_DSN not set (non-fatal)")
+    if problems:
+        return STATUS_WARN, "; ".join(problems)
+    return STATUS_OK, "config within documented guardrails"
+
+
+def overall_status(checks: List[CheckResult]) -> str:
+    """Reduce check statuses to the workflow-facing overall value.
+
+    ``skipped`` never escalates on its own -- a skip always follows
+    a CRITICAL upstream cause that is already counted.
+    """
+    statuses = {check.status for check in checks}
+    if STATUS_CRITICAL in statuses:
+        return "CRITICAL"
+    if STATUS_WARN in statuses:
+        return "WARN"
+    return "OK"
+
+
+def run_checks(ctx: Optional[HealthContext] = None) -> List[CheckResult]:
+    """Execute every health check in dependency order."""
+    ctx = ctx or HealthContext()
+    return [
+        _timed("python_version", check_python_version),
+        _timed("core_dependencies", check_core_dependencies),
+        _timed("optional_dependencies", check_optional_dependencies),
+        _timed("facade_import", check_facade_import),
+        _timed(
+            "smartsheet_token", lambda: check_smartsheet_token(ctx)
+        ),
+        _timed("smartsheet_api", lambda: check_smartsheet_api(ctx)),
+        _timed("target_sheet_access", lambda: check_target_sheet(ctx)),
+        _timed(
+            "generated_docs_writable", check_generated_docs_writable
+        ),
+        _timed("config_sanity", lambda: check_config_sanity(ctx)),
+    ]
+
+
+def build_report(
+    checks: List[CheckResult], notes: List[str]
+) -> Dict[str, Any]:
+    """Assemble the JSON-serializable health report."""
+    now = datetime.datetime.now(datetime.timezone.utc)
+    counts: Dict[str, int] = {}
+    for check in checks:
+        counts[check.status] = counts.get(check.status, 0) + 1
+    return {
+        "overall_status": overall_status(checks),
+        "generated_at_utc": now.isoformat(),
+        "runtime": {
+            "python": ".".join(
+                str(part) for part in sys.version_info[:3]
+            ),
+            "platform": sys.platform,
+            "github_sha": os.getenv("GITHUB_SHA", ""),
+            "github_run_id": os.getenv("GITHUB_RUN_ID", ""),
+        },
+        "summary": counts,
+        "notes": notes,
+        "checks": [asdict(check) for check in checks],
+    }
+
+
+def write_report(
+    report: Dict[str, Any], path: Optional[str] = None
+) -> None:
+    """Write the report JSON (UTF-8, pretty-printed).
+
+    ``path`` defaults to the module-level ``REPORT_PATH`` resolved at
+    call time (not def time) so tests can patch the module global.
+    """
+    if path is None:
+        path = REPORT_PATH
+    directory = os.path.dirname(path)
+    if directory:
+        os.makedirs(directory, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump(report, handle, indent=2)
+        handle.write("\n")
+
+
+def _init_sentry_if_available() -> None:
+    """Best-effort Sentry init; absence is never an error."""
+    dsn = os.getenv("SENTRY_DSN")
+    if not dsn:
+        return
+    try:
+        import sentry_sdk
+
+        sentry_sdk.init(
+            dsn=dsn,
+            environment=os.getenv(
+                "SENTRY_ENVIRONMENT", "system-health"
+            ),
+            release=os.getenv("SENTRY_RELEASE") or None,
+            traces_sample_rate=0.0,
+        )
+    except Exception:  # noqa: BLE001 - monitoring must not break us
+        logger.info("⚠️ Sentry init failed (continuing without it)")
+
+
+_STATUS_ICONS = {
+    STATUS_OK: "✅",
+    STATUS_WARN: "⚠️",
+    STATUS_CRITICAL: "❌",
+    STATUS_SKIPPED: "⏭️",
+}
+
+
+def main() -> int:
+    """Run all checks, write the report, log a summary.
+
+    Returns 0 whenever the report was written (the workflow's
+    evaluate step owns pass/fail); 1 only when writing failed.
+    """
+    _init_sentry_if_available()
+    ctx = HealthContext()
+    checks = run_checks(ctx)
+    report = build_report(checks, ctx.notes)
+
+    for check in checks:
+        icon = _STATUS_ICONS.get(check.status, "•")
+        logger.info(
+            "%s %s: %s (%d ms)",
+            icon, check.name, check.detail, check.duration_ms,
+        )
+    logger.info("🩺 Overall status: %s", report["overall_status"])
+
+    try:
+        write_report(report)
+    except Exception as exc:  # noqa: BLE001 - the one fatal path
+        logger.error(
+            "❌ Could not write %s: %s: %s",
+            REPORT_PATH, type(exc).__name__, exc,
+        )
+        try:
+            import sentry_sdk
+
+            sentry_sdk.capture_exception(exc)
+        except Exception:  # noqa: BLE001
+            pass
+        return 1
+    logger.info("📄 Report written to %s", REPORT_PATH)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/validate_system_health.py
+++ b/validate_system_health.py
@@ -26,6 +26,7 @@ import importlib
 import json
 import logging
 import os
+import re
 import subprocess
 import sys
 import tempfile
@@ -52,6 +53,29 @@ CORE_IMPORTS = ("smartsheet", "openpyxl", "dateutil", "dotenv")
 OPTIONAL_IMPORTS = ("sentry_sdk", "pandas", "supabase", "psutil")
 
 FACADE_IMPORT_TIMEOUT_SEC = 180
+
+# Authoritative source for check_production_workflow_config below.
+# Built from __file__, never the process cwd, mirroring how
+# check_facade_import derives its subprocess `cwd` -- a cwd-relative
+# path would silently re-create the same vacuous-pass class of bug
+# this check exists to close.
+WORKFLOW_PATH = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    ".github",
+    "workflows",
+    "weekly-excel-generation.yml",
+)
+MAX_PARALLEL_WORKERS = 8
+WORKFLOW_WORKER_KEYS = ("PARALLEL_WORKERS", "PARALLEL_WORKERS_DISCOVERY")
+
+# Detail-hygiene: any raw workflow value embedded in a problem
+# string or a note is redacted (if it looks like a secrets-context
+# expression) and truncated before it can reach the JSON report.
+_DETAIL_ECHO_LIMIT = 80
+_REDACTED_MARKER = "<redacted>"
+_SECRETS_CONTEXT_MARKER = "secrets."
+
+_EXPRESSION_FALLBACK_RE = re.compile(r"\|\|\s*'([^']*)'")
 
 STATUS_OK = "ok"
 STATUS_WARN = "warn"
@@ -225,18 +249,30 @@ def check_generated_docs_writable() -> "tuple[str, str]":
 
 
 def check_config_sanity(ctx: HealthContext) -> "tuple[str, str]":
-    """WARN on config values that violate documented guardrails."""
+    """WARN on guardrail values present in THIS process's own env.
+
+    Scope: this job's own process environment only.
+    ``system-health-check.yml`` never exports ``PARALLEL_WORKERS`` or
+    ``TIME_BUDGET_MINUTES`` -- only the weekly production workflow
+    does -- so this check can only ever catch drift if the health
+    job itself is one day given those variables. The authoritative
+    production values (parsed straight from
+    ``weekly-excel-generation.yml``) are graded by
+    ``check_production_workflow_config`` instead.
+    """
     problems = []
     raw_workers = os.getenv("PARALLEL_WORKERS")
     if raw_workers:
         try:
             if int(raw_workers) > 8:
                 problems.append(
-                    f"PARALLEL_WORKERS={raw_workers} exceeds cap 8"
+                    "process env: PARALLEL_WORKERS="
+                    f"{raw_workers} exceeds cap 8"
                 )
         except ValueError:
             problems.append(
-                f"PARALLEL_WORKERS={raw_workers!r} not an integer"
+                "process env: PARALLEL_WORKERS="
+                f"{raw_workers!r} not an integer"
             )
     raw_budget = os.getenv("TIME_BUDGET_MINUTES")
     if raw_budget:
@@ -244,7 +280,8 @@ def check_config_sanity(ctx: HealthContext) -> "tuple[str, str]":
             float(raw_budget)
         except ValueError:
             problems.append(
-                f"TIME_BUDGET_MINUTES={raw_budget!r} not numeric"
+                "process env: TIME_BUDGET_MINUTES="
+                f"{raw_budget!r} not numeric"
             )
     if os.getenv("SENTRY_DSN"):
         ctx.notes.append("SENTRY_DSN present")
@@ -252,7 +289,189 @@ def check_config_sanity(ctx: HealthContext) -> "tuple[str, str]":
         ctx.notes.append("SENTRY_DSN not set (non-fatal)")
     if problems:
         return STATUS_WARN, "; ".join(problems)
-    return STATUS_OK, "config within documented guardrails"
+    return (
+        STATUS_OK,
+        "process environment config within documented guardrails",
+    )
+
+
+def _strip_comment(line: str) -> str:
+    """Return ``line`` with any comment portion removed.
+
+    A line whose first non-space character is ``#`` is entirely a
+    comment and becomes an empty string. Otherwise the line is
+    truncated at the first ``" #"`` (space then hash) so a trailing
+    inline comment is discarded while leaving live content intact.
+    """
+    if line.lstrip().startswith("#"):
+        return ""
+    idx = line.find(" #")
+    if idx != -1:
+        return line[:idx]
+    return line
+
+
+def _resolve_value(raw: str) -> Optional[str]:
+    """Resolve a mapping right-hand side to a plain literal.
+
+    A GitHub Actions expression (``${{ ... }}``) resolves to its
+    ``|| 'fallback'`` literal -- that is the value a scheduled,
+    non-dispatch run actually receives. A quoted literal has its
+    matching quotes stripped. Anything else (including an
+    expression with no ``||`` fallback) returns ``None``.
+    """
+    text = raw.strip()
+    if "${{" in text:
+        match = _EXPRESSION_FALLBACK_RE.search(text)
+        return match.group(1) if match else None
+    if len(text) >= 2 and text[0] == text[-1] and text[0] in "'\"":
+        return text[1:-1]
+    return text or None
+
+
+def _find_key_value(lines: List[str], key: str) -> Optional[str]:
+    """Return the raw right-hand side of the first line for ``key``.
+
+    ``lines`` must already be comment-stripped -- a value that only
+    ever appears on a commented line can never be found here.
+    """
+    pattern = re.compile(r"^\s*" + re.escape(key) + r"\s*:\s*(.*)$")
+    for line in lines:
+        match = pattern.match(line)
+        if match:
+            return match.group(1)
+    return None
+
+
+def _find_timeout_minutes(lines: List[str]) -> List[int]:
+    """Return every live ``timeout-minutes: N`` value found, as int.
+
+    ``lines`` must already be comment-stripped, so a commented
+    ``timeout-minutes`` mention can never inflate this list.
+    """
+    pattern = re.compile(r"^\s*timeout-minutes\s*:\s*(\d+)")
+    values = []
+    for line in lines:
+        match = pattern.match(line)
+        if match:
+            values.append(int(match.group(1)))
+    return values
+
+
+def _sanitize_detail_value(value: str) -> str:
+    """Redact secrets-context expressions and cap echo length.
+
+    Applied to any raw workflow value before it can reach a problem
+    string or a note, so a workflow value never lands in the JSON
+    report verbatim.
+    """
+    if _SECRETS_CONTEXT_MARKER in value:
+        return _REDACTED_MARKER
+    if len(value) > _DETAIL_ECHO_LIMIT:
+        return value[:_DETAIL_ECHO_LIMIT] + "..."
+    return value
+
+
+def check_production_workflow_config(
+    ctx: HealthContext, path: Optional[str] = None
+) -> "tuple[str, str]":
+    """WARN on production workflow config drift the env check misses.
+
+    Reads ``.github/workflows/weekly-excel-generation.yml`` directly
+    -- the authoritative source for ``PARALLEL_WORKERS``,
+    ``PARALLEL_WORKERS_DISCOVERY``, and ``TIME_BUDGET_MINUTES`` --
+    because the health job's own process environment never exports
+    them. ``path`` defaults to the module-level ``WORKFLOW_PATH``
+    resolved at call time (the pattern ``write_report`` already
+    uses), so tests can point it at a temp fixture while production
+    callers get the real repo file.
+    """
+    if path is None:
+        path = WORKFLOW_PATH
+    if not os.path.isfile(path):
+        return (
+            STATUS_CRITICAL,
+            "production workflow file not found -- the billing "
+            "schedule itself is missing",
+        )
+    with open(path, encoding="utf-8", errors="replace") as handle:
+        raw_lines = handle.readlines()
+    lines = [_strip_comment(line) for line in raw_lines]
+
+    problems: List[str] = []
+
+    for key in WORKFLOW_WORKER_KEYS:
+        raw_value = _find_key_value(lines, key)
+        if raw_value is None:
+            ctx.notes.append(
+                f"production workflow: {key} not set "
+                "(engine default applies)"
+            )
+            continue
+        resolved = _resolve_value(raw_value)
+        if resolved is None:
+            problems.append(
+                f"{key}="
+                f"{_sanitize_detail_value(raw_value)!r} could not "
+                "be resolved"
+            )
+            continue
+        try:
+            worker_count = int(resolved)
+        except ValueError:
+            problems.append(
+                f"{key}="
+                f"{_sanitize_detail_value(resolved)!r} is not an "
+                "integer"
+            )
+            continue
+        if worker_count > MAX_PARALLEL_WORKERS:
+            problems.append(
+                f"{key}={worker_count} exceeds cap "
+                f"{MAX_PARALLEL_WORKERS}"
+            )
+
+    raw_budget = _find_key_value(lines, "TIME_BUDGET_MINUTES")
+    if raw_budget is None:
+        ctx.notes.append(
+            "production workflow: TIME_BUDGET_MINUTES not set"
+        )
+    else:
+        resolved_budget = _resolve_value(raw_budget)
+        budget: Optional[float] = None
+        if resolved_budget is not None:
+            try:
+                budget = float(resolved_budget)
+            except ValueError:
+                budget = None
+        if budget is None:
+            problems.append(
+                "TIME_BUDGET_MINUTES="
+                f"{_sanitize_detail_value(raw_budget)!r} not "
+                "numeric"
+            )
+        else:
+            timeout_values = _find_timeout_minutes(lines)
+            if timeout_values:
+                ceiling = max(timeout_values)
+                if not budget < ceiling:
+                    problems.append(
+                        f"TIME_BUDGET_MINUTES={budget:g} is not "
+                        "strictly below timeout-minutes ceiling "
+                        f"{ceiling}"
+                    )
+            else:
+                ctx.notes.append(
+                    "production workflow: no live timeout-minutes "
+                    "found to compare TIME_BUDGET_MINUTES against"
+                )
+
+    if problems:
+        return STATUS_WARN, "; ".join(problems)
+    return (
+        STATUS_OK,
+        "production workflow config within documented guardrails",
+    )
 
 
 def overall_status(checks: List[CheckResult]) -> str:
@@ -286,6 +505,10 @@ def run_checks(ctx: Optional[HealthContext] = None) -> List[CheckResult]:
             "generated_docs_writable", check_generated_docs_writable
         ),
         _timed("config_sanity", lambda: check_config_sanity(ctx)),
+        _timed(
+            "production_workflow_config",
+            lambda: check_production_workflow_config(ctx),
+        ),
     ]
 
 


### PR DESCRIPTION
## Objective

The scheduled `system-health-check.yml` workflow has failed every night because it invokes `python validate_system_health.py` — a file that never existed in the repository (surfaced by Greptile review on #338). This PR adds the maintained entry point, built to match the workflow's **existing** contract so the workflow file itself requires zero changes.

## Changes Made

- **`validate_system_health.py` (new):** read-only daily diagnostic writing `generated_docs/system_health.json` with `overall_status` OK/WARN/CRITICAL.
  - Contract: always writes the report and always exits 0 when written — the workflow's `Evaluate health status` step owns pass/fail (exits 1 on CRITICAL). Script exits 1 only if the report cannot be written.
  - Checks: python version · core imports (smartsheet/openpyxl/dateutil/dotenv → CRITICAL) · optional imports (sentry_sdk/pandas/supabase/psutil → WARN) · `generate_weekly_pdfs` import probe (subprocess, forced UTF-8) · `SMARTSHEET_API_TOKEN` presence · `get_current_user` auth probe · target-sheet metadata probe at `page_size=1` (mirrors `pipeline/config.py` default) · `generated_docs/` writability · config guardrails (`PARALLEL_WORKERS ≤ 8`, numeric `TIME_BUDGET_MINUTES`).
  - Max 2 Smartsheet API calls per run; no writes; no secret values or user identity in any output.
- **`tests/test_validate_system_health.py` (new):** 21 offline tests — status ladder, exit-code contract, mocked API checks, guardrail warnings, report round-trip.
- **`.gitignore`:** ignore `generated_docs/system_health.json` (local smoke runs must not dirty the tree).
- **`memory-bank/living-ledger.md`:** dated entry — workflow contract rule + the Windows subprocess UTF-8 lesson (child `PYTHONUTF8=1` + parent `encoding='utf-8', errors='replace'`).

## Production Safety Check

Existing production logic is unbroken: **no workflow file, pipeline module, billing formula, or Smartsheet write path was touched** — this is a purely additive standalone script plus tests. All checks are read-only (2 API calls/day against the 300 req/min budget). Full suite: **1357 passed + 132 subtests**. Local smoke run verified: report written, exit 0, facade probe green.

Follow-up after merge: remove the KNOWN BROKEN callout for this workflow from `docs/sync-job-run-logs.md` (added in #338).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The health check now evaluates worker and time-budget guardrails from the weekly production workflow instead of relying only on values absent from the health-check environment. The checked-in workflow resolves both worker settings to 8, the time budget to 165 minutes, and the job timeout to 180 minutes. No blocking failure remains, and the change is safe to merge.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

No blocking failure remains.

The prior production-guardrail gap was exercised with invalid workflow settings and the health check reported warnings for each invalid value; the checked-in workflow and focused regression tests also completed successfully.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran an offline validation script that compared the health-job environment check with the authoritative weekly workflow check using a temporary workflow fixture containing over-cap worker values and a non-numeric time budget.
- The environment-only check returned ok when its environment was empty, while the check\_production\_workflow\_config reported warn and identified all three invalid production settings.
- Ran the authoritative check against the checked-in weekly workflow; it resolved worker values 8 and 8, time budget 165, timeout 180, and returned ok.
- Ran the focused health-workflow test suite, which completed with 14 passing tests, confirming the health check now detects the previously missed configuration drift.
- Before capture, check\_config\_sanity reported ok with the health-job environment empty; after capture, check\_production\_workflow\_config reported warn and named all three invalid authoritative settings; current evaluation shows the default-path invocation read the weekly-excel-generation.yml and reported ok with worker values 8, 8, 165 and timeout 180.

<a href="https://app.greptile.com/trex/runs/18999965/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["docs(quick-260814-me8): plan+summary+sta..."](https://github.com/jflo21/generate-weekly-pdfs-dsr-resiliency/commit/881a1ef15e31a3f4134c27bbeb11b67fc62598b9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53465159)</sub>

<!-- /greptile_comment -->