### PR TITLE
fix: harden production workflow guardrail checks (#339 follow-up)

### DIFF
--- a/tests/test_validate_system_health.py
+++ b/tests/test_validate_system_health.py
@@ -266,9 +266,11 @@ class TestProductionWorkflowConfig(unittest.TestCase):
         text = (
             "jobs:\n"
             "  core:\n"
+            "    timeout-minutes: 180\n"
             "    env:\n"
             "      PARALLEL_WORKERS: "
             "${{ github.event.inputs.parallel_workers || '8' }}\n"
+            "      TIME_BUDGET_MINUTES: '165'\n"
         )
         with tempfile.TemporaryDirectory() as tmp:
             path = self._fixture(tmp, text)
@@ -359,8 +361,11 @@ class TestProductionWorkflowConfig(unittest.TestCase):
         self.assertIn("PARALLEL_WORKERS", detail)
         self.assertNotIn("PARALLEL_WORKERS_DISCOVERY", detail)
 
-    def test_absent_keys_are_notes_not_problems(self):
-        text = "jobs:\n  core:\n    env: {}\n"
+    def test_absent_worker_keys_are_notes_not_problems(self):
+        text = (
+            "jobs:\n  core:\n    timeout-minutes: 180\n    env:\n"
+            "      TIME_BUDGET_MINUTES: '165'\n"
+        )
         with tempfile.TemporaryDirectory() as tmp:
             path = self._fixture(tmp, text)
             ctx = vsh.HealthContext()
@@ -371,12 +376,63 @@ class TestProductionWorkflowConfig(unittest.TestCase):
         self.assertTrue(
             any("PARALLEL_WORKERS" in note for note in ctx.notes)
         )
-        self.assertTrue(
-            any(
-                "TIME_BUDGET_MINUTES" in note or "timeout" in note
-                for note in ctx.notes
+
+    def test_absent_time_budget_is_a_warn(self):
+        """Engine default 0 disables the graceful-stop budget --
+        an absent TIME_BUDGET_MINUTES is drift, not a note."""
+        text = "jobs:\n  core:\n    env: {}\n"
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._fixture(tmp, text)
+            ctx = vsh.HealthContext()
+            status, detail = vsh.check_production_workflow_config(
+                ctx, path=path
             )
+        self.assertEqual(status, vsh.STATUS_WARN)
+        self.assertIn("TIME_BUDGET_MINUTES not set", detail)
+
+    def test_zero_worker_count_is_a_warn(self):
+        text = (
+            "jobs:\n  core:\n    timeout-minutes: 180\n    env:\n"
+            "      PARALLEL_WORKERS: '0'\n"
+            "      TIME_BUDGET_MINUTES: '165'\n"
         )
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._fixture(tmp, text)
+            ctx = vsh.HealthContext()
+            status, detail = vsh.check_production_workflow_config(
+                ctx, path=path
+            )
+        self.assertEqual(status, vsh.STATUS_WARN)
+        self.assertIn("not a positive worker count", detail)
+
+    def test_negative_worker_count_is_a_warn(self):
+        text = (
+            "jobs:\n  core:\n    timeout-minutes: 180\n    env:\n"
+            "      PARALLEL_WORKERS: '-3'\n"
+            "      TIME_BUDGET_MINUTES: '165'\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._fixture(tmp, text)
+            ctx = vsh.HealthContext()
+            status, detail = vsh.check_production_workflow_config(
+                ctx, path=path
+            )
+        self.assertEqual(status, vsh.STATUS_WARN)
+        self.assertIn("not a positive worker count", detail)
+
+    def test_single_worker_is_ok(self):
+        text = (
+            "jobs:\n  core:\n    timeout-minutes: 180\n    env:\n"
+            "      PARALLEL_WORKERS: '1'\n"
+            "      TIME_BUDGET_MINUTES: '165'\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._fixture(tmp, text)
+            ctx = vsh.HealthContext()
+            status, _ = vsh.check_production_workflow_config(
+                ctx, path=path
+            )
+        self.assertEqual(status, vsh.STATUS_OK)
 
     def test_detail_hygiene_redacts_and_truncates(self):
         long_value = "x" * 300

--- a/validate_system_health.py
+++ b/validate_system_health.py
@@ -430,11 +430,24 @@ def check_production_workflow_config(
                 f"{key}={worker_count} exceeds cap "
                 f"{MAX_PARALLEL_WORKERS}"
             )
+        elif worker_count < 1:
+            problems.append(
+                f"{key}={worker_count} is not a positive "
+                "worker count"
+            )
 
+    # Asymmetry with the worker keys above is deliberate: an absent
+    # worker key falls back to the engine default of 8, which sits AT
+    # the documented cap (safe). An absent TIME_BUDGET_MINUTES falls
+    # back to the engine default of 0 = graceful-stop budget DISABLED,
+    # so the 180-minute runner ceiling would hard-kill the job and
+    # lose cache/attachment-upload progress -- that is drift worth a
+    # WARN, not a note.
     raw_budget = _find_key_value(lines, "TIME_BUDGET_MINUTES")
     if raw_budget is None:
-        ctx.notes.append(
-            "production workflow: TIME_BUDGET_MINUTES not set"
+        problems.append(
+            "TIME_BUDGET_MINUTES not set in production workflow "
+            "(engine default 0 disables the graceful-stop budget)"
         )
     else:
         resolved_budget = _resolve_value(raw_budget)


### PR DESCRIPTION
## Objective

Close the two substantive post-merge review findings on #339's `check_production_workflow_config` while the context is warm. Third finding (`ctx.client` assigned pre-auth) triaged as cosmetic and intentionally skipped.

## Changes Made

- **`validate_system_health.py`**
  - Absent `TIME_BUDGET_MINUTES` in `weekly-excel-generation.yml` now **WARNs** instead of an informational note — the engine default of `0` disables the graceful-stop budget, so the 180-minute runner ceiling would hard-kill the job and lose cache/attachment-upload progress. Absent worker keys deliberately stay notes (engine default 8 sits AT the cap — safe); the asymmetry is documented in-code.
  - Worker counts below 1 (zero/negative) now WARN as `not a positive worker count`; previously only over-cap values were flagged.
- **`tests/test_validate_system_health.py`** — absent-keys test split into the asymmetric expectations; new coverage for 0, negative, and 1-worker boundary; the at-cap fixture gains a valid budget so it isolates the cap check.

## Production Safety Check

Existing production logic is unbroken: only the health-check script and its tests changed — no pipeline module, workflow file, or billing logic touched. Full suite: **1375 passed + 132 subtests** (the commit body's "1378" is a typo; 1375 is correct). Live smoke against the real workflow still reports `production_workflow_config: OK` (8/8/165/180) — no behavior change for the current, healthy config; only the drift dispositions tightened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This change improves production workflow health reporting by warning when the graceful-stop budget is missing or a configured worker count is not positive. Runtime checks exercised those configurations and confirmed they produce warnings; a valid one-worker configuration with a 165-minute budget and 180-minute job timeout remains healthy. The live weekly workflow was parsed with its active scheduled-run fallback values and evaluated as healthy, and the focused system-health test suite passed (39 tests).
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge: the updated guardrails correctly identify the intended invalid configuration states, preserve valid boundary behavior, and accept the current production workflow.

No defects remain in the final review. Direct runtime checks covered the missing-budget, zero-worker, negative-worker, and valid lower-boundary paths, then confirmed the focused regression suite passes.

**Files Needing Attention:** No files need follow-up attention. The checked implementation is validate_system_health.py, with coverage in tests/test_validate_system_health.py and the live configuration in .github/workflows/weekly-excel-generation.yml.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the focused guardrail verification script against isolated fixtures and the live weekly workflow, and ran the system-health tests.
- The guardrail reported a missing TIME\_BUDGET\_MINUTES warning and warnings for worker values 0 and -3, while worker 1 with a 165-minute budget and 180-minute timeout was OK.
- Parsed the live workflow's fallback values as 8, with budget 165 and timeout 180, and confirmed an OK state.
- The system-health pytest run reported all 39 tests passed.
- Conclusion notes that the guardrail detects absent TIME\_BUDGET\_MINUTES and non-positive worker counts, uses actual live entries in parsing, and that no blockers were encountered and no product code changes were made.

<a href="https://app.greptile.com/trex/runs/19005935/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: harden production workflow guardrai..."](https://github.com/jflo21/generate-weekly-pdfs-dsr-resiliency/commit/06b979d91ed685eeb74b8b5e6fc452e62d45d947) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53562024)</sub>

<!-- /greptile_comment -->